### PR TITLE
add copy button to mnemonic input

### DIFF
--- a/packages/extension/src/components/Account/MnemonicInput.tsx
+++ b/packages/extension/src/components/Account/MnemonicInput.tsx
@@ -200,8 +200,6 @@ export function MnemonicInput({
             label="I saved my secret recovery phrase"
           />
         )}
-      </Box>
-      <Box>
         {readOnly ? null : (
           <Box
             sx={{
@@ -223,14 +221,11 @@ export function MnemonicInput({
                   recovery mnemonic
                 </Link>
               </Box>
-              <Box>
-                <Link className={classes.link} onClick={generateRandom}>
-                  Use a random mnemonic
-                </Link>
-              </Box>
             </>
           </Box>
         )}
+      </Box>
+      <Box>
         <Box
           sx={{
             marginLeft: "16px",
@@ -241,9 +236,11 @@ export function MnemonicInput({
           {error && (
             <Typography className={classes.errorMsg}>{error}</Typography>
           )}
-          <Box sx={{ marginBottom: "12px" }}>
-            <CopyButton mnemonic={mnemonic} disabled={!copyEnabled} />
-          </Box>
+          {readOnly && (
+            <Box sx={{ marginBottom: "12px" }}>
+              <CopyButton mnemonic={mnemonic} disabled={!copyEnabled} />
+            </Box>
+          )}
           <PrimaryButton
             label="Import"
             onClick={next}


### PR DESCRIPTION
Might need some design work (first image feels a bit crowded) but the functionality is useful for testing so lets get it in. I've removed the generate random and copy option from the import wallet flow as the user should know their mnemonic if they are importing. The random mnemonic generation is now handled by the create wallet flow.

<img width="457" alt="Screen Shot 2022-07-01 at 11 01 07 AM" src="https://user-images.githubusercontent.com/489202/176792473-5ef82656-bdb1-4ef8-81ea-97a29f856c4b.png">


<img width="432" alt="Screen Shot 2022-07-01 at 11 17 11 AM" src="https://user-images.githubusercontent.com/489202/176793962-6f7b3dcc-65f0-4de9-b2d8-35375c074435.png">

Closes #206 

