### PR TITLE
add menu to onboarding panel as seen in figma

### DIFF
--- a/packages/app-extension/src/components/Layout/Drawer.tsx
+++ b/packages/app-extension/src/components/Layout/Drawer.tsx
@@ -1,4 +1,11 @@
-import { useEffect } from "react";
+import {
+  type CSSProperties,
+  type Dispatch,
+  type MutableRefObject,
+  type PropsWithChildren,
+  type SetStateAction,
+  useEffect,
+} from "react";
 import { Drawer, Button, IconButton } from "@mui/material";
 import { Close } from "@mui/icons-material";
 import { styles, useCustomTheme } from "@coral-xyz/themes";
@@ -216,6 +223,43 @@ export function WithDrawerNoHeader(props: any) {
           </Button>
         )}
       </div>
+    </Drawer>
+  );
+}
+
+export function WithContaineredDrawer(
+  props: PropsWithChildren<{
+    containerRef: MutableRefObject<any>;
+    openDrawer: boolean;
+    paperStyles: Partial<CSSProperties>;
+    setOpenDrawer: Dispatch<SetStateAction<boolean>>;
+  }>
+) {
+  const theme = useCustomTheme();
+  const { children, containerRef, openDrawer, setOpenDrawer, paperStyles } =
+    props;
+
+  return (
+    <Drawer
+      anchor="bottom"
+      open={openDrawer}
+      onClose={() => setOpenDrawer(false)}
+      PaperProps={{
+        style: {
+          position: "absolute",
+          padding: "16px",
+          background: theme.custom.colors.nav,
+          ...paperStyles,
+        },
+      }}
+      BackdropProps={{ style: { position: "absolute" } }}
+      ModalProps={{
+        container: containerRef.current,
+        style: { position: "absolute" },
+        disableAutoFocus: true,
+      }}
+    >
+      {children}
     </Drawer>
   );
 }

