### PR TITLE
adjust navigation views when entering into xNFT apps

### DIFF
--- a/examples/plugins/deadgods/src/app.tsx
+++ b/examples/plugins/deadgods/src/app.tsx
@@ -191,7 +191,7 @@ function GodGrid({ gods, isDead, estimatedRewards }: any) {
         const signature = await window.anchorUi.send(tx);
         console.log("tx signature", signature);
       } catch (err) {
-        console.log("WTF err here", err);
+        console.log("err here", err);
       }
     })();
   };

--- a/packages/extension/src/components/Layout/Nav.tsx
+++ b/packages/extension/src/components/Layout/Nav.tsx
@@ -17,7 +17,7 @@ const useStyles = styles((theme) => ({
     flexDirection: "column",
   },
   overviewLabel: {
-    fontSize: "18px",
+    fontSize: "inherit",
     fontWeight: 500,
     color: theme.custom.colors.fontColor,
     overflow: "hidden",

--- a/packages/extension/src/components/Layout/NavEphemeral.tsx
+++ b/packages/extension/src/components/Layout/NavEphemeral.tsx
@@ -30,6 +30,7 @@ function NavEphemeralWrapper({
     useEphemeralNav();
   const navButtonLeft = isRoot ? null : <NavBackButton onClick={() => pop()} />;
   const _navbarStyle = {
+    fontSize: "18px",
     borderBottom: `solid 1pt ${theme.custom.colors.border}`,
     ...(navbarStyle ?? {}),
     ...(style ?? {}),

--- a/packages/extension/src/components/Layout/NavTabs.tsx
+++ b/packages/extension/src/components/Layout/NavTabs.tsx
@@ -1,4 +1,4 @@
-import { styles, useCustomTheme } from "@coral-xyz/themes";
+import { useCustomTheme } from "@coral-xyz/themes";
 import { useNavigation } from "@coral-xyz/recoil";
 import { WithTabs } from "./Tab";
 import { WithNav, NavBackButton } from "./Nav";
@@ -7,13 +7,20 @@ import { ApproveTransactionRequest } from "../Unlocked/ApproveTransactionRequest
 // The main nav persistent stack.
 export function NavTabs() {
   const theme = useCustomTheme();
-  const { title, isRoot, pop, navButtonRight } = useNavigation();
+  const { title, isRoot, pop, navButtonLeft, navButtonRight, style } =
+    useNavigation();
   const navbarStyle = {
+    fontSize: "18px",
     borderBottom: !isRoot
       ? `solid 1pt ${theme.custom.colors.border}`
       : undefined,
+    ...style,
   };
-  const navButtonLeft = isRoot ? null : <NavBackButton onClick={pop} />;
+  const _navButtonLeft = navButtonLeft ? (
+    navButtonLeft
+  ) : isRoot ? null : (
+    <NavBackButton onClick={pop} />
+  );
   return (
     <WithTabs>
       <div
@@ -25,7 +32,7 @@ export function NavTabs() {
       >
         <WithNav
           title={title}
-          navButtonLeft={navButtonLeft}
+          navButtonLeft={_navButtonLeft}
           navButtonRight={navButtonRight}
           navbarStyle={navbarStyle}
         />

--- a/packages/extension/src/components/Layout/Router.tsx
+++ b/packages/extension/src/components/Layout/Router.tsx
@@ -7,6 +7,10 @@ import {
   useTab,
 } from "@coral-xyz/recoil";
 import type { SearchParamsFor } from "@coral-xyz/recoil";
+import { useCustomTheme } from "@coral-xyz/themes";
+import { IconButton } from "@mui/material";
+import FullscreenExitIcon from "@mui/icons-material/FullscreenExit";
+import TransitEnterexitIcon from "@mui/icons-material/TransitEnterexit";
 import { Balances } from "../Unlocked/Balances";
 import { Token } from "../Unlocked/Balances/TokensWidget/Token";
 import {
@@ -18,8 +22,16 @@ import { Nfts } from "../Unlocked/Nfts";
 import { SettingsButton } from "../Settings";
 
 export function Router() {
-  const { url } = useNavigation();
-  const { navButtonRight, setNavButtonRight } = useNavigation();
+  const theme = useCustomTheme();
+  const {
+    url,
+    navButtonRight,
+    setNavButtonRight,
+    navButtonLeft,
+    setNavButtonLeft,
+    style: navStyle,
+    setStyle,
+  } = useNavigation();
   const { tab } = useTab();
 
   //
@@ -30,15 +42,18 @@ export function Router() {
   //
   useEffect(() => {
     const previous = navButtonRight;
+    const previousLeft = navButtonLeft;
+    const previousStyle = navStyle;
+    const actions: any = [];
     if (
       url.startsWith("/balances") ||
       url.startsWith("/apps") ||
       url.startsWith("/nfts")
     ) {
       setNavButtonRight(<SettingsButton />);
-      return () => {
+      actions.push(() => {
         setNavButtonRight(previous);
-      };
+      });
     }
     if (
       url.startsWith("/token") ||
@@ -46,12 +61,45 @@ export function Router() {
       url.startsWith("/simulator")
     ) {
       setNavButtonRight(null);
-      return () => {
+      actions.push(() => {
         setNavButtonRight(previous);
-      };
+      });
     }
+
+    if (url.startsWith("/plugins") || url.startsWith("/simulator")) {
+      setNavButtonLeft(<ExitAppButton />);
+      setStyle({
+        backgroundColor: theme.custom.colors.nav,
+        height: "45px",
+        borderBottom: "none",
+        fontSize: "16px",
+      });
+      actions.push(() => {
+        setNavButtonLeft(previousLeft);
+        setStyle(previousStyle);
+      });
+    }
+
+    return () => {
+      actions.forEach((action: any) => action());
+    };
   }, [url, tab]);
   return <_Router />;
+}
+
+function ExitAppButton() {
+  const theme = useCustomTheme();
+  const nav = useNavigation();
+  return (
+    <IconButton
+      style={{
+        padding: 0,
+      }}
+      onClick={() => nav.pop()}
+    >
+      <TransitEnterexitIcon style={{ color: theme.custom.colors.secondary }} />
+    </IconButton>
+  );
 }
 
 function _Router() {

--- a/packages/recoil/src/atoms/navigation.tsx
+++ b/packages/recoil/src/atoms/navigation.tsx
@@ -108,3 +108,13 @@ export const navigationRightButton = atom<any | null>({
   key: "navigationRightButton",
   default: null,
 });
+
+export const navigationLeftButton = atom<any | null>({
+  key: "navigationLeftButton",
+  default: null,
+});
+
+export const navigationStyle = atom<any | null>({
+  key: "navigationStyle",
+  default: {},
+});

--- a/packages/recoil/src/hooks/useNavigation.tsx
+++ b/packages/recoil/src/hooks/useNavigation.tsx
@@ -1,3 +1,4 @@
+import { useState } from "react";
 import { useSearchParams } from "react-router-dom";
 import { useRecoilValue, useRecoilState, useSetRecoilState } from "recoil";
 import * as atoms from "../atoms";
@@ -10,6 +11,10 @@ type NavigationContext = {
   pop: any;
   navButtonRight: any | null;
   setNavButtonRight: (b: null | any) => void;
+  navButtonLeft: any | null;
+  setNavButtonLeft: (b: null | any) => void;
+  style: React.CSSProperties;
+  setStyle: (style: React.CSSProperties) => void;
 };
 
 export module SearchParamsFor {
@@ -35,6 +40,10 @@ export function useNavigation(): NavigationContext {
   const [navButtonRight, setNavButtonRight] = useRecoilState(
     atoms.navigationRightButton
   );
+  const [navButtonLeft, setNavButtonLeft] = useRecoilState(
+    atoms.navigationLeftButton
+  );
+  const [style, setStyle] = useRecoilState(atoms.navigationStyle);
   const { push, pop } = useNavigationSegue();
   const isRoot = navData.urls.length === 1;
   const url = navData.urls[navData.urls.length - 1];
@@ -49,6 +58,10 @@ export function useNavigation(): NavigationContext {
     pop,
     navButtonRight,
     setNavButtonRight,
+    navButtonLeft,
+    setNavButtonLeft,
+    style,
+    setStyle,
   };
 }
 


### PR DESCRIPTION
We'll probably want to adjust the design here but the general idea is to adjust the navigation views when entering into xNFT apps. Namely,

* removes the bottom tab bar (leaves room for the app to introduce their own, which is common and desireable)
* shrinks top nav bar to make room for the app to introduce its own. note that this shrinking should only happen for app views. Not the normal native flows, e.g., token transfers.
* change the left nav button from a back icon to an "exit app" icon (here it's a down, left arrow but it could be something different)

When the time comes to add transition animations, we'll also want to add a different enter/exit navigation to the app view to emphasize the feeling that you're going into an app rather than a native app feature, e.g., token transfers.