### PR TITLE
cleanup background keepalive connection on unmount

### DIFF
--- a/packages/recoil/src/hooks/client.tsx
+++ b/packages/recoil/src/hooks/client.tsx
@@ -1,25 +1,30 @@
+import {
+  ChannelAppUiClient,
+  ChannelAppUiResponder,
+  UI_RPC_METHOD_KEYRING_STORE_KEEP_ALIVE,
+} from "@coral-xyz/common";
 import { useEffect } from "react";
 import { useRecoilValue } from "recoil";
-import { ChannelAppUiClient, ChannelAppUiResponder } from "@coral-xyz/common";
-import * as atoms from "../atoms";
-import { UI_RPC_METHOD_KEYRING_STORE_KEEP_ALIVE } from "@coral-xyz/common";
+import { backgroundClient, backgroundResponder } from "../atoms";
 
 export function useBackgroundClient(): ChannelAppUiClient {
-  return useRecoilValue(atoms.backgroundClient);
+  return useRecoilValue(backgroundClient);
 }
 
 export function useBackgroundResponder(): ChannelAppUiResponder {
-  return useRecoilValue(atoms.backgroundResponder);
+  return useRecoilValue(backgroundResponder);
 }
 
 export function useBackgroundKeepAlive() {
   const bg = useBackgroundClient();
   useEffect(() => {
-    setInterval(() => {
+    const interval = setInterval(() => {
       bg.request({
         method: UI_RPC_METHOD_KEYRING_STORE_KEEP_ALIVE,
         params: [],
       });
     }, 5 * 60 * 1000);
+
+    return () => clearInterval(interval);
   }, []);
 }


### PR DESCRIPTION
ensures the useEffect removes the `UI_RPC_METHOD_KEYRING_STORE_KEEP_ALIVE` pinging on unmount + tidies up imports