### PR TITLE
chore: add `sandbox` attr to plugin iframe

### DIFF
--- a/packages/anchor-ui-renderer/src/plugin.ts
+++ b/packages/anchor-ui-renderer/src/plugin.ts
@@ -111,7 +111,6 @@ export class Plugin {
     this._nextRenderId = 0;
     this._iframe = document.createElement("iframe");
     this._iframe!.src = this.iframeUrl;
-    this._iframe.sandbox.add("allow-modals");
     this._iframe.sandbox.add("allow-same-origin");
     this._iframe.sandbox.add("allow-scripts");
     this._iframe!.onload = async () => {


### PR DESCRIPTION
https://www.w3schools.com/tags/att_iframe_sandbox.asp

https://www.html5rocks.com/en/tutorials/security/sandboxed-iframes/#:~:text=allow%2Dsame%2Dorigin%20allows%20the,trivial%20to%20implement%20via%20JavaScript).

- `allow-same-origin` seems to be required for plugins to load
- `allow-scripts` is necessary for executing JS inside iframe
- ~~leaving `allow-modals` in temporarily while we're using a `prompt()` for custom RPC input~~ not necessary?
