### PR TITLE
fix: add --silent flag so scripts still work with no .env

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,10 +7,10 @@
   "scripts": {
     "lint:fix": "prettier packages/**/*.{ts,tsx,css,md,json} --write",
     "prepare": "husky install",
-    "start": "env-cmd turbo run start --filter=@200ms/extension --filter=@200ms/example-client --filter=@200ms/example-plugin --filter=@200ms/example-plugin-table",
-    "test": "env-cmd turbo run test -- --passWithNoTests --watchAll=false",
-    "build": "env-cmd turbo run build",
-    "e2e": "env-cmd turbo run e2e",
+    "start": "env-cmd --silent turbo run start --filter=@200ms/extension --filter=@200ms/example-client --filter=@200ms/example-plugin --filter=@200ms/example-plugin-table",
+    "test": "env-cmd --silent turbo run test -- --passWithNoTests --watchAll=false",
+    "build": "env-cmd --silent turbo run build",
+    "e2e": "env-cmd --silent turbo run e2e",
     "clean": "npx rimraf .turbo node_modules/ packages/**/node_modules packages/**/.turbo packages/**/build packages/**/dist packages/extension/dev"
   },
   "devDependencies": {


### PR DESCRIPTION
# tldr; this fixes `master`

#29 [wasn't quite finished](https://github.com/200ms-labs/anchor-wallet/pull/29#issuecomment-1113624321) (I'll make it more obvious next time!)

this fixes things so package.json scripts `master` will work without erroring out due to no .env file being present

I'll probably also come back to this at some point to make the process & scripts a bit simpler