### PR TITLE
ci(test): puppeteer memory usage optimizations

### DIFF
--- a/packages/extension/jest-puppeteer.config.js
+++ b/packages/extension/jest-puppeteer.config.js
@@ -26,6 +26,11 @@ module.exports = {
       `--load-extension=${BUILD_OUTPUT_DIR}`,
       // add 150px to height to account for menus and toolbar
       `--window-size=${width},${height + 150}`,
+      // memory optimizations below
+      "--disable-features=AudioServiceOutOfProcess",
+      "--disable-gpu",
+      "--disable-software-rasterize",
+      "--disable-dev-shm-usage",
     ],
     defaultViewport: {
       width,


### PR DESCRIPTION
tests aren't running as expected on master and I think it might be related to https://stackoverflow.com/a/62912457

they seem to work with these flags, will investigate further at some point but hopefully this fixes the issue for now