### PR TITLE
add missing dep to psyfi table

### DIFF
--- a/examples/xnft/table-psyfi/package.json
+++ b/examples/xnft/table-psyfi/package.json
@@ -8,6 +8,7 @@
   },
   "license": "MIT",
   "dependencies": {
+    "@coral-xyz/common": "*",
     "react-xnft": "*",
     "@project-serum/anchor": "^0.25.0-beta.1",
     "@solana/web3.js": "^1.43.2",


### PR DESCRIPTION
fixes issue with build

```
@coral-xyz/example-plugin-table-psyfi:build: [
@coral-xyz/example-plugin-table-psyfi:build:   {
@coral-xyz/example-plugin-table-psyfi:build:     message: "Failed to resolve '@coral-xyz/common' from './xnft/table-psyfi/src/context.tsx'",
@coral-xyz/example-plugin-table-psyfi:build:     origin: '@parcel/core',
@coral-xyz/example-plugin-table-psyfi:build:     codeFrames: [ [Object] ]
@coral-xyz/example-plugin-table-psyfi:build:   },
@coral-xyz/example-plugin-table-psyfi:build:   {
@coral-xyz/example-plugin-table-psyfi:build:     message: "Could not load './dist/esm/index.js' from module '@coral-xyz/common' found in package.json#module",
@coral-xyz/example-plugin-table-psyfi:build:     codeFrames: [ [Object] ],
@coral-xyz/example-plugin-table-psyfi:build:     origin: '@parcel/resolver-default'
@coral-xyz/example-plugin-table-psyfi:build:   }
@coral-xyz/example-plugin-table-psyfi:build: ]
```