### PR TITLE
mnemonic input spacing tweak

### DIFF
--- a/packages/app-extension/src/components/common/Account/MnemonicInput.tsx
+++ b/packages/app-extension/src/components/common/Account/MnemonicInput.tsx
@@ -48,7 +48,8 @@ const useStyles = makeStyles((theme: any) => ({
     "& .MuiInputAdornment-root": {
       color: theme.custom.colors.secondary,
       fontWeight: 500,
-      minWidth: "15px",
+      minWidth: "12px",
+      fontSize: "14px",
     },
     "&:hover": {
       backgroundColor: theme.custom.colors.primary,


### PR DESCRIPTION
Made the number font slightly smaller to fit 8 letter words in the input (8 letters is max).

<img width="376" alt="Screen Shot 2022-09-17 at 1 41 36 PM" src="https://user-images.githubusercontent.com/489202/190835636-560a1652-903c-4b95-aaf3-e8b28abf413e.png">

Closes https://github.com/coral-xyz/backpack/issues/789
