### PR TITLE
automatically split pasted mnemonic string into string[]

### DIFF
--- a/packages/app-extension/src/components/Account/MnemonicInput.tsx
+++ b/packages/app-extension/src/components/Account/MnemonicInput.tsx
@@ -1,7 +1,5 @@
-import { Tooltip } from "@mui/material";
-import { useState, useEffect } from "react";
-import makeStyles from "@mui/styles/makeStyles";
 import {
+  Tooltip,
   Box,
   Grid,
   TextField,
@@ -9,6 +7,8 @@ import {
   InputAdornment,
   Link,
 } from "@mui/material";
+import { useState, useEffect, ClipboardEventHandler } from "react";
+import makeStyles from "@mui/styles/makeStyles";
 import {
   CheckboxForm,
   Header,
@@ -267,6 +267,36 @@ export function MnemonicInputFields({
                 const newMnemonicWords = [...mnemonicWords];
                 newMnemonicWords[i] = e.target.value;
                 onChange(newMnemonicWords);
+              }
+            }}
+            onPaste={(e) => {
+              try {
+                if (onChange) {
+                  // Try to split the string on the clipboard by commas, spaces
+                  // and/or linebreaks into an array of strings. Then effectively
+                  // paste each word into each corresponding textbox.
+                  onChange(
+                    e.clipboardData
+                      .getData("text")
+                      .toLowerCase()
+                      .replace(/[,\r\n\s]/g, " ") // only keep words (all langs)
+                      .split(" ")
+                      .filter(Boolean)
+                      .reduce(
+                        (words, word, j) => {
+                          words[i + j] = word;
+                          return words;
+                        },
+                        [...mnemonicWords]
+                      )
+                      .slice(0, mnemonicWords.length) // don't paste extra words
+                  );
+                  // it worked, prevent the actual paste from happening
+                  e.preventDefault();
+                }
+              } catch (err) {
+                console.error(err);
+                // didn't work, paste as normal
               }
             }}
           />


### PR DESCRIPTION
something to speed up dev testing and reduce onboarding friction, especially for people coming from other wallets

this splits a pasted mnemonic string into an array of strings and puts each word into the corresponding textbox

https://user-images.githubusercontent.com/101902546/180057441-7d895ee6-ae39-41c3-947b-163a64dc4fca.mov

- it'll paste the first word into the currently active textbox and beyond (see end of video)
- if you have 12 boxes visible and paste a 24 word phrase, it won't add the extra 12 boxes, just keeping the scope small atm
- it should probably have a unit test, ditto scope
- it should fail gracefully
- it doesn't use `[a-z]` or `\w` in the regex because it needs to support characters in various languages (although bip39 doesn't seem to validate them correctly atm)
