### PR TITLE
fix: `global` -> `globalThis` in provider-injection

### DIFF
--- a/packages/provider-injection/build.js
+++ b/packages/provider-injection/build.js
@@ -6,6 +6,7 @@ const { DEFAULT_SOLANA_CONNECTION_URL, NODE_DEBUG, NODE_ENV } = process.env;
 esbuild.build({
   bundle: true,
   define: {
+    global: "globalThis",
     "process.env": JSON.stringify({
       DEFAULT_SOLANA_CONNECTION_URL,
       NODE_DEBUG,


### PR DESCRIPTION
fixes `global is not defined` error in injected script