### PR TITLE
fix key removal bugs

### DIFF
--- a/packages/background/src/backend/keyring/solana.ts
+++ b/packages/background/src/backend/keyring/solana.ts
@@ -184,13 +184,16 @@ class SolanaHdKeyring extends SolanaKeyring implements HdKeyring {
   }
 
   public deleteKeyIfNeeded(pubkey: string): number {
-    const idx = super.deleteKeyIfNeeded(pubkey);
+    const idx = this.keypairs.findIndex(
+      (kp) => kp.publicKey.toString() === pubkey
+    );
     if (idx < 0) {
       return idx;
     }
     if (this.keypairs.length <= 1) {
       throw new Error("cannot delete the last key in the hd keyring");
     }
+    super.deleteKeyIfNeeded(pubkey);
     this.accountIndices = this.accountIndices
       .slice(0, idx)
       .concat(this.accountIndices.slice(idx + 1));


### PR DESCRIPTION
- Can't remove non hd keypair if only one hd keypair left and removing from ledger or import keyring
- Removing ledger key removes all except the one specified for removal