### PR TITLE
run `yarn install` in root dir automatically in precommit hook

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,4 +1,5 @@
 #!/bin/sh
 . "$(dirname "$0")/_/husky.sh"
 
-npx lint-staged
+# run `yarn install` to ensure yarn.lock correctly represents package.json
+yarn install && npx lint-staged

--- a/yarn.lock
+++ b/yarn.lock
@@ -3719,27 +3719,6 @@
     snake-case "^3.0.4"
     toml "^3.0.0"
 
-"@project-serum/anchor@^0.25.0":
-  version "0.25.0"
-  resolved "https://registry.yarnpkg.com/@project-serum/anchor/-/anchor-0.25.0.tgz#88ee4843336005cf5a64c80636ce626f0996f503"
-  integrity sha512-E6A5Y/ijqpfMJ5psJvbw0kVTzLZFUcOFgs6eSM2M2iWE1lVRF18T6hWZVNl6zqZsoz98jgnNHtVGJMs+ds9A7A==
-  dependencies:
-    "@project-serum/borsh" "^0.2.5"
-    "@solana/web3.js" "^1.36.0"
-    base64-js "^1.5.1"
-    bn.js "^5.1.2"
-    bs58 "^4.0.1"
-    buffer-layout "^1.2.2"
-    camelcase "^5.3.1"
-    cross-fetch "^3.1.5"
-    crypto-hash "^1.3.0"
-    eventemitter3 "^4.0.7"
-    js-sha256 "^0.9.0"
-    pako "^2.0.3"
-    snake-case "^3.0.4"
-    superstruct "^0.15.4"
-    toml "^3.0.0"
-
 "@project-serum/anchor@^0.25.0-beta.1":
   version "0.25.0-beta.1"
   resolved "https://registry.yarnpkg.com/@project-serum/anchor/-/anchor-0.25.0-beta.1.tgz#7b113fb6604483d6740c8da9c6d86e9a5d5f6cf7"


### PR DESCRIPTION
not sure if this is a good idea but I sometimes notice that if I pull master and then run yarn install, changes are made to my lockfile(s)

<img width="1485" alt="Screenshot 2022-08-02 at 17 13 17" src="https://user-images.githubusercontent.com/101902546/182423136-65167a41-02f5-471d-826b-031ad94860d5.png">

this PR adds `yarn install` in the precommit hook, to ensure that the correct packages and versions are installed in the repo without devs needing to remember to go to the root dir and run `yarn install` themselves before committing