### PR TITLE
dont block wallet on jupiter failure

### DIFF
--- a/packages/app-extension/src/components/Unlocked/Swap.tsx
+++ b/packages/app-extension/src/components/Unlocked/Swap.tsx
@@ -406,10 +406,11 @@ const ConfirmSwapButton = ({
     isLoadingRoutes,
     isLoadingTransactions,
   } = useSwapContext();
+  const tokenAccounts = useJupiterOutputMints(fromMint);
 
   if (exceedsBalance) {
     return <InsufficientBalanceButton />;
-  } else if (isJupiterError) {
+  } else if (isJupiterError || tokenAccounts.length === 0) {
     return <SwapUnavailableButton />;
   }
 

--- a/packages/recoil/src/atoms/solana/jupiter.tsx
+++ b/packages/recoil/src/atoms/solana/jupiter.tsx
@@ -22,7 +22,9 @@ export const allJupiterInputMints = selector({
   key: "allJupiterInputMints",
   get: async ({ get }) => {
     const routeMap = get(jupiterRouteMap);
-    return Object.keys(routeMap);
+    if (routeMap) return Object.keys(routeMap);
+    // API request fail
+    else return [];
   },
 });
 
@@ -50,7 +52,7 @@ export const jupiterOutputMints = selectorFamily({
       // If input mint is SOL native then we can use WSOL with unwrapping
       const routeMapMint =
         inputMint === SOL_NATIVE_MINT ? WSOL_MINT : inputMint;
-      if (!routeMap[routeMapMint]) return [];
+      if (!routeMap || !routeMap[routeMapMint]) return [];
       const swapTokens = routeMap[routeMapMint].map((mint: string) => {
         const tokenMetadata = tokenRegistry.get(mint) ?? ({} as TokenInfo);
         const { name, symbol, logoURI } = tokenMetadata;


### PR DESCRIPTION
This will block the swap tab for blocking requests and display an error that swaps are unavailable if it eventually times out. The rest of the wallet works as normal.

Same question/problem arises with coingecko, if it ever goes down the wallet will become unusable because it is part of the bootstrap. 

- We could not display prices until it loads, which would be a bit of a weird flickery experience.
- Set a reasonably small timeout on the request and not display prices if it fails so the wallet is still usable.
- Write prices to local storage on each query and display the old ones on initial load and then update (flickery again)

We can punt on this at this stage, but I've noticed quite a lot of angering around endless loading indicators on Phantom.

Closes #537 