### PR TITLE
add optional publicKey param to `onAddSuccess` to set as active

### DIFF
--- a/packages/app-extension/src/components/Settings/AddConnectWallet/index.tsx
+++ b/packages/app-extension/src/components/Settings/AddConnectWallet/index.tsx
@@ -17,7 +17,7 @@ export function AddConnectWallet({
   onAddSuccess,
   close,
 }: {
-  onAddSuccess: () => void;
+  onAddSuccess: (publicKey?: string) => void;
   close: () => void;
 }) {
   const theme = useCustomTheme();
@@ -56,8 +56,11 @@ export function AddConnectWallet({
     });
   };
 
-  const secretKeyImport = async (secretKey: string, name: string) => {
-    await background.request({
+  const secretKeyImport = async (
+    secretKey: string,
+    name: string
+  ): Promise<string> => {
+    return background.request({
       method: UI_RPC_METHOD_KEYRING_IMPORT_SECRET_KEY,
       params: [secretKey, name],
     });
@@ -65,7 +68,9 @@ export function AddConnectWallet({
 
   const onSelectAction = (action: AddConnectFlows) => {
     if (action === "create-new-wallet") {
-      createNewWallet().then(onAddSuccess).catch(console.error);
+      createNewWallet()
+        .then(() => onAddSuccess())
+        .catch(console.error);
     } else {
       setAddConnectFlow(action);
     }
@@ -79,8 +84,8 @@ export function AddConnectWallet({
   const importWalletFlow = [
     <ImportSecretKey
       onNext={async (secretKey: string, name: string) => {
-        await secretKeyImport(secretKey, name);
-        onAddSuccess();
+        const publicKey = await secretKeyImport(secretKey, name);
+        onAddSuccess(publicKey);
       }}
     />,
   ];

--- a/packages/app-extension/src/components/Settings/index.tsx
+++ b/packages/app-extension/src/components/Settings/index.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState, Suspense } from "react";
+import { useEffect, useState, Suspense, useCallback } from "react";
 import * as bs58 from "bs58";
 import { Box, Typography, IconButton } from "@mui/material";
 import { styles, useCustomTheme } from "@coral-xyz/themes";
@@ -120,9 +120,28 @@ function SettingsContent({ close }: { close: () => void }) {
 type SettingsPage = "menu" | "add-connect-wallet";
 
 function _SettingsContent({ close }: { close: () => void }) {
+  const background = useBackgroundClient();
   const classes = useStyles();
   const keyringStoreState = useKeyringStoreState();
   const [page, setPage] = useState<SettingsPage>("menu");
+
+  const onAddSuccessHandler = useCallback(
+    async (publicKey?: string) => {
+      try {
+        if (publicKey) {
+          await background.request({
+            method: UI_RPC_METHOD_WALLET_DATA_ACTIVE_WALLET_UPDATE,
+            params: [publicKey],
+          });
+        }
+      } catch (err) {
+        console.error(err);
+      } finally {
+        close();
+      }
+    },
+    [background]
+  );
 
   return (
     <>
@@ -139,7 +158,10 @@ function _SettingsContent({ close }: { close: () => void }) {
         </div>
       )}
       {page === "add-connect-wallet" && (
-        <AddConnectWallet onAddSuccess={close} close={() => setPage("menu")} />
+        <AddConnectWallet
+          onAddSuccess={onAddSuccessHandler}
+          close={() => setPage("menu")}
+        />
       )}
     </>
   );

--- a/packages/background/src/backend/core.ts
+++ b/packages/background/src/backend/core.ts
@@ -334,7 +334,7 @@ export class Backend {
         name: _name,
       },
     });
-    return SUCCESS_RESPONSE;
+    return publicKey;
   }
 
   keyringExportSecretKey(password: string, pubkey: string): string {


### PR DESCRIPTION
closes #286 

- adjust `Backend#importSecretKey` to return the public key of the provided secret key
- adjust `onAddSuccess` prop function to optionally take a `publicKey?: string`. if provided, will call `wallet-active-update` request to backend to update on success