### PR TITLE
refactor: move unique id generator to common

### DIFF
--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -20,9 +20,11 @@
     "@solana/wallet-adapter-base": "^0.9.5",
     "@solana/web3.js": "^1.37.1",
     "bn.js": "^5.2.1",
-    "bs58": "^5.0.0"
+    "bs58": "^5.0.0",
+    "uuid": "^8.3.2"
   },
   "devDependencies": {
+    "@types/uuid": "^8.3.4",
     "@typescript-eslint/eslint-plugin": "^5.25.0",
     "@typescript-eslint/parser": "^5.25.0",
     "eslint": "^8.16.0",

--- a/packages/common/src/channel.ts
+++ b/packages/common/src/channel.ts
@@ -1,7 +1,7 @@
 import type { Event, RpcRequest, RpcResponse, Notification } from "./types";
 import { BrowserRuntime } from "./browser";
 import { POST_MESSAGE_ORIGIN } from "./constants";
-import { v1 } from "uuid";
+import { generateUniqueId } from "./utils";
 
 // Channel is a class that establishes communication channel from a
 // content/injected script to a background script.
@@ -221,7 +221,7 @@ export class PortChannelClient implements BackgroundClient {
     method,
     params,
   }: RpcRequest): Promise<RpcResponse<T>> {
-    const id = v1();
+    const id = generateUniqueId();
     return new Promise((resolve, reject) => {
       BrowserRuntime.sendMessage(
         {

--- a/packages/common/src/utils.ts
+++ b/packages/common/src/utils.ts
@@ -1,3 +1,5 @@
+import { v1 } from "uuid";
+
 export function toTitleCase(blockchain: string) {
   return (
     blockchain.slice(0, 1).toUpperCase() + blockchain.toLowerCase().slice(1)
@@ -15,4 +17,13 @@ export function formatUSD(amount: number | string) {
     style: "currency",
     currency: "USD",
   }).format(Number(String(amountNumber)));
+}
+
+/**
+ * A globally unique ID generator, useful for stateless or readonly things
+ * @returns
+ * uuid/v1, in case we need to extract the timestamp when debugging
+ */
+export function generateUniqueId() {
+  return v1();
 }

--- a/packages/extension/package.json
+++ b/packages/extension/package.json
@@ -28,7 +28,6 @@
     "react-router-dom": "^6.3.0",
     "recoil": "^0.6.1",
     "tweetnacl": "^1.0.3",
-    "uuid": "^8.3.2",
     "web-vitals": "^1.0.1"
   },
   "scripts": {
@@ -62,7 +61,6 @@
     "@types/react": "^17.0.0",
     "@types/react-custom-scrollbars": "^4.0.10",
     "@types/react-dom": "^17.0.0",
-    "@types/uuid": "^8.3.4",
     "@typescript-eslint/eslint-plugin": "^5.25.0",
     "@typescript-eslint/parser": "^5.25.0",
     "esbuild": "^0.14.38",

--- a/packages/extension/src/keyring/solana.ts
+++ b/packages/extension/src/keyring/solana.ts
@@ -3,6 +3,7 @@ import { Keypair, PublicKey } from "@solana/web3.js";
 import nacl from "tweetnacl";
 import * as bs58 from "bs58";
 import {
+  generateUniqueId,
   LEDGER_INJECTED_CHANNEL_REQUEST,
   LEDGER_METHOD_CONNECT,
   LEDGER_METHOD_SIGN_TRANSACTION,
@@ -22,7 +23,6 @@ import {
   LedgerKeyringJson,
   LedgerKeyring,
 } from "./types";
-import { v1 } from "uuid";
 
 export class SolanaKeyringFactory implements KeyringFactory {
   public fromJson(payload: KeyringJson): SolanaKeyring {
@@ -311,7 +311,7 @@ export class SolanaLedgerKeyring implements LedgerKeyring {
     params: Array<any>;
   }): Promise<T> {
     return new Promise((resolve, reject) => {
-      const id = v1(); // using v1 in case we need the timestamp when debugging
+      const id = generateUniqueId();
       responseResolvers[id] = { resolve, reject };
       const msg = {
         type: LEDGER_INJECTED_CHANNEL_REQUEST,


### PR DESCRIPTION
as unique ID code is now shared between common and extension I decided to put a general function in common so if we use a different ID function in future it'll be easy to switch out