### PR TITLE
test: use callbacks vs async in e2e before* hooks

### DIFF
--- a/packages/extension/integration_tests/installation.test.ts
+++ b/packages/extension/integration_tests/installation.test.ts
@@ -157,6 +157,6 @@ describe("Installing Anchor Wallet", () => {
 
       // Ensure the wallet is unlocked and the balance page loads
       await expect(extensionPopupPage).toMatch("Total Balance");
-    }, 30_000 /** allow 30s for test to run due to loading external data */);
+    }, 120_000 /** allow 2 mins for test to run due to loading external data */);
   });
 });

--- a/packages/extension/jest.setup.js
+++ b/packages/extension/jest.setup.js
@@ -1,4 +1,4 @@
 const setDefaultOptions = require("expect-puppeteer").setDefaultOptions;
 
 // big timeout for external requests to do their thing
-setDefaultOptions({ timeout: 20_000 });
+setDefaultOptions({ timeout: 60_000 });


### PR DESCRIPTION
related #57

it's possible that tests aren't waiting for `beforeAll(async () => {})` to complete, so this uses callback format of

```typescript
beforeAll((done) => {
  // setup code
  done()
})
````