--- a/packages/app-extension/src/components/Locked/LockedMenu.tsx
+++ b/packages/app-extension/src/components/Locked/LockedMenu.tsx
@@ -68,7 +68,7 @@ export function LockedMenuList({ setMenuOpen }: any) {
     {
       icon: <SupportIcon style={{ color: theme.custom.colors.secondary }} />,
       text: "Help & Support",
-      onClick: () => console.log("help & support"),
+      onClick: () => console.log("help & support"), // TODO:
     },
     {
       icon: <LockIcon style={{ color: theme.custom.colors.secondary }} />,

--- a/packages/app-extension/src/components/Onboarding/OnboardingWelcome.tsx
+++ b/packages/app-extension/src/components/Onboarding/OnboardingWelcome.tsx
@@ -1,9 +1,34 @@
-import { Box, Grid } from "@mui/material";
-import { AddCircle, ArrowCircleDown } from "@mui/icons-material";
+import {
+  Dispatch,
+  MutableRefObject,
+  SetStateAction,
+  useRef,
+  useState,
+} from "react";
+import {
+  Box,
+  Drawer,
+  Grid,
+  IconButton,
+  ListItemText,
+  Toolbar,
+} from "@mui/material";
+import {
+  AddCircle,
+  ArrowCircleDown,
+  CallMade,
+  Lock,
+  Menu,
+  Support,
+  Twitter,
+} from "@mui/icons-material";
 import { useCustomTheme } from "@coral-xyz/themes";
 import { ActionCard } from "../Layout/ActionCard";
 import { BackpackHeader } from "../Locked";
+import { NAV_BAR_HEIGHT } from "../Layout/Nav";
+import { List, ListItem } from "../common/List";
 import type { OnboardingFlows } from "./";
+import { WithContaineredDrawer } from "../Layout/Drawer";
 
 export function OnboardingWelcome({
   onSelect,
@@ -11,6 +36,9 @@ export function OnboardingWelcome({
   onSelect: (flow: OnboardingFlows) => void;
 }) {
   const theme = useCustomTheme();
+  const [menuOpen, setMenuOpen] = useState(false);
+  const containerRef = useRef(null);
+
   return (
     <div
       style={{
@@ -21,9 +49,17 @@ export function OnboardingWelcome({
         flexDirection: "column",
         height: "100%",
         padding: "20px",
+        position: "relative",
+        overflow: "hidden",
       }}
+      ref={containerRef}
     >
       <Box>
+        <OnboardingMenu
+          containerRef={containerRef}
+          menuOpen={menuOpen}
+          setMenuOpen={setMenuOpen}
+        />
         <BackpackHeader />
       </Box>
 
@@ -44,5 +80,126 @@ export function OnboardingWelcome({
         </Grid>
       </Grid>
     </div>
+  );
+}
+
+function OnboardingMenu({
+  containerRef,
+  menuOpen,
+  setMenuOpen,
+}: {
+  containerRef: MutableRefObject<any>;
+  menuOpen: boolean;
+  setMenuOpen: Dispatch<SetStateAction<boolean>>;
+}) {
+  const theme = useCustomTheme();
+
+  return (
+    <Toolbar
+      sx={{
+        display: "flex",
+        flexDirection: "row-reverse",
+        paddingLeft: "16px",
+        paddingRight: "16px",
+        paddingTop: "10px",
+        paddingBottom: "10px",
+        height: NAV_BAR_HEIGHT,
+      }}
+    >
+      <IconButton
+        color="inherit"
+        onClick={() => setMenuOpen(true)}
+        sx={{ padding: 0 }}
+      >
+        <Menu sx={{ color: theme.custom.colors.hamburger }} />
+      </IconButton>
+      <WithContaineredDrawer
+        containerRef={containerRef}
+        openDrawer={menuOpen}
+        setOpenDrawer={setMenuOpen}
+        paperStyles={{
+          padding: "40px 16px 40px 16px",
+          borderRadius: "15px 15px 0 0",
+        }}
+      >
+        <OnboardingMenuList />
+      </WithContaineredDrawer>
+    </Toolbar>
+  );
+}
+
+function OnboardingMenuList() {
+  const theme = useCustomTheme();
+
+  const options = [
+    {
+      icon: <Support style={{ color: theme.custom.colors.secondary }} />,
+      text: "Help & Support",
+      onClick: () => console.log("help & support"), // TODO:
+    },
+    {
+      icon: <Lock style={{ color: theme.custom.colors.secondary }} />,
+      text: "Backpack.app",
+      onClick: () => window.open("https://backpack.app", "_blank"),
+    },
+    {
+      icon: <Twitter style={{ color: theme.custom.colors.secondary }} />,
+      text: "Twitter",
+      onClick: () => window.open("https://twitter.com/xNFT_Backpack", "_blank"),
+    },
+    {
+      icon: <Twitter style={{ color: theme.custom.colors.secondary }} />, // TODO:
+      text: "Discord",
+      onClick: () => console.log("discord"), // TODO:
+    },
+  ];
+
+  return (
+    <Box sx={{ color: theme.custom.colors.fontColor }}>
+      <List
+        style={{
+          background: theme.custom.colors.bg2,
+          marginLeft: "16px",
+          marginRight: "16px",
+        }}
+      >
+        {options.map((o, idx) => (
+          <ListItem
+            onClick={o.onClick}
+            key={o.text}
+            style={{
+              height: "44px",
+              display: "flex",
+            }}
+            isLast={idx === options.length - 1}
+            borderColor={theme.custom.colors.border1}
+          >
+            <div
+              style={{
+                display: "flex",
+                justifyContent: "center",
+                flexDirection: "column",
+              }}
+            >
+              {o.icon}
+            </div>
+            <ListItemText
+              sx={{
+                marginLeft: "8px",
+                fontSize: "16px",
+                lineHeight: "24px",
+                fontWeight: 500,
+              }}
+              primary={o.text}
+            />
+            <div>
+              <CallMade
+                style={{ flexGrow: 1, color: theme.custom.colors.secondary }}
+              />
+            </div>
+          </ListItem>
+        ))}
+      </List>
+    </Box>
   );
 }


### PR DESCRIPTION
closes #230 

add custom drawer menu to onboarding welcome panel seen in figma.

> Note:
> - Discord icon does not exist yet and should be added
> - help/support and discord onClick links are inactive pending proper urls