### PR TITLE
fix disable already imported accounts

### DIFF
--- a/packages/app-extension/src/components/common/Account/ImportAccounts.tsx
+++ b/packages/app-extension/src/components/common/Account/ImportAccounts.tsx
@@ -85,23 +85,22 @@ export function ImportAccounts({
 
   useEffect(() => {
     (async () => {
-      if (connection) {
-        try {
-          const accounts = await background.request({
-            method: UI_RPC_METHOD_KEYRING_STORE_READ_ALL_PUBKEYS,
-            params: [],
-          });
-          setImportedPubkeys(
-            Object.values(accounts)
-              .flat()
-              .map((a: any) => a.publicKey)
-          );
-        } catch {
-          // Keyring store locked, either onboarding or left open
-        }
+      try {
+        const blockchainKeyrings = await background.request({
+          method: UI_RPC_METHOD_KEYRING_STORE_READ_ALL_PUBKEYS,
+          params: [],
+        });
+        const keyring = blockchainKeyrings[blockchain];
+        setImportedPubkeys(
+          Object.values(keyring)
+            .flat()
+            .map((a: any) => a.publicKey)
+        );
+      } catch {
+        // Keyring store locked, either onboarding or left open
       }
     })();
-  }, [connection]);
+  }, [background, blockchain]);
 
   //
   // Load a list of accounts and their associated balances


### PR DESCRIPTION
Closes https://github.com/coral-xyz/backpack/issues/654

Should note that this has only ever worked if the store is unlocked, otherwise we can't read the pubkeys.