### PR TITLE
handle null 24h price change from coingecko

### DIFF
--- a/packages/recoil/src/atoms/ethereum/token.tsx
+++ b/packages/recoil/src/atoms/ethereum/token.tsx
@@ -37,9 +37,10 @@ export const ethereumTokenBalance = selectorFamily<TokenData | null, string>({
         usdBalance === 0 ? 0 : usdBalance / (1 + price.usd_24h_change);
       const recentUsdBalanceChange =
         (usdBalance - oldUsdBalance) / oldUsdBalance;
-      const recentPercentChange = price
-        ? parseFloat(price.usd_24h_change.toFixed(2))
-        : undefined;
+      const recentPercentChange =
+        price && price.usd_24h_change
+          ? parseFloat(price.usd_24h_change.toFixed(2))
+          : undefined;
 
       return {
         name,

--- a/packages/recoil/src/atoms/solana/token.tsx
+++ b/packages/recoil/src/atoms/solana/token.tsx
@@ -50,9 +50,10 @@ export const solanaTokenBalance = selectorFamily<TokenData | null, string>({
         usdBalance === 0 ? 0 : usdBalance / (1 + price.usd_24h_change);
       const recentUsdBalanceChange =
         (usdBalance - oldUsdBalance) / oldUsdBalance;
-      const recentPercentChange = price
-        ? parseFloat(price.usd_24h_change.toFixed(2))
-        : undefined;
+      const recentPercentChange =
+        price && price.usd_24h_change
+          ? parseFloat(price.usd_24h_change.toFixed(2))
+          : undefined;
 
       return {
         name,


### PR DESCRIPTION
Coingecko can sometimes return null for usd_24h_change which crashes the wallet.

<img width="405" alt="Screen Shot 2022-09-01 at 4 22 00 PM" src="https://user-images.githubusercontent.com/489202/188005111-bdefb520-a5a8-40c7-a6f4-8ecf1973d5a4.png">
