### PR TITLE
fix: update background SW loader for app

### DIFF
--- a/packages/background/package.json
+++ b/packages/background/package.json
@@ -5,7 +5,8 @@
   "main": "dist/esm/index.js",
   "types": "dist/esm/index.d.ts",
   "scripts": {
-    "start": "parcel service-worker-loader.html -p 9333",
+    "start": "parcel src/service-worker-loader.html -p 9333",
+    "build:loader": "parcel build src/service-worker-loader.html",
     "build": "yarn lint && tsc",
     "dev": "tsc --watch",
     "lint": "eslint ./src --ext .js,.jsx,.ts,.tsx"

--- a/packages/background/src/service-worker-loader.html
+++ b/packages/background/src/service-worker-loader.html
@@ -5,22 +5,29 @@
   </head>
   <body>
     <script type="module">
-      setup();
-
-      async function setup() {
+      (async function setup() {
         try {
+          console.log(new URL("./service-worker.ts", import.meta.url));
           const registration = await navigator.serviceWorker.register(
-            new URL("./src/service-worker.ts", import.meta.url),
+            new URL("./service-worker.ts", import.meta.url),
             {
               type: "module",
             }
           );
 
+          navigator.serviceWorker.onmessage = (event) => {
+            alert(JSON.stringify(event));
+          };
+
+          window.forward = (msg) => {
+            navigator.serviceWorker.controller.postMessage(msg);
+          };
+
           document.write("background script service worker registered");
         } catch (err) {
           document.write(JSON.stringify({ err }));
         }
-      }
+      })();
     </script>
   </body>
 </html>

--- a/packages/background/src/service-worker.ts
+++ b/packages/background/src/service-worker.ts
@@ -1,8 +1,13 @@
 // This file is only used by the mobile app
 import { start } from ".";
 
-self.addEventListener("install", (event) => {
-  event.waitUntil(async () => {
-    start();
-  });
+self.addEventListener("install", () => {
+  start();
+  self.skipWaiting();
 });
+
+self.addEventListener("activate", () => {
+  self.clients.claim();
+});
+
+self.addEventListener("message", console.log);


### PR DESCRIPTION
- moves html to same dir as worker so that loading the service worker doesn't silently fail
- adds `window.forward` method, name & functionality is WIP
- converts setup function into an IIFE as it wasn't running when built before
- immediately registers service worker with self.skipWaiting(); & self.clients.claim();
- logs messages sent to the service worker
- adds build:loader task that won't work out of the box due to package.json settings but useful to have while debugging