### PR TITLE
fix: don't minify provider-injection (yet)

### DIFF
--- a/packages/provider-injection/package.json
+++ b/packages/provider-injection/package.json
@@ -5,7 +5,7 @@
   "source": "src/index.ts",
   "scripts": {
     "preinstall": "yarn link @project-serum/anchor",
-    "build": "BROWSER=true parcel build",
+    "build": "BROWSER=true parcel build --no-optimize",
     "dev": "parcel"
   },
   "dependencies": {
@@ -16,7 +16,6 @@
     "eventemitter3": "^4.0.7"
   },
   "devDependencies": {
-    "esbuild": "^0.14.42",
     "parcel": "^2.6.0",
     "typescript": "^4.6.3"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -6747,7 +6747,7 @@ esbuild-windows-arm64@0.14.42:
   resolved "https://registry.yarnpkg.com/esbuild-windows-arm64/-/esbuild-windows-arm64-0.14.42.tgz#79da8744626f24bc016dc40d016950b5a4a2bac5"
   integrity sha512-+lRAARnF+hf8J0mN27ujO+VbhPbDqJ8rCcJKye4y7YZLV6C4n3pTRThAb388k/zqF5uM0lS5O201u0OqoWSicw==
 
-esbuild@^0.14.38, esbuild@^0.14.42:
+esbuild@^0.14.38:
   version "0.14.42"
   resolved "https://registry.yarnpkg.com/esbuild/-/esbuild-0.14.42.tgz#98587df0b024d5f6341b12a1d735a2bff55e1836"
   integrity sha512-V0uPZotCEHokJdNqyozH6qsaQXqmZEOiZWrXnds/zaH/0SyrIayRXWRB98CENO73MIZ9T3HBIOsmds5twWtmgw==


### PR DESCRIPTION
one of the dependencies doesn't have a default export and it breaks loading the plugins when the output is minified

temporarily disabling minification of injected.js until that's sorted