### PR TITLE
fix: prevent default on paste if mnemonic

### DIFF
--- a/packages/extension/src/components/Locked/Reset/MnemonicInput.tsx
+++ b/packages/extension/src/components/Locked/Reset/MnemonicInput.tsx
@@ -83,6 +83,7 @@ export function MnemonicInput({ closeDrawer }: { closeDrawer: () => void }) {
         // Not a valid mnemonic length
         return;
       }
+      e.preventDefault();
       setMnemonicWords(words);
     };
     window.addEventListener("paste", onPaste);


### PR DESCRIPTION
This will stop the full mnemonic ending up in the input field if pasting into one of the input fields.