### PR TITLE
use wrapped sol coingecko id

### DIFF
--- a/packages/recoil/src/atoms/solana/token-registry.tsx
+++ b/packages/recoil/src/atoms/solana/token-registry.tsx
@@ -17,7 +17,14 @@ export const splTokenRegistry = atom<Map<string, TokenInfo> | null>({
             .getList();
           const tokenMap = tokenList.reduce((map, item) => {
             if (item.address === WSOL_MINT) {
-              map.set(item.address, { ...item, symbol: "wSOL" });
+              map.set(item.address, {
+                ...item,
+                symbol: "wSOL",
+                extensions: {
+                  ...item.extensions,
+                  coingeckoId: "wrapped-solana",
+                },
+              });
             } else {
               map.set(item.address, item);
             }


### PR DESCRIPTION
SPL token registry uses `solana` for the coingecko ID for wrapped SOL. It should be `wrapped-solana` per https://www.coingecko.com/en/coins/wrapped-solana

If you have both SOL and wSOL in your wallet the duplicate coingecko ID means the price for wSOL won't return correctly. We could also fix that and use the SOL price for wSOL, not sure what is preferable here. It probably is possible for the SOL/wSOL price to diverge under some condition.

Closes #496 
