### PR TITLE
fix: prevent continuous `useEffect` calls in `Send` page

### DIFF
--- a/packages/extension/src/components/Layout/Drawer.tsx
+++ b/packages/extension/src/components/Layout/Drawer.tsx
@@ -125,7 +125,7 @@ function WithDrawerContent({ children, setOpenDrawer }: any) {
     return () => {
       nav.setNavButtonRight(previous);
     };
-  }, [nav]);
+  }, []);
   return (
     <div className={classes.withDrawer}>
       <div className={classes.withDrawerContent}>{children}</div>


### PR DESCRIPTION
`nav` might be supposed to be in the dependencies array, but for now it stops this error and I'm not seeing any complaints from React. Basically the `nav.setNavButtonRight` was mutating `nav` which meant the `useEffect` dependency had changes and would cause it to run every frame

<img width="756" alt="Screenshot 2022-05-20 at 07 09 57" src="https://user-images.githubusercontent.com/101902546/169515883-04cbce61-b975-4778-82fa-0f333c1b212d.png">
