### PR TITLE
use cached node_modules in CI

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -69,6 +69,7 @@ jobs:
           path: |
             **/node_modules
             ${{ steps.yarn-cache-dir-path.outputs.dir }}
+            !**/node_modules/.cache
           key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
           restore-keys: |
             ${{ runner.os }}-yarn


### PR DESCRIPTION
excludes `node_modules/.cache/` as that's used by turborepo and we have remote caching handling that