### PR TITLE
react-xnft: linking api

### DIFF
--- a/examples/plugins/deadgods/src/Stake.tsx
+++ b/examples/plugins/deadgods/src/Stake.tsx
@@ -11,6 +11,7 @@ import {
   NavScreen,
   Image,
   Loading,
+  Linking,
 } from "react-xnft";
 import { Transaction, SystemProgram } from "@solana/web3.js";
 import { useDegodTokens } from "./utils";
@@ -379,14 +380,20 @@ function GodGrid({ staked, unstaked, isDead }: any) {
           Unstake All
         </Button>
       </View>
-      <Text
-        style={{
-          fontSize: "12px",
-          textAlign: "center",
+      <View
+        onClick={() => {
+          Linking.openLink("https://magiceden.io");
         }}
       >
-        👋 Browse Magic Eden
-      </Text>
+        <Text
+          style={{
+            fontSize: "12px",
+            textAlign: "center",
+          }}
+        >
+          👋 Browse Magic Eden
+        </Text>
+      </View>
     </View>
   );
 }

--- a/packages/common/src/constants.ts
+++ b/packages/common/src/constants.ts
@@ -55,8 +55,11 @@ export const RECONCILER_BRIDGE_METHOD_RENDER_ROOT =
   "reconciler-bridge-method-render-root";
 
 export const PLUGIN_NOTIFICATION_RENDER = "render";
+
 export const PLUGIN_RPC_METHOD_NAV_PUSH = "nav-push";
 export const PLUGIN_RPC_METHOD_NAV_POP = "nav-pop";
+export const PLUGIN_RPC_METHOD_OPEN_LINK = "open-link";
+
 export const PLUGIN_NOTIFICATION_CONNECT = "connect";
 export const PLUGIN_NOTIFICATION_ON_CLICK = "on-click";
 export const PLUGIN_NOTIFICATION_ON_CHANGE = "on-change";

--- a/packages/provider-injection/src/provider-ui.ts
+++ b/packages/provider-injection/src/provider-ui.ts
@@ -19,6 +19,7 @@ import {
   CHANNEL_PLUGIN_RPC_RESPONSE,
   PLUGIN_RPC_METHOD_NAV_PUSH,
   PLUGIN_RPC_METHOD_NAV_POP,
+  PLUGIN_RPC_METHOD_OPEN_LINK,
   PLUGIN_NOTIFICATION_CONNECT,
   PLUGIN_NOTIFICATION_ON_CLICK,
   PLUGIN_NOTIFICATION_ON_CHANGE,
@@ -130,6 +131,13 @@ export class ProviderUiInjection extends EventEmitter implements Provider {
     await this._requestManager.request({
       method: PLUGIN_RPC_METHOD_NAV_POP,
       params: [],
+    });
+  }
+
+  public async openLink(url: string) {
+    return await this._requestManager.request({
+      method: PLUGIN_RPC_METHOD_OPEN_LINK,
+      params: [url],
     });
   }
 

--- a/packages/react-xnft-renderer/src/plugin.ts
+++ b/packages/react-xnft-renderer/src/plugin.ts
@@ -19,6 +19,7 @@ import {
   CHANNEL_PLUGIN_CONNECTION_BRIDGE,
   PLUGIN_RPC_METHOD_NAV_PUSH,
   PLUGIN_RPC_METHOD_NAV_POP,
+  PLUGIN_RPC_METHOD_OPEN_LINK,
   RPC_METHOD_SIGN_TX as PLUGIN_RPC_METHOD_SIGN_TX,
   RPC_METHOD_SIGN_AND_SEND_TX as PLUGIN_RPC_METHOD_SIGN_AND_SEND_TX,
   RPC_METHOD_SIMULATE as PLUGIN_RPC_METHOD_SIMULATE_TX,
@@ -372,6 +373,8 @@ export class Plugin {
         return await this._handleNavPush();
       case PLUGIN_RPC_METHOD_NAV_POP:
         return await this._handleNavPop();
+      case PLUGIN_RPC_METHOD_OPEN_LINK:
+        return await this._openLink(params[0]);
       case PLUGIN_RPC_METHOD_SIGN_TX:
         return await this._handleSignTransaction(params[0], params[1]);
       case PLUGIN_RPC_METHOD_SIGN_AND_SEND_TX:
@@ -392,6 +395,13 @@ export class Plugin {
   // todo: can delete with the widget refactor probably
   private async _handleNavPop(): Promise<RpcResponse> {
     throw new Error("not implemented");
+  }
+
+  private async _openLink(url: string): Promise<RpcResponse> {
+    console.log("armani open link here");
+    // TODO: ask for permission from the user.
+    window.open(url);
+    return ["success"];
   }
 
   private async _handleSignTransaction(

--- a/packages/react-xnft/src/index.ts
+++ b/packages/react-xnft/src/index.ts
@@ -14,3 +14,4 @@ export * from "./Dom";
 export * from "./elements";
 export * from "./hooks";
 export * from "./sdk";
+export * from "./linking";

--- a/packages/react-xnft/src/linking.tsx
+++ b/packages/react-xnft/src/linking.tsx
@@ -1,0 +1,5 @@
+export class Linking {
+  public static async openLink(url: string) {
+    return await window.anchorUi.openLink(url);
+  }
+}


### PR DESCRIPTION
Adds the ability to open external links from the xnft out to the browser.

TODO: 

* permissions UI for notifying the user that they are leaving the app and going to an external link.
* ability to open a link outside the extension popup (e.g. another tab in chrome)
* ability to open a link within the extension popup