### PR TITLE
Add Max button to send screen

### DIFF
--- a/packages/app-extension/src/components/Unlocked/Balances/TokensWidget/Send.tsx
+++ b/packages/app-extension/src/components/Unlocked/Balances/TokensWidget/Send.tsx
@@ -130,6 +130,7 @@ export function Send({
   tokenAddress: string;
 }) {
   const classes = useStyles() as any;
+  const theme = useCustomTheme();
   const { close } = useDrawerContext();
   const token = useBlockchainTokenAccount(blockchain, tokenAddress);
   const { provider } = useAnchorContext();
@@ -143,6 +144,14 @@ export function Send({
   const [accountValidated, setAccountValidated] = useState<boolean>(false);
 
   const amountFloat = parseFloat(amount.toString());
+
+  //
+  // When sending SOL, account for the tx fee.
+  //
+  let lamportsOffset = 0.0;
+  if (token.mint === SOL_NATIVE_MINT) {
+    lamportsOffset = 0.000005;
+  }
 
   // This effect validates the account address given.
   useEffect(() => {
@@ -183,14 +192,6 @@ export function Send({
     let didAmountError = false;
     if (amountFloat <= 0) {
       didAmountError = true;
-    }
-
-    //
-    // When sending SOL, account for the tx fee.
-    //
-    let lamportsOffset = 0.0;
-    if (token.mint === SOL_NATIVE_MINT) {
-      lamportsOffset = 0.000005;
     }
 
     if (token.nativeBalance < amountFloat + lamportsOffset) {
@@ -249,14 +250,7 @@ export function Send({
             leftLabel={"Amount"}
             rightLabel={`${token.nativeBalance} ${token.ticker}`}
           />
-          <div
-            style={{
-              margin: "0 12px",
-              display: "flex",
-              gap: 10,
-              alignItems: "stretch",
-            }}
-          >
+          <div style={{ margin: "0 12px" }}>
             <TextField
               rootClass={classes.textRoot}
               type={"number"}
@@ -267,11 +261,20 @@ export function Send({
               inputProps={{
                 name: "amount",
               }}
-            />
-            <SecondaryButton
-              label="MAX"
-              onClick={() => setAmount(token.nativeBalance)}
-              style={{ width: "auto", height: "auto" }}
+              endAdornment={
+                <SecondaryButton
+                  label="Max"
+                  onClick={() =>
+                    setAmount(token.nativeBalance - lamportsOffset)
+                  }
+                  style={{
+                    width: "auto",
+                    height: "auto",
+                    backgroundColor: theme.custom.colors.background,
+                    borderRadius: "24px",
+                  }}
+                />
+              }
             />
           </div>
         </div>


### PR DESCRIPTION
Add a max button. Bit awkward sized since it's taller than a normal button (e.g. the Send button on the page), but the normal height also looked awkward centered next to the text field. 

<img width="365" alt="Screen Shot 2022-07-19 at 11 15 59 AM" src="https://user-images.githubusercontent.com/1311014/179821021-3b4d543f-4cc1-4d88-b3f8-b6486d732a92.png">

Closes #116 