### PR TITLE
clip text overflow on app title with ellipsis

### DIFF
--- a/packages/app-extension/src/components/Unlocked/Apps/index.tsx
+++ b/packages/app-extension/src/components/Unlocked/Apps/index.tsx
@@ -42,6 +42,9 @@ const useStyles = styles((theme) => ({
     fontSize: "12px",
     lineHeight: "16px",
     textAlign: "center",
+    overflow: "hidden",
+    textOverflow: "ellipsis",
+    whiteSpace: "nowrap",
   },
 }));
 


### PR DESCRIPTION
closes https://github.com/coral-xyz/xnft/issues/102

This is a title overflow style change instead of managing two app names in account data as discussed in the issue linked above. This is how smart phones handle app name overflows - lmk what you think.

<img width="193" alt="Screen Shot 2022-08-30 at 11 10 01 AM" src="https://user-images.githubusercontent.com/13121516/187473961-8d402b70-44b0-4bf5-a5b9-345ad208b4cd.png">