### PR TITLE
use token name instead of ticker in token table title

### DIFF
--- a/packages/extension/src/components/Unlocked/Balances/TokensWidget/TokenTable.tsx
+++ b/packages/extension/src/components/Unlocked/Balances/TokensWidget/TokenTable.tsx
@@ -94,7 +94,7 @@ function TokenRow({ token, blockchain }: { token: any; blockchain: string }) {
       <BalancesTableCell
         props={{
           icon: token.logo,
-          title: token.ticker,
+          title: token.name,
           subtitle: `${token.nativeBalance.toLocaleString()} ${token.ticker}`,
           usdValue: token.usdBalance,
           percentChange: token.recentUsdBalanceChange,


### PR DESCRIPTION
Ticker is in the subtitle so it's duplicate information, also the tickers for Wrapped SOL and SOL are both `SOL`.