### PR TITLE
mnemonic pasting improvements

### DIFF
--- a/packages/extension/src/components/Locked/Reset/MnemonicInput.tsx
+++ b/packages/extension/src/components/Locked/Reset/MnemonicInput.tsx
@@ -210,7 +210,6 @@ export function MnemonicInput({ closeDrawer }: { closeDrawer: () => void }) {
             </Link>
           </Box>
         </Box>
-        {error && <Typography className={classes.errorMsg}>{error}</Typography>}
         <Box
           sx={{
             marginLeft: "16px",
@@ -218,6 +217,9 @@ export function MnemonicInput({ closeDrawer }: { closeDrawer: () => void }) {
             marginBottom: "16px",
           }}
         >
+          {error && (
+            <Typography className={classes.errorMsg}>{error}</Typography>
+          )}
           <PrimaryButton
             label="Import"
             onClick={next}


### PR DESCRIPTION
Remove the separate state variable the mnemonic length because it is a bit cleaner, and add support for auto switching the mnemonic length based on what is being pasted.

Closes #190 