### PR TITLE
dont assert unlocked on lock

### DIFF
--- a/packages/background/src/backend/keyring/index.ts
+++ b/packages/background/src/backend/keyring/index.ts
@@ -141,11 +141,9 @@ export class KeyringStore {
   }
 
   public lock() {
-    return this.withUnlock(() => {
-      this.blockchains = new Map();
-      this.lastUsedTs = 0;
-      this.activeBlockchain_ = undefined;
-    });
+    this.blockchains = new Map();
+    this.lastUsedTs = 0;
+    this.activeBlockchain_ = undefined;
   }
 
   // Return the public keys of all blockchain keyrings in the keyring.


### PR DESCRIPTION
Can't see a downside to removing check on wallet being unlocked before locking. 

Closes https://github.com/coral-xyz/backpack/issues/714

