### PR TITLE
build: add missing `next-auth` package

### DIFF
--- a/apps/appstore-web/package.json
+++ b/apps/appstore-web/package.json
@@ -11,6 +11,7 @@
   },
   "dependencies": {
     "next": "^12.1.6",
+    "next-auth": "^4.3.4",
     "react": "^17.0.2",
     "react-dom": "^17.0.2"
   },


### PR DESCRIPTION
fixes `yarn build` in root