### PR TITLE
fix missing onUnlock call

### DIFF
--- a/packages/app-extension/src/components/Locked/index.tsx
+++ b/packages/app-extension/src/components/Locked/index.tsx
@@ -19,7 +19,7 @@ export function Locked({ onUnlock }: { onUnlock?: () => Promise<void> }) {
         height: "100%",
       }}
     >
-      <LockedInner />
+      <LockedInner onUnlock={onUnlock} />
     </Box>
   );
 }


### PR DESCRIPTION
`onUnlock` doesn't get passed from the `Locked` to the `LockedInner` component so it never gets called. I'm ashamed how long it took me to find this.