### PR TITLE
app-extension: mini drawer tweaks

### DIFF
--- a/packages/app-extension/src/components/Layout/Drawer.tsx
+++ b/packages/app-extension/src/components/Layout/Drawer.tsx
@@ -126,12 +126,14 @@ export function WithMiniDrawer(props: any) {
     setOpenDrawer,
     paperAnchorBottom,
     backdropProps,
+    modalProps,
+    onClose,
   } = props;
   return (
     <Drawer
       anchor={"bottom"}
       open={openDrawer}
-      onClose={() => setOpenDrawer(false)}
+      onClose={() => (onClose ? onClose() : setOpenDrawer(false))}
       classes={{
         root: classes.miniDrawerRoot,
         paper: classes.miniDrawerPaper,
@@ -140,10 +142,12 @@ export function WithMiniDrawer(props: any) {
       BackdropProps={{
         style: {
           background: "transparent",
-          ...backdropProps,
         },
+        ...backdropProps,
       }}
-      ModalProps={{ onBackdropClick: () => setOpenDrawer(false) }}
+      ModalProps={{
+        ...modalProps,
+      }}
     >
       {children}
     </Drawer>


### PR DESCRIPTION
- Allow a custom onClose function, remove onBackDropClick (deprecated and onClose handles it)
- Use backdropProps properly, it shouldn't be spread in the style
- Add modalProps