### PR TITLE
style import private key

### DIFF
--- a/packages/extension/src/components/Settings/index.tsx
+++ b/packages/extension/src/components/Settings/index.tsx
@@ -415,7 +415,11 @@ export function ImportSecretKey({
           setValue={setSecretKey}
           rows={4}
         />
-        {error && <Typography style={{ color: "red" }}>{error}</Typography>}
+        {error && (
+          <Typography style={{ color: "red", marginTop: "8px" }}>
+            {error}
+          </Typography>
+        )}
       </Box>
       <Box
         sx={{


### PR DESCRIPTION
I think the spacing to the header is wrong in Figma as it is inconsistent with other pages (96 instead of 80)

Closes https://github.com/coral-xyz/backpack/issues/141