### PR TITLE
Update setup instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ Go to chrome://flags/#allow-insecure-localhost and enable the toggle, then resta
 git clone https://github.com/coral-xyz/wallet-adapter
 cd wallet-adapter
 yarn
+export NODE_OPTIONS=--no-experimental-fetch
 yarn build
 npx lerna exec -- yarn link
 ```


### PR DESCRIPTION
Using a recent version of node fails at the `yarn build` step due to an issue in parcel. https://github.com/parcel-bundler/parcel/issues/8005#issuecomment-1120149358 is a workaround that should work regardless of node version. Added it to the readme.