### PR TITLE
fix: add missing dependency to recoil package

### DIFF
--- a/packages/recoil/package.json
+++ b/packages/recoil/package.json
@@ -13,6 +13,7 @@
   "dependencies": {
     "@200ms/anchor-ui-renderer": "*",
     "@200ms/common": "*",
+    "@jup-ag/react-hook": "^1.0.0-beta.19",
     "recoil": "^0.6.1"
   },
   "peerDependencies": {


### PR DESCRIPTION
adds missing `@jup-ag/react-hook` to fix build