### PR TITLE
[wip] make app android compatible

### DIFF
--- a/packages/app/index.js
+++ b/packages/app/index.js
@@ -38,7 +38,7 @@ function Background() {
             // put the injectJavaScript function in a global observable
             // store so that it can be used here & in @coral-xyz/common
             setInjectJavaScript(ref.injectJavaScript);
-          }, 1_000);
+          }, 1000);
         }}
         source={{
           // XXX: this can only be a domain that's specified in


### PR DESCRIPTION
- change 1_000 to 1000 in JS due to android throwing "No identifiers allowed directly after numeric literal" error
- set up android studio + emulator, https://docs.expo.dev/workflow/android-studio-emulator/
- ensure emulator it has enough storage in device settings
- run `adb devices`, then `adb -s [[emulator-XXXX]] reverse tcp:9333 tcp:9333` so that you can use localhost and not 10.0.2.2
- ???

related #280