### PR TITLE
hotfix: remove derive functions from common/crypto

### DIFF
--- a/packages/background/src/keyring/solana.ts
+++ b/packages/background/src/keyring/solana.ts
@@ -11,8 +11,8 @@ import {
   DerivationPath,
   LEDGER_INJECTED_CHANNEL_RESPONSE,
 } from "@200ms/common";
-import { deriveKeypairs, deriveKeypair } from "@200ms/common";
-import {
+import { deriveKeypairs, deriveKeypair } from "@200ms/common/dist/esm/derive";
+import type {
   ImportedDerivationPath,
   Keyring,
   KeyringFactory,

--- a/packages/common/src/crypto.ts
+++ b/packages/common/src/crypto.ts
@@ -1,7 +1,3 @@
-import { derivePath } from "ed25519-hd-key";
-import { Keypair } from "@solana/web3.js";
-import nacl from "tweetnacl";
-
 export const DerivationPath: { [key: string]: DerivationPath } = {
   Bip44: "bip44",
   Bip44Change: "bip44-change",
@@ -9,42 +5,3 @@ export const DerivationPath: { [key: string]: DerivationPath } = {
 };
 
 export type DerivationPath = "bip44" | "bip44-change";
-
-export function deriveKeypairs(
-  seed: Buffer,
-  dPath: DerivationPath,
-  numberOfAccounts: number
-): Array<Keypair> {
-  const kps: Array<Keypair> = [];
-  const seedHex = seed.toString("hex");
-  for (let k = 0; k < numberOfAccounts; k += 1) {
-    const kp = deriveKeypair(seedHex, k, dPath);
-    kps.push(kp);
-  }
-  return kps;
-}
-
-// Returns the account Keypair for the given seed and derivation path.
-export function deriveKeypair(
-  seedHex: string,
-  accountIndex: number,
-  dPath: DerivationPath
-): Keypair {
-  let pathStr = derivePathStr(dPath, accountIndex);
-  const dSeed = derivePath(pathStr, seedHex).key;
-  const secret = nacl.sign.keyPair.fromSeed(dSeed).secretKey;
-  return Keypair.fromSecretKey(secret);
-}
-
-function derivePathStr(dPath: DerivationPath, accountIndex: number): string {
-  switch (dPath) {
-    case DerivationPath.Bip44:
-      return accountIndex === 0
-        ? `m/44'/501'`
-        : `m/44'/501'/${accountIndex - 1}'`;
-    case DerivationPath.Bip44Change:
-      return `m/44'/501'/${accountIndex}'/0'`;
-    default:
-      throw new Error(`invalid derivation path: ${dPath}`);
-  }
-}

--- a/packages/common/src/derive.ts
+++ b/packages/common/src/derive.ts
@@ -1,0 +1,43 @@
+import { derivePath } from "ed25519-hd-key";
+import { Keypair } from "@solana/web3.js";
+import { sign } from "tweetnacl";
+import { DerivationPath } from "./crypto";
+
+export function deriveKeypairs(
+  seed: Buffer,
+  dPath: DerivationPath,
+  numberOfAccounts: number
+): Array<Keypair> {
+  const kps: Array<Keypair> = [];
+  const seedHex = seed.toString("hex");
+  for (let k = 0; k < numberOfAccounts; k += 1) {
+    const kp = deriveKeypair(seedHex, k, dPath);
+    kps.push(kp);
+  }
+  return kps;
+}
+
+// Returns the account Keypair for the given seed and derivation path.
+export function deriveKeypair(
+  seedHex: string,
+  accountIndex: number,
+  dPath: DerivationPath
+): Keypair {
+  let pathStr = derivePathStr(dPath, accountIndex);
+  const dSeed = derivePath(pathStr, seedHex).key;
+  const secret = sign.keyPair.fromSeed(dSeed).secretKey;
+  return Keypair.fromSecretKey(secret);
+}
+
+function derivePathStr(dPath: DerivationPath, accountIndex: number): string {
+  switch (dPath) {
+    case DerivationPath.Bip44:
+      return accountIndex === 0
+        ? `m/44'/501'`
+        : `m/44'/501'/${accountIndex - 1}'`;
+    case DerivationPath.Bip44Change:
+      return `m/44'/501'/${accountIndex}'/0'`;
+    default:
+      throw new Error(`invalid derivation path: ${dPath}`);
+  }
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -3124,7 +3124,7 @@
   dependencies:
     "@solana/wallet-adapter-base" "^0.9.4"
 
-"@solana/web3.js@^1.17.0", "@solana/web3.js@^1.21.0", "@solana/web3.js@^1.32.0", "@solana/web3.js@^1.35.1", "@solana/web3.js@^1.36.0", "@solana/web3.js@^1.37.1":
+"@solana/web3.js@1.41.6", "@solana/web3.js@^1.17.0", "@solana/web3.js@^1.21.0", "@solana/web3.js@^1.32.0", "@solana/web3.js@^1.35.1", "@solana/web3.js@^1.36.0", "@solana/web3.js@^1.37.1":
   version "1.41.6"
   resolved "https://registry.yarnpkg.com/@solana/web3.js/-/web3.js-1.41.6.tgz#120a45b758de5efd3c17d635fdf869a5f2a95c0a"
   integrity sha512-4uGXNxFMdS/Sk1WRoZ0hbkL1/fo7XoaYlBZEFHawQwTGsM5FxDuXKqfRzhQCiMzOPf2DBKgM67sdpzDuHk4uKw==
@@ -13909,7 +13909,7 @@ react-dev-utils@^11.0.1:
     strip-ansi "6.0.0"
     text-table "0.2.0"
 
-react-dom@^17.0.2:
+react-dom@^17.0.0, react-dom@^17.0.2:
   version "17.0.2"
   resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-17.0.2.tgz#ecffb6845e3ad8dbfcdc498f0d0a939736502c23"
   integrity sha512-s4h96KtLDUQlsENhMn1ar8t2bEa+q/YAtj8pPPdIjPDGBDIVNsrD9aXNWqspUe6AzKCIG0C1HZZLqLV7qpOBGA==


### PR DESCRIPTION
there's an error about global being undefined if this code is inside comoon/crypto, so I _temporarily_ moved it to common/derive and **do not** export common/derive from common/index.js @armaniferrante 