### PR TITLE
only use direct jupiter routes to ensure single transaction

### DIFF
--- a/packages/recoil/src/atoms/solana/jupiter.tsx
+++ b/packages/recoil/src/atoms/solana/jupiter.tsx
@@ -83,7 +83,7 @@ export const jupiterOutputMints = selectorFamily({
 
 export async function fetchJupiterRouteMap() {
   const response = await (
-    await fetch(`${JUPITER_BASE_URL}indexed-route-map`)
+    await fetch(`${JUPITER_BASE_URL}indexed-route-map?onlyDirectRoutes=true`)
   ).json();
   const getMint = (index: number) => response["mintKeys"][index];
   // Replace indices with mint addresses


### PR DESCRIPTION
Use Jupiter `onlyDirectRoutes` param to ensure we fit a swap into a single transaction. Removes our own wrapping/unwrapping SOL scheme to rely on Jupiters, which unfortunately closes the entire wSOL account unwrapping any pre-existing wSOL balance. This is unavoidable if we want a single transaction.

Jupiter is working on minimising transaction sizes using https://docs.solana.com/proposals/transactions-v2 so in the future we can bring back multi step routes.

Closes https://github.com/coral-xyz/backpack/issues/626
Closes https://github.com/coral-xyz/backpack/issues/625
Closes https://github.com/coral-xyz/backpack/issues/624