### PR TITLE
fix: use `uuid` for `PortChannelClient` request ids

### DIFF
--- a/packages/common/src/channel.ts
+++ b/packages/common/src/channel.ts
@@ -1,6 +1,7 @@
 import type { Event, RpcRequest, RpcResponse, Notification } from "./types";
 import { BrowserRuntime } from "./browser";
 import { POST_MESSAGE_ORIGIN } from "./constants";
+import { v1 } from "uuid";
 
 // Channel is a class that establishes communication channel from a
 // content/injected script to a background script.
@@ -214,17 +215,13 @@ export class PortChannelNotifications {
 }
 
 export class PortChannelClient implements BackgroundClient {
-  private _requestId: number;
-
-  constructor(private name: string) {
-    this._requestId = 0;
-  }
+  constructor(private name: string) {}
 
   public async request<T = any>({
     method,
     params,
   }: RpcRequest): Promise<RpcResponse<T>> {
-    const id = this._requestId++;
+    const id = v1();
     return new Promise((resolve, reject) => {
       BrowserRuntime.sendMessage(
         {


### PR DESCRIPTION
fixes #110

an instance of `PortChannelClient` is readonly so it needs to use an external id, in this case it generates a uuid when needed

I'll come back to review whether to change this to a uuid/v4 in future, leaving it as v1 for now to be consistent with the other usage of it in the codebase