### PR TITLE
catch errors from fetching recent tx history

### DIFF
--- a/packages/recoil/src/atoms/recent-transactions.tsx
+++ b/packages/recoil/src/atoms/recent-transactions.tsx
@@ -35,14 +35,19 @@ export async function fetchRecentTransactions(
   connection: Connection,
   publicKey: PublicKey
 ): Promise<Array<ParsedTransactionWithMeta>> {
-  const resp = await connection.getConfirmedSignaturesForAddress2(publicKey, {
-    limit: 15,
-  });
+  try {
+    const resp = await connection.getConfirmedSignaturesForAddress2(publicKey, {
+      limit: 15,
+    });
 
-  const signatures = resp.map((s) => s.signature);
-  const transactions: Array<ParsedTransactionWithMeta | null> =
-    await connection.getParsedTransactions(signatures);
-  return transactions.filter(
-    (tx) => tx !== null
-  ) as Array<ParsedTransactionWithMeta>;
+    const signatures = resp.map((s) => s.signature);
+    const transactions: Array<ParsedTransactionWithMeta | null> =
+      await connection.getParsedTransactions(signatures);
+    return transactions.filter(
+      (tx) => tx !== null
+    ) as Array<ParsedTransactionWithMeta>;
+  } catch (err) {
+    console.error(err);
+    return [];
+  }
 }


### PR DESCRIPTION
Catch these errors so that the entire app doesn't break if the recent tx history api is down.