### PR TITLE
feat: qr code

### DIFF
--- a/packages/extension/src/components/Unlocked/Balances/TokensWidget/Deposit.tsx
+++ b/packages/extension/src/components/Unlocked/Balances/TokensWidget/Deposit.tsx
@@ -96,7 +96,7 @@ export function Deposit({ close }: any) {
               width: "168px",
             }}
           >
-            <QrCode />
+            <QrCode data={activeWallet.publicKey.toString()} />
           </div>
           <div style={{ marginTop: "163px" }}>
             <div>
@@ -127,20 +127,21 @@ export function Deposit({ close }: any) {
   );
 }
 
-export function QrCode() {
+export function QrCode({ data }: { data: string }) {
   return (
     <div
       style={{
         backgroundColor: "#fff",
         borderRadius: "8px",
         height: "168px",
-        width: "168px",
+        width: "169px",
         display: "flex",
         justifyContent: "center",
         flexDirection: "column",
+        padding: "8px",
       }}
     >
-      <Typography style={{ textAlign: "center" }}>QR Code</Typography>
+      <img src={`https://qr.warp.workers.dev/qz=0?${data}`} alt={data} />
     </div>
   );
 }


### PR DESCRIPTION
uses a basic [worker](https://github.com/u32i64/qr-worker) for now, could either upload this or something similar to coral infra or replace it with client-side generation in future

<img width="380" alt="174484114-8a6eb11d-efc4-4ff3-b201-7e9531544800" src="https://user-images.githubusercontent.com/601961/174484724-f74aae9a-7522-484f-ad63-d0ff79bb48ef.png">