### PR TITLE
add auth worker for creating users in the backend

### DIFF
--- a/backend/reef/hasura/migrations/default/1663966553134_create_table_auth_users/up.sql
+++ b/backend/reef/hasura/migrations/default/1663966553134_create_table_auth_users/up.sql
@@ -1,4 +1,4 @@
-CREATE TABLE "auth"."users" ("id" uuid NOT NULL DEFAULT gen_random_uuid(), "username" citext NOT NULL, "created_at" timestamptz NOT NULL DEFAULT now(), "updated_at" timestamptz NOT NULL DEFAULT now(), "last_active_at" timestamptz NOT NULL DEFAULT now(), "invitation_id" uuid NOT NULL, PRIMARY KEY ("id") , FOREIGN KEY ("invitation_id") REFERENCES "auth"."invitations"("id") ON UPDATE cascade ON DELETE cascade, UNIQUE ("username"), UNIQUE ("invitation_id"), CONSTRAINT "username_format" CHECK (username ~ '^[a-z_]{4,15}$'));
+CREATE TABLE "auth"."users" ("id" uuid NOT NULL DEFAULT gen_random_uuid(), "username" citext NOT NULL, "created_at" timestamptz NOT NULL DEFAULT now(), "updated_at" timestamptz NOT NULL DEFAULT now(), "last_active_at" timestamptz NOT NULL DEFAULT now(), "invitation_id" uuid NOT NULL, PRIMARY KEY ("id") , FOREIGN KEY ("invitation_id") REFERENCES "auth"."invitations"("id") ON UPDATE cascade ON DELETE cascade, UNIQUE ("username"), UNIQUE ("invitation_id"), CONSTRAINT "username_format" CHECK (username ~ '^[a-z0-9_]{4,15}$'));
 CREATE OR REPLACE FUNCTION "auth"."set_current_timestamp_updated_at"()
 RETURNS TRIGGER AS $$
 DECLARE

--- a/backend/workers/auth/package.json
+++ b/backend/workers/auth/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "auth",
+  "version": "0.0.0",
+  "devDependencies": {
+    "@cloudflare/workers-types": "^3.16.0",
+    "typescript": "^4.8.3",
+    "wrangler": "^2.1.6"
+  },
+  "private": true,
+  "scripts": {
+    "dev": "wrangler dev --local",
+    "deploy": "wrangler publish",
+    "zeus": "npx zeus http://localhost:8112/v1/graphql ./src --header=x-hasura-admin-secret:myadminsecretkey"
+  },
+  "dependencies": {
+    "@solana/web3.js": "^1.63.1",
+    "hono": "^2.2.1",
+    "zod": "^3.19.1"
+  }
+}

--- a/backend/workers/auth/src/index.ts
+++ b/backend/workers/auth/src/index.ts
@@ -1,0 +1,72 @@
+/**
+ *  Auth worker
+ *
+ *  POST /users - Creates a new user if all of the required data is valid
+ *    { username:string; publicKey:PublicKeyString; inviteCode: uuid; waitlistId?: string; }
+ */
+
+import { Hono } from "hono";
+import { z, ZodError } from "zod";
+import { PublicKey } from "@solana/web3.js";
+import { Chain } from "./zeus";
+
+const CreateUser = z.object({
+  username: z
+    .string()
+    .regex(
+      /^[a-z0-9_]{4,15}$/,
+      "must be 4-15 characters, lowercase, and can only contain only letters, numbers and underscores"
+    ),
+  inviteCode: z
+    .string()
+    .regex(
+      /^[0-9a-f]{8}-[0-9a-f]{4}-[0-5][0-9a-f]{3}-[089ab][0-9a-f]{3}-[0-9a-f]{12}$/i,
+      "invalid format"
+    ),
+  publicKey: z.string().refine((str) => {
+    try {
+      new PublicKey(str);
+      return true;
+    } catch (err) {}
+    return false;
+  }, "must be a valid Solana public key"),
+  waitlistId: z.optional(z.string()),
+});
+
+// ----- routing -----
+
+const app = new Hono();
+
+app.use("*", async (c, next) => {
+  try {
+    await next();
+  } catch (err) {
+    return c.json(err, err instanceof ZodError ? 400 : 500);
+  }
+});
+
+app.post("/users", async (c) => {
+  const variables = CreateUser.parse(await c.req.json());
+
+  const chain = Chain(c.env.HASURA_URL, {
+    headers: { "x-hasura-admin-secret": c.env.HASURA_SECRET },
+  });
+
+  const res = await chain("mutation")({
+    insert_auth_users_one: [
+      {
+        object: {
+          username: variables.username,
+          invitation_id: variables.inviteCode,
+        },
+      },
+      {
+        id: true,
+      },
+    ],
+  });
+
+  return c.json(res);
+});
+
+export default app;

--- a/backend/workers/auth/src/zeus/const.ts
+++ b/backend/workers/auth/src/zeus/const.ts
@@ -1,0 +1,443 @@
+/* eslint-disable */
+
+export const AllTypesProps: Record<string, any> = {
+  String_comparison_exp: {},
+  auth_invitations: {
+    data: {},
+  },
+  auth_invitations_aggregate_fields: {
+    count: {
+      columns: "auth_invitations_select_column",
+    },
+  },
+  auth_invitations_append_input: {
+    data: "jsonb",
+  },
+  auth_invitations_bool_exp: {
+    _and: "auth_invitations_bool_exp",
+    _not: "auth_invitations_bool_exp",
+    _or: "auth_invitations_bool_exp",
+    created_at: "timestamptz_comparison_exp",
+    data: "jsonb_comparison_exp",
+    id: "uuid_comparison_exp",
+  },
+  auth_invitations_constraint: "enum" as const,
+  auth_invitations_delete_at_path_input: {},
+  auth_invitations_delete_elem_input: {},
+  auth_invitations_delete_key_input: {},
+  auth_invitations_insert_input: {
+    created_at: "timestamptz",
+    data: "jsonb",
+    id: "uuid",
+  },
+  auth_invitations_on_conflict: {
+    constraint: "auth_invitations_constraint",
+    update_columns: "auth_invitations_update_column",
+    where: "auth_invitations_bool_exp",
+  },
+  auth_invitations_order_by: {
+    created_at: "order_by",
+    data: "order_by",
+    id: "order_by",
+  },
+  auth_invitations_pk_columns_input: {
+    id: "uuid",
+  },
+  auth_invitations_prepend_input: {
+    data: "jsonb",
+  },
+  auth_invitations_select_column: "enum" as const,
+  auth_invitations_set_input: {
+    created_at: "timestamptz",
+    data: "jsonb",
+    id: "uuid",
+  },
+  auth_invitations_stream_cursor_input: {
+    initial_value: "auth_invitations_stream_cursor_value_input",
+    ordering: "cursor_ordering",
+  },
+  auth_invitations_stream_cursor_value_input: {
+    created_at: "timestamptz",
+    data: "jsonb",
+    id: "uuid",
+  },
+  auth_invitations_update_column: "enum" as const,
+  auth_invitations_updates: {
+    _append: "auth_invitations_append_input",
+    _delete_at_path: "auth_invitations_delete_at_path_input",
+    _delete_elem: "auth_invitations_delete_elem_input",
+    _delete_key: "auth_invitations_delete_key_input",
+    _prepend: "auth_invitations_prepend_input",
+    _set: "auth_invitations_set_input",
+    where: "auth_invitations_bool_exp",
+  },
+  auth_users_aggregate_fields: {
+    count: {
+      columns: "auth_users_select_column",
+    },
+  },
+  auth_users_bool_exp: {
+    _and: "auth_users_bool_exp",
+    _not: "auth_users_bool_exp",
+    _or: "auth_users_bool_exp",
+    created_at: "timestamptz_comparison_exp",
+    id: "uuid_comparison_exp",
+    invitation_id: "uuid_comparison_exp",
+    last_active_at: "timestamptz_comparison_exp",
+    updated_at: "timestamptz_comparison_exp",
+    username: "citext_comparison_exp",
+  },
+  auth_users_constraint: "enum" as const,
+  auth_users_insert_input: {
+    created_at: "timestamptz",
+    id: "uuid",
+    invitation_id: "uuid",
+    last_active_at: "timestamptz",
+    updated_at: "timestamptz",
+    username: "citext",
+  },
+  auth_users_on_conflict: {
+    constraint: "auth_users_constraint",
+    update_columns: "auth_users_update_column",
+    where: "auth_users_bool_exp",
+  },
+  auth_users_order_by: {
+    created_at: "order_by",
+    id: "order_by",
+    invitation_id: "order_by",
+    last_active_at: "order_by",
+    updated_at: "order_by",
+    username: "order_by",
+  },
+  auth_users_pk_columns_input: {
+    id: "uuid",
+  },
+  auth_users_select_column: "enum" as const,
+  auth_users_set_input: {
+    created_at: "timestamptz",
+    id: "uuid",
+    invitation_id: "uuid",
+    last_active_at: "timestamptz",
+    updated_at: "timestamptz",
+    username: "citext",
+  },
+  auth_users_stream_cursor_input: {
+    initial_value: "auth_users_stream_cursor_value_input",
+    ordering: "cursor_ordering",
+  },
+  auth_users_stream_cursor_value_input: {
+    created_at: "timestamptz",
+    id: "uuid",
+    invitation_id: "uuid",
+    last_active_at: "timestamptz",
+    updated_at: "timestamptz",
+    username: "citext",
+  },
+  auth_users_update_column: "enum" as const,
+  auth_users_updates: {
+    _set: "auth_users_set_input",
+    where: "auth_users_bool_exp",
+  },
+  citext: `scalar.citext` as const,
+  citext_comparison_exp: {
+    _eq: "citext",
+    _gt: "citext",
+    _gte: "citext",
+    _ilike: "citext",
+    _in: "citext",
+    _iregex: "citext",
+    _like: "citext",
+    _lt: "citext",
+    _lte: "citext",
+    _neq: "citext",
+    _nilike: "citext",
+    _nin: "citext",
+    _niregex: "citext",
+    _nlike: "citext",
+    _nregex: "citext",
+    _nsimilar: "citext",
+    _regex: "citext",
+    _similar: "citext",
+  },
+  cursor_ordering: "enum" as const,
+  jsonb: `scalar.jsonb` as const,
+  jsonb_cast_exp: {
+    String: "String_comparison_exp",
+  },
+  jsonb_comparison_exp: {
+    _cast: "jsonb_cast_exp",
+    _contained_in: "jsonb",
+    _contains: "jsonb",
+    _eq: "jsonb",
+    _gt: "jsonb",
+    _gte: "jsonb",
+    _in: "jsonb",
+    _lt: "jsonb",
+    _lte: "jsonb",
+    _neq: "jsonb",
+    _nin: "jsonb",
+  },
+  mutation_root: {
+    delete_auth_invitations: {
+      where: "auth_invitations_bool_exp",
+    },
+    delete_auth_invitations_by_pk: {
+      id: "uuid",
+    },
+    delete_auth_users: {
+      where: "auth_users_bool_exp",
+    },
+    delete_auth_users_by_pk: {
+      id: "uuid",
+    },
+    insert_auth_invitations: {
+      objects: "auth_invitations_insert_input",
+      on_conflict: "auth_invitations_on_conflict",
+    },
+    insert_auth_invitations_one: {
+      object: "auth_invitations_insert_input",
+      on_conflict: "auth_invitations_on_conflict",
+    },
+    insert_auth_users: {
+      objects: "auth_users_insert_input",
+      on_conflict: "auth_users_on_conflict",
+    },
+    insert_auth_users_one: {
+      object: "auth_users_insert_input",
+      on_conflict: "auth_users_on_conflict",
+    },
+    update_auth_invitations: {
+      _append: "auth_invitations_append_input",
+      _delete_at_path: "auth_invitations_delete_at_path_input",
+      _delete_elem: "auth_invitations_delete_elem_input",
+      _delete_key: "auth_invitations_delete_key_input",
+      _prepend: "auth_invitations_prepend_input",
+      _set: "auth_invitations_set_input",
+      where: "auth_invitations_bool_exp",
+    },
+    update_auth_invitations_by_pk: {
+      _append: "auth_invitations_append_input",
+      _delete_at_path: "auth_invitations_delete_at_path_input",
+      _delete_elem: "auth_invitations_delete_elem_input",
+      _delete_key: "auth_invitations_delete_key_input",
+      _prepend: "auth_invitations_prepend_input",
+      _set: "auth_invitations_set_input",
+      pk_columns: "auth_invitations_pk_columns_input",
+    },
+    update_auth_invitations_many: {
+      updates: "auth_invitations_updates",
+    },
+    update_auth_users: {
+      _set: "auth_users_set_input",
+      where: "auth_users_bool_exp",
+    },
+    update_auth_users_by_pk: {
+      _set: "auth_users_set_input",
+      pk_columns: "auth_users_pk_columns_input",
+    },
+    update_auth_users_many: {
+      updates: "auth_users_updates",
+    },
+  },
+  order_by: "enum" as const,
+  query_root: {
+    auth_invitations: {
+      distinct_on: "auth_invitations_select_column",
+      order_by: "auth_invitations_order_by",
+      where: "auth_invitations_bool_exp",
+    },
+    auth_invitations_aggregate: {
+      distinct_on: "auth_invitations_select_column",
+      order_by: "auth_invitations_order_by",
+      where: "auth_invitations_bool_exp",
+    },
+    auth_invitations_by_pk: {
+      id: "uuid",
+    },
+    auth_users: {
+      distinct_on: "auth_users_select_column",
+      order_by: "auth_users_order_by",
+      where: "auth_users_bool_exp",
+    },
+    auth_users_aggregate: {
+      distinct_on: "auth_users_select_column",
+      order_by: "auth_users_order_by",
+      where: "auth_users_bool_exp",
+    },
+    auth_users_by_pk: {
+      id: "uuid",
+    },
+  },
+  subscription_root: {
+    auth_invitations: {
+      distinct_on: "auth_invitations_select_column",
+      order_by: "auth_invitations_order_by",
+      where: "auth_invitations_bool_exp",
+    },
+    auth_invitations_aggregate: {
+      distinct_on: "auth_invitations_select_column",
+      order_by: "auth_invitations_order_by",
+      where: "auth_invitations_bool_exp",
+    },
+    auth_invitations_by_pk: {
+      id: "uuid",
+    },
+    auth_invitations_stream: {
+      cursor: "auth_invitations_stream_cursor_input",
+      where: "auth_invitations_bool_exp",
+    },
+    auth_users: {
+      distinct_on: "auth_users_select_column",
+      order_by: "auth_users_order_by",
+      where: "auth_users_bool_exp",
+    },
+    auth_users_aggregate: {
+      distinct_on: "auth_users_select_column",
+      order_by: "auth_users_order_by",
+      where: "auth_users_bool_exp",
+    },
+    auth_users_by_pk: {
+      id: "uuid",
+    },
+    auth_users_stream: {
+      cursor: "auth_users_stream_cursor_input",
+      where: "auth_users_bool_exp",
+    },
+  },
+  timestamptz: `scalar.timestamptz` as const,
+  timestamptz_comparison_exp: {
+    _eq: "timestamptz",
+    _gt: "timestamptz",
+    _gte: "timestamptz",
+    _in: "timestamptz",
+    _lt: "timestamptz",
+    _lte: "timestamptz",
+    _neq: "timestamptz",
+    _nin: "timestamptz",
+  },
+  uuid: `scalar.uuid` as const,
+  uuid_comparison_exp: {
+    _eq: "uuid",
+    _gt: "uuid",
+    _gte: "uuid",
+    _in: "uuid",
+    _lt: "uuid",
+    _lte: "uuid",
+    _neq: "uuid",
+    _nin: "uuid",
+  },
+};
+
+export const ReturnTypes: Record<string, any> = {
+  cached: {
+    ttl: "Int",
+    refresh: "Boolean",
+  },
+  auth_invitations: {
+    created_at: "timestamptz",
+    data: "jsonb",
+    id: "uuid",
+  },
+  auth_invitations_aggregate: {
+    aggregate: "auth_invitations_aggregate_fields",
+    nodes: "auth_invitations",
+  },
+  auth_invitations_aggregate_fields: {
+    count: "Int",
+    max: "auth_invitations_max_fields",
+    min: "auth_invitations_min_fields",
+  },
+  auth_invitations_max_fields: {
+    created_at: "timestamptz",
+    id: "uuid",
+  },
+  auth_invitations_min_fields: {
+    created_at: "timestamptz",
+    id: "uuid",
+  },
+  auth_invitations_mutation_response: {
+    affected_rows: "Int",
+    returning: "auth_invitations",
+  },
+  auth_users: {
+    created_at: "timestamptz",
+    id: "uuid",
+    invitation_id: "uuid",
+    last_active_at: "timestamptz",
+    updated_at: "timestamptz",
+    username: "citext",
+  },
+  auth_users_aggregate: {
+    aggregate: "auth_users_aggregate_fields",
+    nodes: "auth_users",
+  },
+  auth_users_aggregate_fields: {
+    count: "Int",
+    max: "auth_users_max_fields",
+    min: "auth_users_min_fields",
+  },
+  auth_users_max_fields: {
+    created_at: "timestamptz",
+    id: "uuid",
+    invitation_id: "uuid",
+    last_active_at: "timestamptz",
+    updated_at: "timestamptz",
+    username: "citext",
+  },
+  auth_users_min_fields: {
+    created_at: "timestamptz",
+    id: "uuid",
+    invitation_id: "uuid",
+    last_active_at: "timestamptz",
+    updated_at: "timestamptz",
+    username: "citext",
+  },
+  auth_users_mutation_response: {
+    affected_rows: "Int",
+    returning: "auth_users",
+  },
+  citext: `scalar.citext` as const,
+  jsonb: `scalar.jsonb` as const,
+  mutation_root: {
+    delete_auth_invitations: "auth_invitations_mutation_response",
+    delete_auth_invitations_by_pk: "auth_invitations",
+    delete_auth_users: "auth_users_mutation_response",
+    delete_auth_users_by_pk: "auth_users",
+    insert_auth_invitations: "auth_invitations_mutation_response",
+    insert_auth_invitations_one: "auth_invitations",
+    insert_auth_users: "auth_users_mutation_response",
+    insert_auth_users_one: "auth_users",
+    update_auth_invitations: "auth_invitations_mutation_response",
+    update_auth_invitations_by_pk: "auth_invitations",
+    update_auth_invitations_many: "auth_invitations_mutation_response",
+    update_auth_users: "auth_users_mutation_response",
+    update_auth_users_by_pk: "auth_users",
+    update_auth_users_many: "auth_users_mutation_response",
+  },
+  query_root: {
+    auth_invitations: "auth_invitations",
+    auth_invitations_aggregate: "auth_invitations_aggregate",
+    auth_invitations_by_pk: "auth_invitations",
+    auth_users: "auth_users",
+    auth_users_aggregate: "auth_users_aggregate",
+    auth_users_by_pk: "auth_users",
+  },
+  subscription_root: {
+    auth_invitations: "auth_invitations",
+    auth_invitations_aggregate: "auth_invitations_aggregate",
+    auth_invitations_by_pk: "auth_invitations",
+    auth_invitations_stream: "auth_invitations",
+    auth_users: "auth_users",
+    auth_users_aggregate: "auth_users_aggregate",
+    auth_users_by_pk: "auth_users",
+    auth_users_stream: "auth_users",
+  },
+  timestamptz: `scalar.timestamptz` as const,
+  uuid: `scalar.uuid` as const,
+};
+
+export const Ops = {
+  mutation: "mutation_root" as const,
+  query: "query_root" as const,
+  subscription: "subscription_root" as const,
+};

--- a/backend/workers/auth/src/zeus/index.ts
+++ b/backend/workers/auth/src/zeus/index.ts
@@ -1,0 +1,4081 @@
+/* eslint-disable */
+
+import { AllTypesProps, ReturnTypes, Ops } from "./const";
+export const HOST = "http://localhost:8112/v1/graphql";
+
+export const HEADERS = {};
+export const apiSubscription = (options: chainOptions) => (query: string) => {
+  try {
+    const queryString = options[0] + "?query=" + encodeURIComponent(query);
+    const wsString = queryString.replace("http", "ws");
+    const host = (options.length > 1 && options[1]?.websocket?.[0]) || wsString;
+    const webSocketOptions = options[1]?.websocket || [host];
+    const ws = new WebSocket(...webSocketOptions);
+    return {
+      ws,
+      on: (e: (args: any) => void) => {
+        ws.onmessage = (event: any) => {
+          if (event.data) {
+            const parsed = JSON.parse(event.data);
+            const data = parsed.data;
+            return e(data);
+          }
+        };
+      },
+      off: (e: (args: any) => void) => {
+        ws.onclose = e;
+      },
+      error: (e: (args: any) => void) => {
+        ws.onerror = e;
+      },
+      open: (e: () => void) => {
+        ws.onopen = e;
+      },
+    };
+  } catch {
+    throw new Error("No websockets implemented");
+  }
+};
+const handleFetchResponse = (response: Response): Promise<GraphQLResponse> => {
+  if (!response.ok) {
+    return new Promise((_, reject) => {
+      response
+        .text()
+        .then((text) => {
+          try {
+            reject(JSON.parse(text));
+          } catch (err) {
+            reject(text);
+          }
+        })
+        .catch(reject);
+    });
+  }
+  return response.json();
+};
+
+export const apiFetch =
+  (options: fetchOptions) =>
+  (query: string, variables: Record<string, unknown> = {}) => {
+    const fetchOptions = options[1] || {};
+    if (fetchOptions.method && fetchOptions.method === "GET") {
+      return fetch(
+        `${options[0]}?query=${encodeURIComponent(query)}`,
+        fetchOptions
+      )
+        .then(handleFetchResponse)
+        .then((response: GraphQLResponse) => {
+          if (response.errors) {
+            throw new GraphQLError(response);
+          }
+          return response.data;
+        });
+    }
+    return fetch(`${options[0]}`, {
+      body: JSON.stringify({ query, variables }),
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      ...fetchOptions,
+    })
+      .then(handleFetchResponse)
+      .then((response: GraphQLResponse) => {
+        if (response.errors) {
+          throw new GraphQLError(response);
+        }
+        return response.data;
+      });
+  };
+
+export const InternalsBuildQuery = ({
+  ops,
+  props,
+  returns,
+  options,
+  scalars,
+}: {
+  props: AllTypesPropsType;
+  returns: ReturnTypesType;
+  ops: Operations;
+  options?: OperationOptions;
+  scalars?: ScalarDefinition;
+}) => {
+  const ibb = (
+    k: string,
+    o: InputValueType | VType,
+    p = "",
+    root = true,
+    vars: Array<{ name: string; graphQLType: string }> = []
+  ): string => {
+    const keyForPath = purifyGraphQLKey(k);
+    const newPath = [p, keyForPath].join(SEPARATOR);
+    if (!o) {
+      return "";
+    }
+    if (typeof o === "boolean" || typeof o === "number") {
+      return k;
+    }
+    if (typeof o === "string") {
+      return `${k} ${o}`;
+    }
+    if (Array.isArray(o)) {
+      const args = InternalArgsBuilt({
+        props,
+        returns,
+        ops,
+        scalars,
+        vars,
+      })(o[0], newPath);
+      return `${ibb(args ? `${k}(${args})` : k, o[1], p, false, vars)}`;
+    }
+    if (k === "__alias") {
+      return Object.entries(o)
+        .map(([alias, objectUnderAlias]) => {
+          if (
+            typeof objectUnderAlias !== "object" ||
+            Array.isArray(objectUnderAlias)
+          ) {
+            throw new Error(
+              "Invalid alias it should be __alias:{ YOUR_ALIAS_NAME: { OPERATION_NAME: { ...selectors }}}"
+            );
+          }
+          const operationName = Object.keys(objectUnderAlias)[0];
+          const operation = objectUnderAlias[operationName];
+          return ibb(`${alias}:${operationName}`, operation, p, false, vars);
+        })
+        .join("\n");
+    }
+    const hasOperationName =
+      root && options?.operationName ? " " + options.operationName : "";
+    const keyForDirectives = o.__directives ?? "";
+    const query = `{${Object.entries(o)
+      .filter(([k]) => k !== "__directives")
+      .map((e) =>
+        ibb(...e, [p, `field<>${keyForPath}`].join(SEPARATOR), false, vars)
+      )
+      .join("\n")}}`;
+    if (!root) {
+      return `${k} ${keyForDirectives}${hasOperationName} ${query}`;
+    }
+    const varsString = vars
+      .map((v) => `${v.name}: ${v.graphQLType}`)
+      .join(", ");
+    return `${k} ${keyForDirectives}${hasOperationName}${
+      varsString ? `(${varsString})` : ""
+    } ${query}`;
+  };
+  return ibb;
+};
+
+export const Thunder =
+  (fn: FetchFunction) =>
+  <
+    O extends keyof typeof Ops,
+    SCLR extends ScalarDefinition,
+    R extends keyof ValueTypes = GenericOperation<O>
+  >(
+    operation: O,
+    graphqlOptions?: ThunderGraphQLOptions<SCLR>
+  ) =>
+  <Z extends ValueTypes[R]>(
+    o: Z | ValueTypes[R],
+    ops?: OperationOptions & { variables?: Record<string, unknown> }
+  ) =>
+    fn(
+      Zeus(operation, o, {
+        operationOptions: ops,
+        scalars: graphqlOptions?.scalars,
+      }),
+      ops?.variables
+    ).then((data) => {
+      if (graphqlOptions?.scalars) {
+        return decodeScalarsInResponse({
+          response: data,
+          initialOp: operation,
+          initialZeusQuery: o as VType,
+          returns: ReturnTypes,
+          scalars: graphqlOptions.scalars,
+          ops: Ops,
+        });
+      }
+      return data;
+    }) as Promise<InputType<GraphQLTypes[R], Z, SCLR>>;
+
+export const Chain = (...options: chainOptions) => Thunder(apiFetch(options));
+
+export const SubscriptionThunder =
+  (fn: SubscriptionFunction) =>
+  <
+    O extends keyof typeof Ops,
+    SCLR extends ScalarDefinition,
+    R extends keyof ValueTypes = GenericOperation<O>
+  >(
+    operation: O,
+    graphqlOptions?: ThunderGraphQLOptions<SCLR>
+  ) =>
+  <Z extends ValueTypes[R]>(
+    o: Z | ValueTypes[R],
+    ops?: OperationOptions & { variables?: ExtractVariables<Z> }
+  ) => {
+    const returnedFunction = fn(
+      Zeus(operation, o, {
+        operationOptions: ops,
+        scalars: graphqlOptions?.scalars,
+      })
+    ) as SubscriptionToGraphQL<Z, GraphQLTypes[R], SCLR>;
+    if (returnedFunction?.on && graphqlOptions?.scalars) {
+      const wrapped = returnedFunction.on;
+      returnedFunction.on = (
+        fnToCall: (args: InputType<GraphQLTypes[R], Z, SCLR>) => void
+      ) =>
+        wrapped((data: InputType<GraphQLTypes[R], Z, SCLR>) => {
+          if (graphqlOptions?.scalars) {
+            return fnToCall(
+              decodeScalarsInResponse({
+                response: data,
+                initialOp: operation,
+                initialZeusQuery: o as VType,
+                returns: ReturnTypes,
+                scalars: graphqlOptions.scalars,
+                ops: Ops,
+              })
+            );
+          }
+          return fnToCall(data);
+        });
+    }
+    return returnedFunction;
+  };
+
+export const Subscription = (...options: chainOptions) =>
+  SubscriptionThunder(apiSubscription(options));
+export const Zeus = <
+  Z extends ValueTypes[R],
+  O extends keyof typeof Ops,
+  R extends keyof ValueTypes = GenericOperation<O>
+>(
+  operation: O,
+  o: Z | ValueTypes[R],
+  ops?: {
+    operationOptions?: OperationOptions;
+    scalars?: ScalarDefinition;
+  }
+) =>
+  InternalsBuildQuery({
+    props: AllTypesProps,
+    returns: ReturnTypes,
+    ops: Ops,
+    options: ops?.operationOptions,
+    scalars: ops?.scalars,
+  })(operation, o as VType);
+
+export const ZeusSelect = <T>() => ((t: unknown) => t) as SelectionFunction<T>;
+
+export const Selector = <T extends keyof ValueTypes>(key: T) =>
+  key && ZeusSelect<ValueTypes[T]>();
+
+export const TypeFromSelector = <T extends keyof ValueTypes>(key: T) =>
+  key && ZeusSelect<ValueTypes[T]>();
+export const Gql = Chain(HOST, {
+  headers: {
+    "Content-Type": "application/json",
+    ...HEADERS,
+  },
+});
+
+export const ZeusScalars = ZeusSelect<ScalarCoders>();
+
+export const decodeScalarsInResponse = <O extends Operations>({
+  response,
+  scalars,
+  returns,
+  ops,
+  initialZeusQuery,
+  initialOp,
+}: {
+  ops: O;
+  response: any;
+  returns: ReturnTypesType;
+  scalars?: Record<string, ScalarResolver | undefined>;
+  initialOp: keyof O;
+  initialZeusQuery: InputValueType | VType;
+}) => {
+  if (!scalars) {
+    return response;
+  }
+  const builder = PrepareScalarPaths({
+    ops,
+    returns,
+  });
+
+  const scalarPaths = builder(
+    initialOp as string,
+    ops[initialOp],
+    initialZeusQuery
+  );
+  if (scalarPaths) {
+    const r = traverseResponse({ scalarPaths, resolvers: scalars })(
+      initialOp as string,
+      response,
+      [ops[initialOp]]
+    );
+    return r;
+  }
+  return response;
+};
+
+export const traverseResponse = ({
+  resolvers,
+  scalarPaths,
+}: {
+  scalarPaths: { [x: string]: `scalar.${string}` };
+  resolvers: {
+    [x: string]: ScalarResolver | undefined;
+  };
+}) => {
+  const ibb = (
+    k: string,
+    o: InputValueType | VType,
+    p: string[] = []
+  ): unknown => {
+    if (Array.isArray(o)) {
+      return o.map((eachO) => ibb(k, eachO, p));
+    }
+    if (o == null) {
+      return o;
+    }
+    const scalarPathString = p.join(SEPARATOR);
+    const currentScalarString = scalarPaths[scalarPathString];
+    if (currentScalarString) {
+      const currentDecoder =
+        resolvers[currentScalarString.split(".")[1]]?.decode;
+      if (currentDecoder) {
+        return currentDecoder(o);
+      }
+    }
+    if (
+      typeof o === "boolean" ||
+      typeof o === "number" ||
+      typeof o === "string" ||
+      !o
+    ) {
+      return o;
+    }
+    return Object.fromEntries(
+      Object.entries(o).map(([k, v]) => [
+        k,
+        ibb(k, v, [...p, purifyGraphQLKey(k)]),
+      ])
+    );
+  };
+  return ibb;
+};
+
+export type AllTypesPropsType = {
+  [x: string]:
+    | undefined
+    | `scalar.${string}`
+    | "enum"
+    | {
+        [x: string]:
+          | undefined
+          | string
+          | {
+              [x: string]: string | undefined;
+            };
+      };
+};
+
+export type ReturnTypesType = {
+  [x: string]:
+    | {
+        [x: string]: string | undefined;
+      }
+    | `scalar.${string}`
+    | undefined;
+};
+export type InputValueType = {
+  [x: string]:
+    | undefined
+    | boolean
+    | string
+    | number
+    | [any, undefined | boolean | InputValueType]
+    | InputValueType;
+};
+export type VType =
+  | undefined
+  | boolean
+  | string
+  | number
+  | [any, undefined | boolean | InputValueType]
+  | InputValueType;
+
+export type PlainType = boolean | number | string | null | undefined;
+export type ZeusArgsType =
+  | PlainType
+  | {
+      [x: string]: ZeusArgsType;
+    }
+  | Array<ZeusArgsType>;
+
+export type Operations = Record<string, string>;
+
+export type VariableDefinition = {
+  [x: string]: unknown;
+};
+
+export const SEPARATOR = "|";
+
+export type fetchOptions = Parameters<typeof fetch>;
+type websocketOptions = typeof WebSocket extends new (
+  ...args: infer R
+) => WebSocket
+  ? R
+  : never;
+export type chainOptions =
+  | [fetchOptions[0], fetchOptions[1] & { websocket?: websocketOptions }]
+  | [fetchOptions[0]];
+export type FetchFunction = (
+  query: string,
+  variables?: Record<string, unknown>
+) => Promise<any>;
+export type SubscriptionFunction = (query: string) => any;
+type NotUndefined<T> = T extends undefined ? never : T;
+export type ResolverType<F> = NotUndefined<
+  F extends [infer ARGS, any] ? ARGS : undefined
+>;
+
+export type OperationOptions = {
+  operationName?: string;
+};
+
+export type ScalarCoder = Record<string, (s: unknown) => string>;
+
+export interface GraphQLResponse {
+  data?: Record<string, any>;
+  errors?: Array<{
+    message: string;
+  }>;
+}
+export class GraphQLError extends Error {
+  constructor(public response: GraphQLResponse) {
+    super("");
+    console.error(response);
+  }
+  toString() {
+    return "GraphQL Response Error";
+  }
+}
+export type GenericOperation<O> = O extends keyof typeof Ops
+  ? typeof Ops[O]
+  : never;
+export type ThunderGraphQLOptions<SCLR extends ScalarDefinition> = {
+  scalars?: SCLR | ScalarCoders;
+};
+
+const ExtractScalar = (
+  mappedParts: string[],
+  returns: ReturnTypesType
+): `scalar.${string}` | undefined => {
+  if (mappedParts.length === 0) {
+    return;
+  }
+  const oKey = mappedParts[0];
+  const returnP1 = returns[oKey];
+  if (typeof returnP1 === "object") {
+    const returnP2 = returnP1[mappedParts[1]];
+    if (returnP2) {
+      return ExtractScalar([returnP2, ...mappedParts.slice(2)], returns);
+    }
+    return undefined;
+  }
+  return returnP1 as `scalar.${string}` | undefined;
+};
+
+export const PrepareScalarPaths = ({
+  ops,
+  returns,
+}: {
+  returns: ReturnTypesType;
+  ops: Operations;
+}) => {
+  const ibb = (
+    k: string,
+    originalKey: string,
+    o: InputValueType | VType,
+    p: string[] = [],
+    pOriginals: string[] = [],
+    root = true
+  ): { [x: string]: `scalar.${string}` } | undefined => {
+    if (!o) {
+      return;
+    }
+    if (
+      typeof o === "boolean" ||
+      typeof o === "number" ||
+      typeof o === "string"
+    ) {
+      const extractionArray = [...pOriginals, originalKey];
+      const isScalar = ExtractScalar(extractionArray, returns);
+      if (isScalar?.startsWith("scalar")) {
+        const partOfTree = {
+          [[...p, k].join(SEPARATOR)]: isScalar,
+        };
+        return partOfTree;
+      }
+      return {};
+    }
+    if (Array.isArray(o)) {
+      return ibb(k, k, o[1], p, pOriginals, false);
+    }
+    if (k === "__alias") {
+      return Object.entries(o)
+        .map(([alias, objectUnderAlias]) => {
+          if (
+            typeof objectUnderAlias !== "object" ||
+            Array.isArray(objectUnderAlias)
+          ) {
+            throw new Error(
+              "Invalid alias it should be __alias:{ YOUR_ALIAS_NAME: { OPERATION_NAME: { ...selectors }}}"
+            );
+          }
+          const operationName = Object.keys(objectUnderAlias)[0];
+          const operation = objectUnderAlias[operationName];
+          return ibb(alias, operationName, operation, p, pOriginals, false);
+        })
+        .reduce((a, b) => ({
+          ...a,
+          ...b,
+        }));
+    }
+    const keyName = root ? ops[k] : k;
+    return Object.entries(o)
+      .filter(([k]) => k !== "__directives")
+      .map(([k, v]) => {
+        // Inline fragments shouldn't be added to the path as they aren't a field
+        const isInlineFragment = originalKey.match(/^...\s*on/) != null;
+        return ibb(
+          k,
+          k,
+          v,
+          isInlineFragment ? p : [...p, purifyGraphQLKey(keyName || k)],
+          isInlineFragment
+            ? pOriginals
+            : [...pOriginals, purifyGraphQLKey(originalKey)],
+          false
+        );
+      })
+      .reduce((a, b) => ({
+        ...a,
+        ...b,
+      }));
+  };
+  return ibb;
+};
+
+export const purifyGraphQLKey = (k: string) =>
+  k.replace(/\([^)]*\)/g, "").replace(/^[^:]*\:/g, "");
+
+const mapPart = (p: string) => {
+  const [isArg, isField] = p.split("<>");
+  if (isField) {
+    return {
+      v: isField,
+      __type: "field",
+    } as const;
+  }
+  return {
+    v: isArg,
+    __type: "arg",
+  } as const;
+};
+
+type Part = ReturnType<typeof mapPart>;
+
+export const ResolveFromPath = (
+  props: AllTypesPropsType,
+  returns: ReturnTypesType,
+  ops: Operations
+) => {
+  const ResolvePropsType = (mappedParts: Part[]) => {
+    const oKey = ops[mappedParts[0].v];
+    const propsP1 = oKey ? props[oKey] : props[mappedParts[0].v];
+    if (propsP1 === "enum" && mappedParts.length === 1) {
+      return "enum";
+    }
+    if (
+      typeof propsP1 === "string" &&
+      propsP1.startsWith("scalar.") &&
+      mappedParts.length === 1
+    ) {
+      return propsP1;
+    }
+    if (typeof propsP1 === "object") {
+      if (mappedParts.length < 2) {
+        return "not";
+      }
+      const propsP2 = propsP1[mappedParts[1].v];
+      if (typeof propsP2 === "string") {
+        return rpp(
+          `${propsP2}${SEPARATOR}${mappedParts
+            .slice(2)
+            .map((mp) => mp.v)
+            .join(SEPARATOR)}`
+        );
+      }
+      if (typeof propsP2 === "object") {
+        if (mappedParts.length < 3) {
+          return "not";
+        }
+        const propsP3 = propsP2[mappedParts[2].v];
+        if (propsP3 && mappedParts[2].__type === "arg") {
+          return rpp(
+            `${propsP3}${SEPARATOR}${mappedParts
+              .slice(3)
+              .map((mp) => mp.v)
+              .join(SEPARATOR)}`
+          );
+        }
+      }
+    }
+  };
+  const ResolveReturnType = (mappedParts: Part[]) => {
+    if (mappedParts.length === 0) {
+      return "not";
+    }
+    const oKey = ops[mappedParts[0].v];
+    const returnP1 = oKey ? returns[oKey] : returns[mappedParts[0].v];
+    if (typeof returnP1 === "object") {
+      if (mappedParts.length < 2) return "not";
+      const returnP2 = returnP1[mappedParts[1].v];
+      if (returnP2) {
+        return rpp(
+          `${returnP2}${SEPARATOR}${mappedParts
+            .slice(2)
+            .map((mp) => mp.v)
+            .join(SEPARATOR)}`
+        );
+      }
+    }
+  };
+  const rpp = (path: string): "enum" | "not" | `scalar.${string}` => {
+    const parts = path.split(SEPARATOR).filter((l) => l.length > 0);
+    const mappedParts = parts.map(mapPart);
+    const propsP1 = ResolvePropsType(mappedParts);
+    if (propsP1) {
+      return propsP1;
+    }
+    const returnP1 = ResolveReturnType(mappedParts);
+    if (returnP1) {
+      return returnP1;
+    }
+    return "not";
+  };
+  return rpp;
+};
+
+export const InternalArgsBuilt = ({
+  props,
+  ops,
+  returns,
+  scalars,
+  vars,
+}: {
+  props: AllTypesPropsType;
+  returns: ReturnTypesType;
+  ops: Operations;
+  scalars?: ScalarDefinition;
+  vars: Array<{ name: string; graphQLType: string }>;
+}) => {
+  const arb = (a: ZeusArgsType, p = "", root = true): string => {
+    if (typeof a === "string") {
+      if (a.startsWith(START_VAR_NAME)) {
+        const [varName, graphQLType] = a
+          .replace(START_VAR_NAME, "$")
+          .split(GRAPHQL_TYPE_SEPARATOR);
+        const v = vars.find((v) => v.name === varName);
+        if (!v) {
+          vars.push({
+            name: varName,
+            graphQLType,
+          });
+        } else {
+          if (v.graphQLType !== graphQLType) {
+            throw new Error(
+              `Invalid variable exists with two different GraphQL Types, "${v.graphQLType}" and ${graphQLType}`
+            );
+          }
+        }
+        return varName;
+      }
+    }
+    const checkType = ResolveFromPath(props, returns, ops)(p);
+    if (checkType.startsWith("scalar.")) {
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars
+      const [_, ...splittedScalar] = checkType.split(".");
+      const scalarKey = splittedScalar.join(".");
+      return (scalars?.[scalarKey]?.encode?.(a) as string) || JSON.stringify(a);
+    }
+    if (Array.isArray(a)) {
+      return `[${a.map((arr) => arb(arr, p, false)).join(", ")}]`;
+    }
+    if (typeof a === "string") {
+      if (checkType === "enum") {
+        return a;
+      }
+      return `${JSON.stringify(a)}`;
+    }
+    if (typeof a === "object") {
+      if (a === null) {
+        return `null`;
+      }
+      const returnedObjectString = Object.entries(a)
+        .filter(([, v]) => typeof v !== "undefined")
+        .map(([k, v]) => `${k}: ${arb(v, [p, k].join(SEPARATOR), false)}`)
+        .join(",\n");
+      if (!root) {
+        return `{${returnedObjectString}}`;
+      }
+      return returnedObjectString;
+    }
+    return `${a}`;
+  };
+  return arb;
+};
+
+export const resolverFor = <
+  X,
+  T extends keyof ResolverInputTypes,
+  Z extends keyof ResolverInputTypes[T]
+>(
+  type: T,
+  field: Z,
+  fn: (
+    args: Required<ResolverInputTypes[T]>[Z] extends [infer Input, any]
+      ? Input
+      : any,
+    source: any
+  ) => Z extends keyof ModelTypes[T]
+    ? ModelTypes[T][Z] | Promise<ModelTypes[T][Z]> | X
+    : any
+) => fn as (args?: any, source?: any) => any;
+
+export type UnwrapPromise<T> = T extends Promise<infer R> ? R : T;
+export type ZeusState<T extends (...args: any[]) => Promise<any>> = NonNullable<
+  UnwrapPromise<ReturnType<T>>
+>;
+export type ZeusHook<
+  T extends (
+    ...args: any[]
+  ) => Record<string, (...args: any[]) => Promise<any>>,
+  N extends keyof ReturnType<T>
+> = ZeusState<ReturnType<T>[N]>;
+
+export type WithTypeNameValue<T> = T & {
+  __typename?: boolean;
+  __directives?: string;
+};
+export type AliasType<T> = WithTypeNameValue<T> & {
+  __alias?: Record<string, WithTypeNameValue<T>>;
+};
+type DeepAnify<T> = {
+  [P in keyof T]?: any;
+};
+type IsPayLoad<T> = T extends [any, infer PayLoad] ? PayLoad : T;
+export type ScalarDefinition = Record<string, ScalarResolver>;
+
+type IsScalar<S, SCLR extends ScalarDefinition> = S extends "scalar" & {
+  name: infer T;
+}
+  ? T extends keyof SCLR
+    ? SCLR[T]["decode"] extends (s: unknown) => unknown
+      ? ReturnType<SCLR[T]["decode"]>
+      : unknown
+    : unknown
+  : S;
+type IsArray<T, U, SCLR extends ScalarDefinition> = T extends Array<infer R>
+  ? InputType<R, U, SCLR>[]
+  : InputType<T, U, SCLR>;
+type FlattenArray<T> = T extends Array<infer R> ? R : T;
+type BaseZeusResolver = boolean | 1 | string | Variable<any, string>;
+
+type IsInterfaced<
+  SRC extends DeepAnify<DST>,
+  DST,
+  SCLR extends ScalarDefinition
+> = FlattenArray<SRC> extends ZEUS_INTERFACES | ZEUS_UNIONS
+  ? {
+      [P in keyof SRC]: SRC[P] extends "__union" & infer R
+        ? P extends keyof DST
+          ? IsArray<
+              R,
+              "__typename" extends keyof DST
+                ? DST[P] & { __typename: true }
+                : DST[P],
+              SCLR
+            >
+          : Record<string, unknown>
+        : never;
+    }[keyof DST] & {
+      [P in keyof Omit<
+        Pick<
+          SRC,
+          {
+            [P in keyof DST]: SRC[P] extends "__union" & infer R ? never : P;
+          }[keyof DST]
+        >,
+        "__typename"
+      >]: IsPayLoad<DST[P]> extends BaseZeusResolver
+        ? IsScalar<SRC[P], SCLR>
+        : IsArray<SRC[P], DST[P], SCLR>;
+    }
+  : {
+      [P in keyof Pick<SRC, keyof DST>]: IsPayLoad<
+        DST[P]
+      > extends BaseZeusResolver
+        ? IsScalar<SRC[P], SCLR>
+        : IsArray<SRC[P], DST[P], SCLR>;
+    };
+
+export type MapType<
+  SRC,
+  DST,
+  SCLR extends ScalarDefinition
+> = SRC extends DeepAnify<DST> ? IsInterfaced<SRC, DST, SCLR> : never;
+// eslint-disable-next-line @typescript-eslint/ban-types
+export type InputType<
+  SRC,
+  DST,
+  SCLR extends ScalarDefinition = {}
+> = IsPayLoad<DST> extends { __alias: infer R }
+  ? {
+      [P in keyof R]: MapType<SRC, R[P], SCLR>[keyof MapType<SRC, R[P], SCLR>];
+    } & MapType<SRC, Omit<IsPayLoad<DST>, "__alias">, SCLR>
+  : MapType<SRC, IsPayLoad<DST>, SCLR>;
+export type SubscriptionToGraphQL<Z, T, SCLR extends ScalarDefinition> = {
+  ws: WebSocket;
+  on: (fn: (args: InputType<T, Z, SCLR>) => void) => void;
+  off: (
+    fn: (e: {
+      data?: InputType<T, Z, SCLR>;
+      code?: number;
+      reason?: string;
+      message?: string;
+    }) => void
+  ) => void;
+  error: (
+    fn: (e: { data?: InputType<T, Z, SCLR>; errors?: string[] }) => void
+  ) => void;
+  open: () => void;
+};
+
+// eslint-disable-next-line @typescript-eslint/ban-types
+export type FromSelector<
+  SELECTOR,
+  NAME extends keyof GraphQLTypes,
+  SCLR extends ScalarDefinition = {}
+> = InputType<GraphQLTypes[NAME], SELECTOR, SCLR>;
+
+export type ScalarResolver = {
+  encode?: (s: unknown) => string;
+  decode?: (s: unknown) => unknown;
+};
+
+export type SelectionFunction<V> = <T>(t: T | V) => T;
+
+type BuiltInVariableTypes = {
+  ["String"]: string;
+  ["Int"]: number;
+  ["Float"]: number;
+  ["ID"]: unknown;
+  ["Boolean"]: boolean;
+};
+type AllVariableTypes = keyof BuiltInVariableTypes | keyof ZEUS_VARIABLES;
+type VariableRequired<T extends string> =
+  | `${T}!`
+  | T
+  | `[${T}]`
+  | `[${T}]!`
+  | `[${T}!]`
+  | `[${T}!]!`;
+type VR<T extends string> = VariableRequired<VariableRequired<T>>;
+
+export type GraphQLVariableType = VR<AllVariableTypes>;
+
+type ExtractVariableTypeString<T extends string> = T extends VR<infer R1>
+  ? R1 extends VR<infer R2>
+    ? R2 extends VR<infer R3>
+      ? R3 extends VR<infer R4>
+        ? R4 extends VR<infer R5>
+          ? R5
+          : R4
+        : R3
+      : R2
+    : R1
+  : T;
+
+type DecomposeType<T, Type> = T extends `[${infer R}]`
+  ? Array<DecomposeType<R, Type>> | undefined
+  : T extends `${infer R}!`
+  ? NonNullable<DecomposeType<R, Type>>
+  : Type | undefined;
+
+type ExtractTypeFromGraphQLType<T extends string> =
+  T extends keyof ZEUS_VARIABLES
+    ? ZEUS_VARIABLES[T]
+    : T extends keyof BuiltInVariableTypes
+    ? BuiltInVariableTypes[T]
+    : any;
+
+export type GetVariableType<T extends string> = DecomposeType<
+  T,
+  ExtractTypeFromGraphQLType<ExtractVariableTypeString<T>>
+>;
+
+type UndefinedKeys<T> = {
+  [K in keyof T]-?: T[K] extends NonNullable<T[K]> ? never : K;
+}[keyof T];
+
+type WithNullableKeys<T> = Pick<T, UndefinedKeys<T>>;
+type WithNonNullableKeys<T> = Omit<T, UndefinedKeys<T>>;
+
+type OptionalKeys<T> = {
+  [P in keyof T]?: T[P];
+};
+
+export type WithOptionalNullables<T> = OptionalKeys<WithNullableKeys<T>> &
+  WithNonNullableKeys<T>;
+
+export type Variable<T extends GraphQLVariableType, Name extends string> = {
+  " __zeus_name": Name;
+  " __zeus_type": T;
+};
+
+export type ExtractVariables<Query> = Query extends Variable<
+  infer VType,
+  infer VName
+>
+  ? { [key in VName]: GetVariableType<VType> }
+  : Query extends [infer Inputs, infer Outputs]
+  ? ExtractVariables<Inputs> & ExtractVariables<Outputs>
+  : Query extends string | number | boolean
+  ? // eslint-disable-next-line @typescript-eslint/ban-types
+    {}
+  : UnionToIntersection<
+      {
+        [K in keyof Query]: WithOptionalNullables<ExtractVariables<Query[K]>>;
+      }[keyof Query]
+    >;
+
+type UnionToIntersection<U> = (U extends any ? (k: U) => void : never) extends (
+  k: infer I
+) => void
+  ? I
+  : never;
+
+export const START_VAR_NAME = `$ZEUS_VAR`;
+export const GRAPHQL_TYPE_SEPARATOR = `__$GRAPHQL__`;
+
+export const $ = <Type extends GraphQLVariableType, Name extends string>(
+  name: Name,
+  graphqlType: Type
+) => {
+  return (START_VAR_NAME +
+    name +
+    GRAPHQL_TYPE_SEPARATOR +
+    graphqlType) as unknown as Variable<Type, Name>;
+};
+type ZEUS_INTERFACES = never;
+export type ScalarCoders = {
+  citext?: ScalarResolver;
+  jsonb?: ScalarResolver;
+  timestamptz?: ScalarResolver;
+  uuid?: ScalarResolver;
+};
+type ZEUS_UNIONS = never;
+
+export type ValueTypes = {
+  /** Boolean expression to compare columns of type "String". All fields are combined with logical 'AND'. */
+  ["String_comparison_exp"]: {
+    _eq?: string | undefined | null | Variable<any, string>;
+    _gt?: string | undefined | null | Variable<any, string>;
+    _gte?: string | undefined | null | Variable<any, string>;
+    /** does the column match the given case-insensitive pattern */
+    _ilike?: string | undefined | null | Variable<any, string>;
+    _in?: Array<string> | undefined | null | Variable<any, string>;
+    /** does the column match the given POSIX regular expression, case insensitive */
+    _iregex?: string | undefined | null | Variable<any, string>;
+    _is_null?: boolean | undefined | null | Variable<any, string>;
+    /** does the column match the given pattern */
+    _like?: string | undefined | null | Variable<any, string>;
+    _lt?: string | undefined | null | Variable<any, string>;
+    _lte?: string | undefined | null | Variable<any, string>;
+    _neq?: string | undefined | null | Variable<any, string>;
+    /** does the column NOT match the given case-insensitive pattern */
+    _nilike?: string | undefined | null | Variable<any, string>;
+    _nin?: Array<string> | undefined | null | Variable<any, string>;
+    /** does the column NOT match the given POSIX regular expression, case insensitive */
+    _niregex?: string | undefined | null | Variable<any, string>;
+    /** does the column NOT match the given pattern */
+    _nlike?: string | undefined | null | Variable<any, string>;
+    /** does the column NOT match the given POSIX regular expression, case sensitive */
+    _nregex?: string | undefined | null | Variable<any, string>;
+    /** does the column NOT match the given SQL regular expression */
+    _nsimilar?: string | undefined | null | Variable<any, string>;
+    /** does the column match the given POSIX regular expression, case sensitive */
+    _regex?: string | undefined | null | Variable<any, string>;
+    /** does the column match the given SQL regular expression */
+    _similar?: string | undefined | null | Variable<any, string>;
+  };
+  /** ids are beta invite codes */
+  ["auth_invitations"]: AliasType<{
+    created_at?: boolean | `@${string}`;
+    data?: [
+      {
+        /** JSON select path */
+        path?: string | undefined | null | Variable<any, string>;
+      },
+      boolean | `@${string}`
+    ];
+    id?: boolean | `@${string}`;
+    __typename?: boolean | `@${string}`;
+  }>;
+  /** aggregated selection of "auth.invitations" */
+  ["auth_invitations_aggregate"]: AliasType<{
+    aggregate?: ValueTypes["auth_invitations_aggregate_fields"];
+    nodes?: ValueTypes["auth_invitations"];
+    __typename?: boolean | `@${string}`;
+  }>;
+  /** aggregate fields of "auth.invitations" */
+  ["auth_invitations_aggregate_fields"]: AliasType<{
+    count?: [
+      {
+        columns?:
+          | Array<ValueTypes["auth_invitations_select_column"]>
+          | undefined
+          | null
+          | Variable<any, string>;
+        distinct?: boolean | undefined | null | Variable<any, string>;
+      },
+      boolean | `@${string}`
+    ];
+    max?: ValueTypes["auth_invitations_max_fields"];
+    min?: ValueTypes["auth_invitations_min_fields"];
+    __typename?: boolean | `@${string}`;
+  }>;
+  /** append existing jsonb value of filtered columns with new jsonb value */
+  ["auth_invitations_append_input"]: {
+    data?: ValueTypes["jsonb"] | undefined | null | Variable<any, string>;
+  };
+  /** Boolean expression to filter rows from the table "auth.invitations". All fields are combined with a logical 'AND'. */
+  ["auth_invitations_bool_exp"]: {
+    _and?:
+      | Array<ValueTypes["auth_invitations_bool_exp"]>
+      | undefined
+      | null
+      | Variable<any, string>;
+    _not?:
+      | ValueTypes["auth_invitations_bool_exp"]
+      | undefined
+      | null
+      | Variable<any, string>;
+    _or?:
+      | Array<ValueTypes["auth_invitations_bool_exp"]>
+      | undefined
+      | null
+      | Variable<any, string>;
+    created_at?:
+      | ValueTypes["timestamptz_comparison_exp"]
+      | undefined
+      | null
+      | Variable<any, string>;
+    data?:
+      | ValueTypes["jsonb_comparison_exp"]
+      | undefined
+      | null
+      | Variable<any, string>;
+    id?:
+      | ValueTypes["uuid_comparison_exp"]
+      | undefined
+      | null
+      | Variable<any, string>;
+  };
+  /** unique or primary key constraints on table "auth.invitations" */
+  ["auth_invitations_constraint"]: auth_invitations_constraint;
+  /** delete the field or element with specified path (for JSON arrays, negative integers count from the end) */
+  ["auth_invitations_delete_at_path_input"]: {
+    data?: Array<string> | undefined | null | Variable<any, string>;
+  };
+  /** delete the array element with specified index (negative integers count from the end). throws an error if top level container is not an array */
+  ["auth_invitations_delete_elem_input"]: {
+    data?: number | undefined | null | Variable<any, string>;
+  };
+  /** delete key/value pair or string element. key/value pairs are matched based on their key value */
+  ["auth_invitations_delete_key_input"]: {
+    data?: string | undefined | null | Variable<any, string>;
+  };
+  /** input type for inserting data into table "auth.invitations" */
+  ["auth_invitations_insert_input"]: {
+    created_at?:
+      | ValueTypes["timestamptz"]
+      | undefined
+      | null
+      | Variable<any, string>;
+    data?: ValueTypes["jsonb"] | undefined | null | Variable<any, string>;
+    id?: ValueTypes["uuid"] | undefined | null | Variable<any, string>;
+  };
+  /** aggregate max on columns */
+  ["auth_invitations_max_fields"]: AliasType<{
+    created_at?: boolean | `@${string}`;
+    id?: boolean | `@${string}`;
+    __typename?: boolean | `@${string}`;
+  }>;
+  /** aggregate min on columns */
+  ["auth_invitations_min_fields"]: AliasType<{
+    created_at?: boolean | `@${string}`;
+    id?: boolean | `@${string}`;
+    __typename?: boolean | `@${string}`;
+  }>;
+  /** response of any mutation on the table "auth.invitations" */
+  ["auth_invitations_mutation_response"]: AliasType<{
+    /** number of rows affected by the mutation */
+    affected_rows?: boolean | `@${string}`;
+    /** data from the rows affected by the mutation */
+    returning?: ValueTypes["auth_invitations"];
+    __typename?: boolean | `@${string}`;
+  }>;
+  /** on_conflict condition type for table "auth.invitations" */
+  ["auth_invitations_on_conflict"]: {
+    constraint:
+      | ValueTypes["auth_invitations_constraint"]
+      | Variable<any, string>;
+    update_columns:
+      | Array<ValueTypes["auth_invitations_update_column"]>
+      | Variable<any, string>;
+    where?:
+      | ValueTypes["auth_invitations_bool_exp"]
+      | undefined
+      | null
+      | Variable<any, string>;
+  };
+  /** Ordering options when selecting data from "auth.invitations". */
+  ["auth_invitations_order_by"]: {
+    created_at?:
+      | ValueTypes["order_by"]
+      | undefined
+      | null
+      | Variable<any, string>;
+    data?: ValueTypes["order_by"] | undefined | null | Variable<any, string>;
+    id?: ValueTypes["order_by"] | undefined | null | Variable<any, string>;
+  };
+  /** primary key columns input for table: auth_invitations */
+  ["auth_invitations_pk_columns_input"]: {
+    id: ValueTypes["uuid"] | Variable<any, string>;
+  };
+  /** prepend existing jsonb value of filtered columns with new jsonb value */
+  ["auth_invitations_prepend_input"]: {
+    data?: ValueTypes["jsonb"] | undefined | null | Variable<any, string>;
+  };
+  /** select columns of table "auth.invitations" */
+  ["auth_invitations_select_column"]: auth_invitations_select_column;
+  /** input type for updating data in table "auth.invitations" */
+  ["auth_invitations_set_input"]: {
+    created_at?:
+      | ValueTypes["timestamptz"]
+      | undefined
+      | null
+      | Variable<any, string>;
+    data?: ValueTypes["jsonb"] | undefined | null | Variable<any, string>;
+    id?: ValueTypes["uuid"] | undefined | null | Variable<any, string>;
+  };
+  /** Streaming cursor of the table "auth_invitations" */
+  ["auth_invitations_stream_cursor_input"]: {
+    /** Stream column input with initial value */
+    initial_value:
+      | ValueTypes["auth_invitations_stream_cursor_value_input"]
+      | Variable<any, string>;
+    /** cursor ordering */
+    ordering?:
+      | ValueTypes["cursor_ordering"]
+      | undefined
+      | null
+      | Variable<any, string>;
+  };
+  /** Initial value of the column from where the streaming should start */
+  ["auth_invitations_stream_cursor_value_input"]: {
+    created_at?:
+      | ValueTypes["timestamptz"]
+      | undefined
+      | null
+      | Variable<any, string>;
+    data?: ValueTypes["jsonb"] | undefined | null | Variable<any, string>;
+    id?: ValueTypes["uuid"] | undefined | null | Variable<any, string>;
+  };
+  /** update columns of table "auth.invitations" */
+  ["auth_invitations_update_column"]: auth_invitations_update_column;
+  ["auth_invitations_updates"]: {
+    /** append existing jsonb value of filtered columns with new jsonb value */
+    _append?:
+      | ValueTypes["auth_invitations_append_input"]
+      | undefined
+      | null
+      | Variable<any, string>;
+    /** delete the field or element with specified path (for JSON arrays, negative integers count from the end) */
+    _delete_at_path?:
+      | ValueTypes["auth_invitations_delete_at_path_input"]
+      | undefined
+      | null
+      | Variable<any, string>;
+    /** delete the array element with specified index (negative integers count from the end). throws an error if top level container is not an array */
+    _delete_elem?:
+      | ValueTypes["auth_invitations_delete_elem_input"]
+      | undefined
+      | null
+      | Variable<any, string>;
+    /** delete key/value pair or string element. key/value pairs are matched based on their key value */
+    _delete_key?:
+      | ValueTypes["auth_invitations_delete_key_input"]
+      | undefined
+      | null
+      | Variable<any, string>;
+    /** prepend existing jsonb value of filtered columns with new jsonb value */
+    _prepend?:
+      | ValueTypes["auth_invitations_prepend_input"]
+      | undefined
+      | null
+      | Variable<any, string>;
+    /** sets the columns of the filtered rows to the given values */
+    _set?:
+      | ValueTypes["auth_invitations_set_input"]
+      | undefined
+      | null
+      | Variable<any, string>;
+    where: ValueTypes["auth_invitations_bool_exp"] | Variable<any, string>;
+  };
+  /** columns and relationships of "auth.users" */
+  ["auth_users"]: AliasType<{
+    created_at?: boolean | `@${string}`;
+    id?: boolean | `@${string}`;
+    invitation_id?: boolean | `@${string}`;
+    last_active_at?: boolean | `@${string}`;
+    updated_at?: boolean | `@${string}`;
+    username?: boolean | `@${string}`;
+    __typename?: boolean | `@${string}`;
+  }>;
+  /** aggregated selection of "auth.users" */
+  ["auth_users_aggregate"]: AliasType<{
+    aggregate?: ValueTypes["auth_users_aggregate_fields"];
+    nodes?: ValueTypes["auth_users"];
+    __typename?: boolean | `@${string}`;
+  }>;
+  /** aggregate fields of "auth.users" */
+  ["auth_users_aggregate_fields"]: AliasType<{
+    count?: [
+      {
+        columns?:
+          | Array<ValueTypes["auth_users_select_column"]>
+          | undefined
+          | null
+          | Variable<any, string>;
+        distinct?: boolean | undefined | null | Variable<any, string>;
+      },
+      boolean | `@${string}`
+    ];
+    max?: ValueTypes["auth_users_max_fields"];
+    min?: ValueTypes["auth_users_min_fields"];
+    __typename?: boolean | `@${string}`;
+  }>;
+  /** Boolean expression to filter rows from the table "auth.users". All fields are combined with a logical 'AND'. */
+  ["auth_users_bool_exp"]: {
+    _and?:
+      | Array<ValueTypes["auth_users_bool_exp"]>
+      | undefined
+      | null
+      | Variable<any, string>;
+    _not?:
+      | ValueTypes["auth_users_bool_exp"]
+      | undefined
+      | null
+      | Variable<any, string>;
+    _or?:
+      | Array<ValueTypes["auth_users_bool_exp"]>
+      | undefined
+      | null
+      | Variable<any, string>;
+    created_at?:
+      | ValueTypes["timestamptz_comparison_exp"]
+      | undefined
+      | null
+      | Variable<any, string>;
+    id?:
+      | ValueTypes["uuid_comparison_exp"]
+      | undefined
+      | null
+      | Variable<any, string>;
+    invitation_id?:
+      | ValueTypes["uuid_comparison_exp"]
+      | undefined
+      | null
+      | Variable<any, string>;
+    last_active_at?:
+      | ValueTypes["timestamptz_comparison_exp"]
+      | undefined
+      | null
+      | Variable<any, string>;
+    updated_at?:
+      | ValueTypes["timestamptz_comparison_exp"]
+      | undefined
+      | null
+      | Variable<any, string>;
+    username?:
+      | ValueTypes["citext_comparison_exp"]
+      | undefined
+      | null
+      | Variable<any, string>;
+  };
+  /** unique or primary key constraints on table "auth.users" */
+  ["auth_users_constraint"]: auth_users_constraint;
+  /** input type for inserting data into table "auth.users" */
+  ["auth_users_insert_input"]: {
+    created_at?:
+      | ValueTypes["timestamptz"]
+      | undefined
+      | null
+      | Variable<any, string>;
+    id?: ValueTypes["uuid"] | undefined | null | Variable<any, string>;
+    invitation_id?:
+      | ValueTypes["uuid"]
+      | undefined
+      | null
+      | Variable<any, string>;
+    last_active_at?:
+      | ValueTypes["timestamptz"]
+      | undefined
+      | null
+      | Variable<any, string>;
+    updated_at?:
+      | ValueTypes["timestamptz"]
+      | undefined
+      | null
+      | Variable<any, string>;
+    username?: ValueTypes["citext"] | undefined | null | Variable<any, string>;
+  };
+  /** aggregate max on columns */
+  ["auth_users_max_fields"]: AliasType<{
+    created_at?: boolean | `@${string}`;
+    id?: boolean | `@${string}`;
+    invitation_id?: boolean | `@${string}`;
+    last_active_at?: boolean | `@${string}`;
+    updated_at?: boolean | `@${string}`;
+    username?: boolean | `@${string}`;
+    __typename?: boolean | `@${string}`;
+  }>;
+  /** aggregate min on columns */
+  ["auth_users_min_fields"]: AliasType<{
+    created_at?: boolean | `@${string}`;
+    id?: boolean | `@${string}`;
+    invitation_id?: boolean | `@${string}`;
+    last_active_at?: boolean | `@${string}`;
+    updated_at?: boolean | `@${string}`;
+    username?: boolean | `@${string}`;
+    __typename?: boolean | `@${string}`;
+  }>;
+  /** response of any mutation on the table "auth.users" */
+  ["auth_users_mutation_response"]: AliasType<{
+    /** number of rows affected by the mutation */
+    affected_rows?: boolean | `@${string}`;
+    /** data from the rows affected by the mutation */
+    returning?: ValueTypes["auth_users"];
+    __typename?: boolean | `@${string}`;
+  }>;
+  /** on_conflict condition type for table "auth.users" */
+  ["auth_users_on_conflict"]: {
+    constraint: ValueTypes["auth_users_constraint"] | Variable<any, string>;
+    update_columns:
+      | Array<ValueTypes["auth_users_update_column"]>
+      | Variable<any, string>;
+    where?:
+      | ValueTypes["auth_users_bool_exp"]
+      | undefined
+      | null
+      | Variable<any, string>;
+  };
+  /** Ordering options when selecting data from "auth.users". */
+  ["auth_users_order_by"]: {
+    created_at?:
+      | ValueTypes["order_by"]
+      | undefined
+      | null
+      | Variable<any, string>;
+    id?: ValueTypes["order_by"] | undefined | null | Variable<any, string>;
+    invitation_id?:
+      | ValueTypes["order_by"]
+      | undefined
+      | null
+      | Variable<any, string>;
+    last_active_at?:
+      | ValueTypes["order_by"]
+      | undefined
+      | null
+      | Variable<any, string>;
+    updated_at?:
+      | ValueTypes["order_by"]
+      | undefined
+      | null
+      | Variable<any, string>;
+    username?:
+      | ValueTypes["order_by"]
+      | undefined
+      | null
+      | Variable<any, string>;
+  };
+  /** primary key columns input for table: auth_users */
+  ["auth_users_pk_columns_input"]: {
+    id: ValueTypes["uuid"] | Variable<any, string>;
+  };
+  /** select columns of table "auth.users" */
+  ["auth_users_select_column"]: auth_users_select_column;
+  /** input type for updating data in table "auth.users" */
+  ["auth_users_set_input"]: {
+    created_at?:
+      | ValueTypes["timestamptz"]
+      | undefined
+      | null
+      | Variable<any, string>;
+    id?: ValueTypes["uuid"] | undefined | null | Variable<any, string>;
+    invitation_id?:
+      | ValueTypes["uuid"]
+      | undefined
+      | null
+      | Variable<any, string>;
+    last_active_at?:
+      | ValueTypes["timestamptz"]
+      | undefined
+      | null
+      | Variable<any, string>;
+    updated_at?:
+      | ValueTypes["timestamptz"]
+      | undefined
+      | null
+      | Variable<any, string>;
+    username?: ValueTypes["citext"] | undefined | null | Variable<any, string>;
+  };
+  /** Streaming cursor of the table "auth_users" */
+  ["auth_users_stream_cursor_input"]: {
+    /** Stream column input with initial value */
+    initial_value:
+      | ValueTypes["auth_users_stream_cursor_value_input"]
+      | Variable<any, string>;
+    /** cursor ordering */
+    ordering?:
+      | ValueTypes["cursor_ordering"]
+      | undefined
+      | null
+      | Variable<any, string>;
+  };
+  /** Initial value of the column from where the streaming should start */
+  ["auth_users_stream_cursor_value_input"]: {
+    created_at?:
+      | ValueTypes["timestamptz"]
+      | undefined
+      | null
+      | Variable<any, string>;
+    id?: ValueTypes["uuid"] | undefined | null | Variable<any, string>;
+    invitation_id?:
+      | ValueTypes["uuid"]
+      | undefined
+      | null
+      | Variable<any, string>;
+    last_active_at?:
+      | ValueTypes["timestamptz"]
+      | undefined
+      | null
+      | Variable<any, string>;
+    updated_at?:
+      | ValueTypes["timestamptz"]
+      | undefined
+      | null
+      | Variable<any, string>;
+    username?: ValueTypes["citext"] | undefined | null | Variable<any, string>;
+  };
+  /** update columns of table "auth.users" */
+  ["auth_users_update_column"]: auth_users_update_column;
+  ["auth_users_updates"]: {
+    /** sets the columns of the filtered rows to the given values */
+    _set?:
+      | ValueTypes["auth_users_set_input"]
+      | undefined
+      | null
+      | Variable<any, string>;
+    where: ValueTypes["auth_users_bool_exp"] | Variable<any, string>;
+  };
+  ["citext"]: unknown;
+  /** Boolean expression to compare columns of type "citext". All fields are combined with logical 'AND'. */
+  ["citext_comparison_exp"]: {
+    _eq?: ValueTypes["citext"] | undefined | null | Variable<any, string>;
+    _gt?: ValueTypes["citext"] | undefined | null | Variable<any, string>;
+    _gte?: ValueTypes["citext"] | undefined | null | Variable<any, string>;
+    /** does the column match the given case-insensitive pattern */
+    _ilike?: ValueTypes["citext"] | undefined | null | Variable<any, string>;
+    _in?:
+      | Array<ValueTypes["citext"]>
+      | undefined
+      | null
+      | Variable<any, string>;
+    /** does the column match the given POSIX regular expression, case insensitive */
+    _iregex?: ValueTypes["citext"] | undefined | null | Variable<any, string>;
+    _is_null?: boolean | undefined | null | Variable<any, string>;
+    /** does the column match the given pattern */
+    _like?: ValueTypes["citext"] | undefined | null | Variable<any, string>;
+    _lt?: ValueTypes["citext"] | undefined | null | Variable<any, string>;
+    _lte?: ValueTypes["citext"] | undefined | null | Variable<any, string>;
+    _neq?: ValueTypes["citext"] | undefined | null | Variable<any, string>;
+    /** does the column NOT match the given case-insensitive pattern */
+    _nilike?: ValueTypes["citext"] | undefined | null | Variable<any, string>;
+    _nin?:
+      | Array<ValueTypes["citext"]>
+      | undefined
+      | null
+      | Variable<any, string>;
+    /** does the column NOT match the given POSIX regular expression, case insensitive */
+    _niregex?: ValueTypes["citext"] | undefined | null | Variable<any, string>;
+    /** does the column NOT match the given pattern */
+    _nlike?: ValueTypes["citext"] | undefined | null | Variable<any, string>;
+    /** does the column NOT match the given POSIX regular expression, case sensitive */
+    _nregex?: ValueTypes["citext"] | undefined | null | Variable<any, string>;
+    /** does the column NOT match the given SQL regular expression */
+    _nsimilar?: ValueTypes["citext"] | undefined | null | Variable<any, string>;
+    /** does the column match the given POSIX regular expression, case sensitive */
+    _regex?: ValueTypes["citext"] | undefined | null | Variable<any, string>;
+    /** does the column match the given SQL regular expression */
+    _similar?: ValueTypes["citext"] | undefined | null | Variable<any, string>;
+  };
+  /** ordering argument of a cursor */
+  ["cursor_ordering"]: cursor_ordering;
+  ["jsonb"]: unknown;
+  ["jsonb_cast_exp"]: {
+    String?:
+      | ValueTypes["String_comparison_exp"]
+      | undefined
+      | null
+      | Variable<any, string>;
+  };
+  /** Boolean expression to compare columns of type "jsonb". All fields are combined with logical 'AND'. */
+  ["jsonb_comparison_exp"]: {
+    _cast?:
+      | ValueTypes["jsonb_cast_exp"]
+      | undefined
+      | null
+      | Variable<any, string>;
+    /** is the column contained in the given json value */
+    _contained_in?:
+      | ValueTypes["jsonb"]
+      | undefined
+      | null
+      | Variable<any, string>;
+    /** does the column contain the given json value at the top level */
+    _contains?: ValueTypes["jsonb"] | undefined | null | Variable<any, string>;
+    _eq?: ValueTypes["jsonb"] | undefined | null | Variable<any, string>;
+    _gt?: ValueTypes["jsonb"] | undefined | null | Variable<any, string>;
+    _gte?: ValueTypes["jsonb"] | undefined | null | Variable<any, string>;
+    /** does the string exist as a top-level key in the column */
+    _has_key?: string | undefined | null | Variable<any, string>;
+    /** do all of these strings exist as top-level keys in the column */
+    _has_keys_all?: Array<string> | undefined | null | Variable<any, string>;
+    /** do any of these strings exist as top-level keys in the column */
+    _has_keys_any?: Array<string> | undefined | null | Variable<any, string>;
+    _in?: Array<ValueTypes["jsonb"]> | undefined | null | Variable<any, string>;
+    _is_null?: boolean | undefined | null | Variable<any, string>;
+    _lt?: ValueTypes["jsonb"] | undefined | null | Variable<any, string>;
+    _lte?: ValueTypes["jsonb"] | undefined | null | Variable<any, string>;
+    _neq?: ValueTypes["jsonb"] | undefined | null | Variable<any, string>;
+    _nin?:
+      | Array<ValueTypes["jsonb"]>
+      | undefined
+      | null
+      | Variable<any, string>;
+  };
+  /** mutation root */
+  ["mutation_root"]: AliasType<{
+    delete_auth_invitations?: [
+      {
+        /** filter the rows which have to be deleted */
+        where: ValueTypes["auth_invitations_bool_exp"] | Variable<any, string>;
+      },
+      ValueTypes["auth_invitations_mutation_response"]
+    ];
+    delete_auth_invitations_by_pk?: [
+      { id: ValueTypes["uuid"] | Variable<any, string> },
+      ValueTypes["auth_invitations"]
+    ];
+    delete_auth_users?: [
+      {
+        /** filter the rows which have to be deleted */
+        where: ValueTypes["auth_users_bool_exp"] | Variable<any, string>;
+      },
+      ValueTypes["auth_users_mutation_response"]
+    ];
+    delete_auth_users_by_pk?: [
+      { id: ValueTypes["uuid"] | Variable<any, string> },
+      ValueTypes["auth_users"]
+    ];
+    insert_auth_invitations?: [
+      {
+        /** the rows to be inserted */
+        objects:
+          | Array<ValueTypes["auth_invitations_insert_input"]>
+          | Variable<any, string> /** upsert condition */;
+        on_conflict?:
+          | ValueTypes["auth_invitations_on_conflict"]
+          | undefined
+          | null
+          | Variable<any, string>;
+      },
+      ValueTypes["auth_invitations_mutation_response"]
+    ];
+    insert_auth_invitations_one?: [
+      {
+        /** the row to be inserted */
+        object:
+          | ValueTypes["auth_invitations_insert_input"]
+          | Variable<any, string> /** upsert condition */;
+        on_conflict?:
+          | ValueTypes["auth_invitations_on_conflict"]
+          | undefined
+          | null
+          | Variable<any, string>;
+      },
+      ValueTypes["auth_invitations"]
+    ];
+    insert_auth_users?: [
+      {
+        /** the rows to be inserted */
+        objects:
+          | Array<ValueTypes["auth_users_insert_input"]>
+          | Variable<any, string> /** upsert condition */;
+        on_conflict?:
+          | ValueTypes["auth_users_on_conflict"]
+          | undefined
+          | null
+          | Variable<any, string>;
+      },
+      ValueTypes["auth_users_mutation_response"]
+    ];
+    insert_auth_users_one?: [
+      {
+        /** the row to be inserted */
+        object:
+          | ValueTypes["auth_users_insert_input"]
+          | Variable<any, string> /** upsert condition */;
+        on_conflict?:
+          | ValueTypes["auth_users_on_conflict"]
+          | undefined
+          | null
+          | Variable<any, string>;
+      },
+      ValueTypes["auth_users"]
+    ];
+    update_auth_invitations?: [
+      {
+        /** append existing jsonb value of filtered columns with new jsonb value */
+        _append?:
+          | ValueTypes["auth_invitations_append_input"]
+          | undefined
+          | null
+          | Variable<
+              any,
+              string
+            > /** delete the field or element with specified path (for JSON arrays, negative integers count from the end) */;
+        _delete_at_path?:
+          | ValueTypes["auth_invitations_delete_at_path_input"]
+          | undefined
+          | null
+          | Variable<
+              any,
+              string
+            > /** delete the array element with specified index (negative integers count from the end). throws an error if top level container is not an array */;
+        _delete_elem?:
+          | ValueTypes["auth_invitations_delete_elem_input"]
+          | undefined
+          | null
+          | Variable<
+              any,
+              string
+            > /** delete key/value pair or string element. key/value pairs are matched based on their key value */;
+        _delete_key?:
+          | ValueTypes["auth_invitations_delete_key_input"]
+          | undefined
+          | null
+          | Variable<
+              any,
+              string
+            > /** prepend existing jsonb value of filtered columns with new jsonb value */;
+        _prepend?:
+          | ValueTypes["auth_invitations_prepend_input"]
+          | undefined
+          | null
+          | Variable<
+              any,
+              string
+            > /** sets the columns of the filtered rows to the given values */;
+        _set?:
+          | ValueTypes["auth_invitations_set_input"]
+          | undefined
+          | null
+          | Variable<
+              any,
+              string
+            > /** filter the rows which have to be updated */;
+        where: ValueTypes["auth_invitations_bool_exp"] | Variable<any, string>;
+      },
+      ValueTypes["auth_invitations_mutation_response"]
+    ];
+    update_auth_invitations_by_pk?: [
+      {
+        /** append existing jsonb value of filtered columns with new jsonb value */
+        _append?:
+          | ValueTypes["auth_invitations_append_input"]
+          | undefined
+          | null
+          | Variable<
+              any,
+              string
+            > /** delete the field or element with specified path (for JSON arrays, negative integers count from the end) */;
+        _delete_at_path?:
+          | ValueTypes["auth_invitations_delete_at_path_input"]
+          | undefined
+          | null
+          | Variable<
+              any,
+              string
+            > /** delete the array element with specified index (negative integers count from the end). throws an error if top level container is not an array */;
+        _delete_elem?:
+          | ValueTypes["auth_invitations_delete_elem_input"]
+          | undefined
+          | null
+          | Variable<
+              any,
+              string
+            > /** delete key/value pair or string element. key/value pairs are matched based on their key value */;
+        _delete_key?:
+          | ValueTypes["auth_invitations_delete_key_input"]
+          | undefined
+          | null
+          | Variable<
+              any,
+              string
+            > /** prepend existing jsonb value of filtered columns with new jsonb value */;
+        _prepend?:
+          | ValueTypes["auth_invitations_prepend_input"]
+          | undefined
+          | null
+          | Variable<
+              any,
+              string
+            > /** sets the columns of the filtered rows to the given values */;
+        _set?:
+          | ValueTypes["auth_invitations_set_input"]
+          | undefined
+          | null
+          | Variable<any, string>;
+        pk_columns:
+          | ValueTypes["auth_invitations_pk_columns_input"]
+          | Variable<any, string>;
+      },
+      ValueTypes["auth_invitations"]
+    ];
+    update_auth_invitations_many?: [
+      {
+        /** updates to execute, in order */
+        updates:
+          | Array<ValueTypes["auth_invitations_updates"]>
+          | Variable<any, string>;
+      },
+      ValueTypes["auth_invitations_mutation_response"]
+    ];
+    update_auth_users?: [
+      {
+        /** sets the columns of the filtered rows to the given values */
+        _set?:
+          | ValueTypes["auth_users_set_input"]
+          | undefined
+          | null
+          | Variable<
+              any,
+              string
+            > /** filter the rows which have to be updated */;
+        where: ValueTypes["auth_users_bool_exp"] | Variable<any, string>;
+      },
+      ValueTypes["auth_users_mutation_response"]
+    ];
+    update_auth_users_by_pk?: [
+      {
+        /** sets the columns of the filtered rows to the given values */
+        _set?:
+          | ValueTypes["auth_users_set_input"]
+          | undefined
+          | null
+          | Variable<any, string>;
+        pk_columns:
+          | ValueTypes["auth_users_pk_columns_input"]
+          | Variable<any, string>;
+      },
+      ValueTypes["auth_users"]
+    ];
+    update_auth_users_many?: [
+      {
+        /** updates to execute, in order */
+        updates:
+          | Array<ValueTypes["auth_users_updates"]>
+          | Variable<any, string>;
+      },
+      ValueTypes["auth_users_mutation_response"]
+    ];
+    __typename?: boolean | `@${string}`;
+  }>;
+  /** column ordering options */
+  ["order_by"]: order_by;
+  ["query_root"]: AliasType<{
+    auth_invitations?: [
+      {
+        /** distinct select on columns */
+        distinct_on?:
+          | Array<ValueTypes["auth_invitations_select_column"]>
+          | undefined
+          | null
+          | Variable<any, string> /** limit the number of rows returned */;
+        limit?:
+          | number
+          | undefined
+          | null
+          | Variable<
+              any,
+              string
+            > /** skip the first n rows. Use only with order_by */;
+        offset?:
+          | number
+          | undefined
+          | null
+          | Variable<any, string> /** sort the rows by one or more columns */;
+        order_by?:
+          | Array<ValueTypes["auth_invitations_order_by"]>
+          | undefined
+          | null
+          | Variable<any, string> /** filter the rows returned */;
+        where?:
+          | ValueTypes["auth_invitations_bool_exp"]
+          | undefined
+          | null
+          | Variable<any, string>;
+      },
+      ValueTypes["auth_invitations"]
+    ];
+    auth_invitations_aggregate?: [
+      {
+        /** distinct select on columns */
+        distinct_on?:
+          | Array<ValueTypes["auth_invitations_select_column"]>
+          | undefined
+          | null
+          | Variable<any, string> /** limit the number of rows returned */;
+        limit?:
+          | number
+          | undefined
+          | null
+          | Variable<
+              any,
+              string
+            > /** skip the first n rows. Use only with order_by */;
+        offset?:
+          | number
+          | undefined
+          | null
+          | Variable<any, string> /** sort the rows by one or more columns */;
+        order_by?:
+          | Array<ValueTypes["auth_invitations_order_by"]>
+          | undefined
+          | null
+          | Variable<any, string> /** filter the rows returned */;
+        where?:
+          | ValueTypes["auth_invitations_bool_exp"]
+          | undefined
+          | null
+          | Variable<any, string>;
+      },
+      ValueTypes["auth_invitations_aggregate"]
+    ];
+    auth_invitations_by_pk?: [
+      { id: ValueTypes["uuid"] | Variable<any, string> },
+      ValueTypes["auth_invitations"]
+    ];
+    auth_users?: [
+      {
+        /** distinct select on columns */
+        distinct_on?:
+          | Array<ValueTypes["auth_users_select_column"]>
+          | undefined
+          | null
+          | Variable<any, string> /** limit the number of rows returned */;
+        limit?:
+          | number
+          | undefined
+          | null
+          | Variable<
+              any,
+              string
+            > /** skip the first n rows. Use only with order_by */;
+        offset?:
+          | number
+          | undefined
+          | null
+          | Variable<any, string> /** sort the rows by one or more columns */;
+        order_by?:
+          | Array<ValueTypes["auth_users_order_by"]>
+          | undefined
+          | null
+          | Variable<any, string> /** filter the rows returned */;
+        where?:
+          | ValueTypes["auth_users_bool_exp"]
+          | undefined
+          | null
+          | Variable<any, string>;
+      },
+      ValueTypes["auth_users"]
+    ];
+    auth_users_aggregate?: [
+      {
+        /** distinct select on columns */
+        distinct_on?:
+          | Array<ValueTypes["auth_users_select_column"]>
+          | undefined
+          | null
+          | Variable<any, string> /** limit the number of rows returned */;
+        limit?:
+          | number
+          | undefined
+          | null
+          | Variable<
+              any,
+              string
+            > /** skip the first n rows. Use only with order_by */;
+        offset?:
+          | number
+          | undefined
+          | null
+          | Variable<any, string> /** sort the rows by one or more columns */;
+        order_by?:
+          | Array<ValueTypes["auth_users_order_by"]>
+          | undefined
+          | null
+          | Variable<any, string> /** filter the rows returned */;
+        where?:
+          | ValueTypes["auth_users_bool_exp"]
+          | undefined
+          | null
+          | Variable<any, string>;
+      },
+      ValueTypes["auth_users_aggregate"]
+    ];
+    auth_users_by_pk?: [
+      { id: ValueTypes["uuid"] | Variable<any, string> },
+      ValueTypes["auth_users"]
+    ];
+    __typename?: boolean | `@${string}`;
+  }>;
+  ["subscription_root"]: AliasType<{
+    auth_invitations?: [
+      {
+        /** distinct select on columns */
+        distinct_on?:
+          | Array<ValueTypes["auth_invitations_select_column"]>
+          | undefined
+          | null
+          | Variable<any, string> /** limit the number of rows returned */;
+        limit?:
+          | number
+          | undefined
+          | null
+          | Variable<
+              any,
+              string
+            > /** skip the first n rows. Use only with order_by */;
+        offset?:
+          | number
+          | undefined
+          | null
+          | Variable<any, string> /** sort the rows by one or more columns */;
+        order_by?:
+          | Array<ValueTypes["auth_invitations_order_by"]>
+          | undefined
+          | null
+          | Variable<any, string> /** filter the rows returned */;
+        where?:
+          | ValueTypes["auth_invitations_bool_exp"]
+          | undefined
+          | null
+          | Variable<any, string>;
+      },
+      ValueTypes["auth_invitations"]
+    ];
+    auth_invitations_aggregate?: [
+      {
+        /** distinct select on columns */
+        distinct_on?:
+          | Array<ValueTypes["auth_invitations_select_column"]>
+          | undefined
+          | null
+          | Variable<any, string> /** limit the number of rows returned */;
+        limit?:
+          | number
+          | undefined
+          | null
+          | Variable<
+              any,
+              string
+            > /** skip the first n rows. Use only with order_by */;
+        offset?:
+          | number
+          | undefined
+          | null
+          | Variable<any, string> /** sort the rows by one or more columns */;
+        order_by?:
+          | Array<ValueTypes["auth_invitations_order_by"]>
+          | undefined
+          | null
+          | Variable<any, string> /** filter the rows returned */;
+        where?:
+          | ValueTypes["auth_invitations_bool_exp"]
+          | undefined
+          | null
+          | Variable<any, string>;
+      },
+      ValueTypes["auth_invitations_aggregate"]
+    ];
+    auth_invitations_by_pk?: [
+      { id: ValueTypes["uuid"] | Variable<any, string> },
+      ValueTypes["auth_invitations"]
+    ];
+    auth_invitations_stream?: [
+      {
+        /** maximum number of rows returned in a single batch */
+        batch_size:
+          | number
+          | Variable<
+              any,
+              string
+            > /** cursor to stream the results returned by the query */;
+        cursor:
+          | Array<
+              | ValueTypes["auth_invitations_stream_cursor_input"]
+              | undefined
+              | null
+            >
+          | Variable<any, string> /** filter the rows returned */;
+        where?:
+          | ValueTypes["auth_invitations_bool_exp"]
+          | undefined
+          | null
+          | Variable<any, string>;
+      },
+      ValueTypes["auth_invitations"]
+    ];
+    auth_users?: [
+      {
+        /** distinct select on columns */
+        distinct_on?:
+          | Array<ValueTypes["auth_users_select_column"]>
+          | undefined
+          | null
+          | Variable<any, string> /** limit the number of rows returned */;
+        limit?:
+          | number
+          | undefined
+          | null
+          | Variable<
+              any,
+              string
+            > /** skip the first n rows. Use only with order_by */;
+        offset?:
+          | number
+          | undefined
+          | null
+          | Variable<any, string> /** sort the rows by one or more columns */;
+        order_by?:
+          | Array<ValueTypes["auth_users_order_by"]>
+          | undefined
+          | null
+          | Variable<any, string> /** filter the rows returned */;
+        where?:
+          | ValueTypes["auth_users_bool_exp"]
+          | undefined
+          | null
+          | Variable<any, string>;
+      },
+      ValueTypes["auth_users"]
+    ];
+    auth_users_aggregate?: [
+      {
+        /** distinct select on columns */
+        distinct_on?:
+          | Array<ValueTypes["auth_users_select_column"]>
+          | undefined
+          | null
+          | Variable<any, string> /** limit the number of rows returned */;
+        limit?:
+          | number
+          | undefined
+          | null
+          | Variable<
+              any,
+              string
+            > /** skip the first n rows. Use only with order_by */;
+        offset?:
+          | number
+          | undefined
+          | null
+          | Variable<any, string> /** sort the rows by one or more columns */;
+        order_by?:
+          | Array<ValueTypes["auth_users_order_by"]>
+          | undefined
+          | null
+          | Variable<any, string> /** filter the rows returned */;
+        where?:
+          | ValueTypes["auth_users_bool_exp"]
+          | undefined
+          | null
+          | Variable<any, string>;
+      },
+      ValueTypes["auth_users_aggregate"]
+    ];
+    auth_users_by_pk?: [
+      { id: ValueTypes["uuid"] | Variable<any, string> },
+      ValueTypes["auth_users"]
+    ];
+    auth_users_stream?: [
+      {
+        /** maximum number of rows returned in a single batch */
+        batch_size:
+          | number
+          | Variable<
+              any,
+              string
+            > /** cursor to stream the results returned by the query */;
+        cursor:
+          | Array<
+              ValueTypes["auth_users_stream_cursor_input"] | undefined | null
+            >
+          | Variable<any, string> /** filter the rows returned */;
+        where?:
+          | ValueTypes["auth_users_bool_exp"]
+          | undefined
+          | null
+          | Variable<any, string>;
+      },
+      ValueTypes["auth_users"]
+    ];
+    __typename?: boolean | `@${string}`;
+  }>;
+  ["timestamptz"]: unknown;
+  /** Boolean expression to compare columns of type "timestamptz". All fields are combined with logical 'AND'. */
+  ["timestamptz_comparison_exp"]: {
+    _eq?: ValueTypes["timestamptz"] | undefined | null | Variable<any, string>;
+    _gt?: ValueTypes["timestamptz"] | undefined | null | Variable<any, string>;
+    _gte?: ValueTypes["timestamptz"] | undefined | null | Variable<any, string>;
+    _in?:
+      | Array<ValueTypes["timestamptz"]>
+      | undefined
+      | null
+      | Variable<any, string>;
+    _is_null?: boolean | undefined | null | Variable<any, string>;
+    _lt?: ValueTypes["timestamptz"] | undefined | null | Variable<any, string>;
+    _lte?: ValueTypes["timestamptz"] | undefined | null | Variable<any, string>;
+    _neq?: ValueTypes["timestamptz"] | undefined | null | Variable<any, string>;
+    _nin?:
+      | Array<ValueTypes["timestamptz"]>
+      | undefined
+      | null
+      | Variable<any, string>;
+  };
+  ["uuid"]: unknown;
+  /** Boolean expression to compare columns of type "uuid". All fields are combined with logical 'AND'. */
+  ["uuid_comparison_exp"]: {
+    _eq?: ValueTypes["uuid"] | undefined | null | Variable<any, string>;
+    _gt?: ValueTypes["uuid"] | undefined | null | Variable<any, string>;
+    _gte?: ValueTypes["uuid"] | undefined | null | Variable<any, string>;
+    _in?: Array<ValueTypes["uuid"]> | undefined | null | Variable<any, string>;
+    _is_null?: boolean | undefined | null | Variable<any, string>;
+    _lt?: ValueTypes["uuid"] | undefined | null | Variable<any, string>;
+    _lte?: ValueTypes["uuid"] | undefined | null | Variable<any, string>;
+    _neq?: ValueTypes["uuid"] | undefined | null | Variable<any, string>;
+    _nin?: Array<ValueTypes["uuid"]> | undefined | null | Variable<any, string>;
+  };
+};
+
+export type ResolverInputTypes = {
+  /** Boolean expression to compare columns of type "String". All fields are combined with logical 'AND'. */
+  ["String_comparison_exp"]: {
+    _eq?: string | undefined | null;
+    _gt?: string | undefined | null;
+    _gte?: string | undefined | null;
+    /** does the column match the given case-insensitive pattern */
+    _ilike?: string | undefined | null;
+    _in?: Array<string> | undefined | null;
+    /** does the column match the given POSIX regular expression, case insensitive */
+    _iregex?: string | undefined | null;
+    _is_null?: boolean | undefined | null;
+    /** does the column match the given pattern */
+    _like?: string | undefined | null;
+    _lt?: string | undefined | null;
+    _lte?: string | undefined | null;
+    _neq?: string | undefined | null;
+    /** does the column NOT match the given case-insensitive pattern */
+    _nilike?: string | undefined | null;
+    _nin?: Array<string> | undefined | null;
+    /** does the column NOT match the given POSIX regular expression, case insensitive */
+    _niregex?: string | undefined | null;
+    /** does the column NOT match the given pattern */
+    _nlike?: string | undefined | null;
+    /** does the column NOT match the given POSIX regular expression, case sensitive */
+    _nregex?: string | undefined | null;
+    /** does the column NOT match the given SQL regular expression */
+    _nsimilar?: string | undefined | null;
+    /** does the column match the given POSIX regular expression, case sensitive */
+    _regex?: string | undefined | null;
+    /** does the column match the given SQL regular expression */
+    _similar?: string | undefined | null;
+  };
+  /** ids are beta invite codes */
+  ["auth_invitations"]: AliasType<{
+    created_at?: boolean | `@${string}`;
+    data?: [
+      {
+        /** JSON select path */ path?: string | undefined | null;
+      },
+      boolean | `@${string}`
+    ];
+    id?: boolean | `@${string}`;
+    __typename?: boolean | `@${string}`;
+  }>;
+  /** aggregated selection of "auth.invitations" */
+  ["auth_invitations_aggregate"]: AliasType<{
+    aggregate?: ResolverInputTypes["auth_invitations_aggregate_fields"];
+    nodes?: ResolverInputTypes["auth_invitations"];
+    __typename?: boolean | `@${string}`;
+  }>;
+  /** aggregate fields of "auth.invitations" */
+  ["auth_invitations_aggregate_fields"]: AliasType<{
+    count?: [
+      {
+        columns?:
+          | Array<ResolverInputTypes["auth_invitations_select_column"]>
+          | undefined
+          | null;
+        distinct?: boolean | undefined | null;
+      },
+      boolean | `@${string}`
+    ];
+    max?: ResolverInputTypes["auth_invitations_max_fields"];
+    min?: ResolverInputTypes["auth_invitations_min_fields"];
+    __typename?: boolean | `@${string}`;
+  }>;
+  /** append existing jsonb value of filtered columns with new jsonb value */
+  ["auth_invitations_append_input"]: {
+    data?: ResolverInputTypes["jsonb"] | undefined | null;
+  };
+  /** Boolean expression to filter rows from the table "auth.invitations". All fields are combined with a logical 'AND'. */
+  ["auth_invitations_bool_exp"]: {
+    _and?:
+      | Array<ResolverInputTypes["auth_invitations_bool_exp"]>
+      | undefined
+      | null;
+    _not?: ResolverInputTypes["auth_invitations_bool_exp"] | undefined | null;
+    _or?:
+      | Array<ResolverInputTypes["auth_invitations_bool_exp"]>
+      | undefined
+      | null;
+    created_at?:
+      | ResolverInputTypes["timestamptz_comparison_exp"]
+      | undefined
+      | null;
+    data?: ResolverInputTypes["jsonb_comparison_exp"] | undefined | null;
+    id?: ResolverInputTypes["uuid_comparison_exp"] | undefined | null;
+  };
+  /** unique or primary key constraints on table "auth.invitations" */
+  ["auth_invitations_constraint"]: auth_invitations_constraint;
+  /** delete the field or element with specified path (for JSON arrays, negative integers count from the end) */
+  ["auth_invitations_delete_at_path_input"]: {
+    data?: Array<string> | undefined | null;
+  };
+  /** delete the array element with specified index (negative integers count from the end). throws an error if top level container is not an array */
+  ["auth_invitations_delete_elem_input"]: {
+    data?: number | undefined | null;
+  };
+  /** delete key/value pair or string element. key/value pairs are matched based on their key value */
+  ["auth_invitations_delete_key_input"]: {
+    data?: string | undefined | null;
+  };
+  /** input type for inserting data into table "auth.invitations" */
+  ["auth_invitations_insert_input"]: {
+    created_at?: ResolverInputTypes["timestamptz"] | undefined | null;
+    data?: ResolverInputTypes["jsonb"] | undefined | null;
+    id?: ResolverInputTypes["uuid"] | undefined | null;
+  };
+  /** aggregate max on columns */
+  ["auth_invitations_max_fields"]: AliasType<{
+    created_at?: boolean | `@${string}`;
+    id?: boolean | `@${string}`;
+    __typename?: boolean | `@${string}`;
+  }>;
+  /** aggregate min on columns */
+  ["auth_invitations_min_fields"]: AliasType<{
+    created_at?: boolean | `@${string}`;
+    id?: boolean | `@${string}`;
+    __typename?: boolean | `@${string}`;
+  }>;
+  /** response of any mutation on the table "auth.invitations" */
+  ["auth_invitations_mutation_response"]: AliasType<{
+    /** number of rows affected by the mutation */
+    affected_rows?: boolean | `@${string}`;
+    /** data from the rows affected by the mutation */
+    returning?: ResolverInputTypes["auth_invitations"];
+    __typename?: boolean | `@${string}`;
+  }>;
+  /** on_conflict condition type for table "auth.invitations" */
+  ["auth_invitations_on_conflict"]: {
+    constraint: ResolverInputTypes["auth_invitations_constraint"];
+    update_columns: Array<ResolverInputTypes["auth_invitations_update_column"]>;
+    where?: ResolverInputTypes["auth_invitations_bool_exp"] | undefined | null;
+  };
+  /** Ordering options when selecting data from "auth.invitations". */
+  ["auth_invitations_order_by"]: {
+    created_at?: ResolverInputTypes["order_by"] | undefined | null;
+    data?: ResolverInputTypes["order_by"] | undefined | null;
+    id?: ResolverInputTypes["order_by"] | undefined | null;
+  };
+  /** primary key columns input for table: auth_invitations */
+  ["auth_invitations_pk_columns_input"]: {
+    id: ResolverInputTypes["uuid"];
+  };
+  /** prepend existing jsonb value of filtered columns with new jsonb value */
+  ["auth_invitations_prepend_input"]: {
+    data?: ResolverInputTypes["jsonb"] | undefined | null;
+  };
+  /** select columns of table "auth.invitations" */
+  ["auth_invitations_select_column"]: auth_invitations_select_column;
+  /** input type for updating data in table "auth.invitations" */
+  ["auth_invitations_set_input"]: {
+    created_at?: ResolverInputTypes["timestamptz"] | undefined | null;
+    data?: ResolverInputTypes["jsonb"] | undefined | null;
+    id?: ResolverInputTypes["uuid"] | undefined | null;
+  };
+  /** Streaming cursor of the table "auth_invitations" */
+  ["auth_invitations_stream_cursor_input"]: {
+    /** Stream column input with initial value */
+    initial_value: ResolverInputTypes["auth_invitations_stream_cursor_value_input"];
+    /** cursor ordering */
+    ordering?: ResolverInputTypes["cursor_ordering"] | undefined | null;
+  };
+  /** Initial value of the column from where the streaming should start */
+  ["auth_invitations_stream_cursor_value_input"]: {
+    created_at?: ResolverInputTypes["timestamptz"] | undefined | null;
+    data?: ResolverInputTypes["jsonb"] | undefined | null;
+    id?: ResolverInputTypes["uuid"] | undefined | null;
+  };
+  /** update columns of table "auth.invitations" */
+  ["auth_invitations_update_column"]: auth_invitations_update_column;
+  ["auth_invitations_updates"]: {
+    /** append existing jsonb value of filtered columns with new jsonb value */
+    _append?:
+      | ResolverInputTypes["auth_invitations_append_input"]
+      | undefined
+      | null;
+    /** delete the field or element with specified path (for JSON arrays, negative integers count from the end) */
+    _delete_at_path?:
+      | ResolverInputTypes["auth_invitations_delete_at_path_input"]
+      | undefined
+      | null;
+    /** delete the array element with specified index (negative integers count from the end). throws an error if top level container is not an array */
+    _delete_elem?:
+      | ResolverInputTypes["auth_invitations_delete_elem_input"]
+      | undefined
+      | null;
+    /** delete key/value pair or string element. key/value pairs are matched based on their key value */
+    _delete_key?:
+      | ResolverInputTypes["auth_invitations_delete_key_input"]
+      | undefined
+      | null;
+    /** prepend existing jsonb value of filtered columns with new jsonb value */
+    _prepend?:
+      | ResolverInputTypes["auth_invitations_prepend_input"]
+      | undefined
+      | null;
+    /** sets the columns of the filtered rows to the given values */
+    _set?: ResolverInputTypes["auth_invitations_set_input"] | undefined | null;
+    where: ResolverInputTypes["auth_invitations_bool_exp"];
+  };
+  /** columns and relationships of "auth.users" */
+  ["auth_users"]: AliasType<{
+    created_at?: boolean | `@${string}`;
+    id?: boolean | `@${string}`;
+    invitation_id?: boolean | `@${string}`;
+    last_active_at?: boolean | `@${string}`;
+    updated_at?: boolean | `@${string}`;
+    username?: boolean | `@${string}`;
+    __typename?: boolean | `@${string}`;
+  }>;
+  /** aggregated selection of "auth.users" */
+  ["auth_users_aggregate"]: AliasType<{
+    aggregate?: ResolverInputTypes["auth_users_aggregate_fields"];
+    nodes?: ResolverInputTypes["auth_users"];
+    __typename?: boolean | `@${string}`;
+  }>;
+  /** aggregate fields of "auth.users" */
+  ["auth_users_aggregate_fields"]: AliasType<{
+    count?: [
+      {
+        columns?:
+          | Array<ResolverInputTypes["auth_users_select_column"]>
+          | undefined
+          | null;
+        distinct?: boolean | undefined | null;
+      },
+      boolean | `@${string}`
+    ];
+    max?: ResolverInputTypes["auth_users_max_fields"];
+    min?: ResolverInputTypes["auth_users_min_fields"];
+    __typename?: boolean | `@${string}`;
+  }>;
+  /** Boolean expression to filter rows from the table "auth.users". All fields are combined with a logical 'AND'. */
+  ["auth_users_bool_exp"]: {
+    _and?: Array<ResolverInputTypes["auth_users_bool_exp"]> | undefined | null;
+    _not?: ResolverInputTypes["auth_users_bool_exp"] | undefined | null;
+    _or?: Array<ResolverInputTypes["auth_users_bool_exp"]> | undefined | null;
+    created_at?:
+      | ResolverInputTypes["timestamptz_comparison_exp"]
+      | undefined
+      | null;
+    id?: ResolverInputTypes["uuid_comparison_exp"] | undefined | null;
+    invitation_id?:
+      | ResolverInputTypes["uuid_comparison_exp"]
+      | undefined
+      | null;
+    last_active_at?:
+      | ResolverInputTypes["timestamptz_comparison_exp"]
+      | undefined
+      | null;
+    updated_at?:
+      | ResolverInputTypes["timestamptz_comparison_exp"]
+      | undefined
+      | null;
+    username?: ResolverInputTypes["citext_comparison_exp"] | undefined | null;
+  };
+  /** unique or primary key constraints on table "auth.users" */
+  ["auth_users_constraint"]: auth_users_constraint;
+  /** input type for inserting data into table "auth.users" */
+  ["auth_users_insert_input"]: {
+    created_at?: ResolverInputTypes["timestamptz"] | undefined | null;
+    id?: ResolverInputTypes["uuid"] | undefined | null;
+    invitation_id?: ResolverInputTypes["uuid"] | undefined | null;
+    last_active_at?: ResolverInputTypes["timestamptz"] | undefined | null;
+    updated_at?: ResolverInputTypes["timestamptz"] | undefined | null;
+    username?: ResolverInputTypes["citext"] | undefined | null;
+  };
+  /** aggregate max on columns */
+  ["auth_users_max_fields"]: AliasType<{
+    created_at?: boolean | `@${string}`;
+    id?: boolean | `@${string}`;
+    invitation_id?: boolean | `@${string}`;
+    last_active_at?: boolean | `@${string}`;
+    updated_at?: boolean | `@${string}`;
+    username?: boolean | `@${string}`;
+    __typename?: boolean | `@${string}`;
+  }>;
+  /** aggregate min on columns */
+  ["auth_users_min_fields"]: AliasType<{
+    created_at?: boolean | `@${string}`;
+    id?: boolean | `@${string}`;
+    invitation_id?: boolean | `@${string}`;
+    last_active_at?: boolean | `@${string}`;
+    updated_at?: boolean | `@${string}`;
+    username?: boolean | `@${string}`;
+    __typename?: boolean | `@${string}`;
+  }>;
+  /** response of any mutation on the table "auth.users" */
+  ["auth_users_mutation_response"]: AliasType<{
+    /** number of rows affected by the mutation */
+    affected_rows?: boolean | `@${string}`;
+    /** data from the rows affected by the mutation */
+    returning?: ResolverInputTypes["auth_users"];
+    __typename?: boolean | `@${string}`;
+  }>;
+  /** on_conflict condition type for table "auth.users" */
+  ["auth_users_on_conflict"]: {
+    constraint: ResolverInputTypes["auth_users_constraint"];
+    update_columns: Array<ResolverInputTypes["auth_users_update_column"]>;
+    where?: ResolverInputTypes["auth_users_bool_exp"] | undefined | null;
+  };
+  /** Ordering options when selecting data from "auth.users". */
+  ["auth_users_order_by"]: {
+    created_at?: ResolverInputTypes["order_by"] | undefined | null;
+    id?: ResolverInputTypes["order_by"] | undefined | null;
+    invitation_id?: ResolverInputTypes["order_by"] | undefined | null;
+    last_active_at?: ResolverInputTypes["order_by"] | undefined | null;
+    updated_at?: ResolverInputTypes["order_by"] | undefined | null;
+    username?: ResolverInputTypes["order_by"] | undefined | null;
+  };
+  /** primary key columns input for table: auth_users */
+  ["auth_users_pk_columns_input"]: {
+    id: ResolverInputTypes["uuid"];
+  };
+  /** select columns of table "auth.users" */
+  ["auth_users_select_column"]: auth_users_select_column;
+  /** input type for updating data in table "auth.users" */
+  ["auth_users_set_input"]: {
+    created_at?: ResolverInputTypes["timestamptz"] | undefined | null;
+    id?: ResolverInputTypes["uuid"] | undefined | null;
+    invitation_id?: ResolverInputTypes["uuid"] | undefined | null;
+    last_active_at?: ResolverInputTypes["timestamptz"] | undefined | null;
+    updated_at?: ResolverInputTypes["timestamptz"] | undefined | null;
+    username?: ResolverInputTypes["citext"] | undefined | null;
+  };
+  /** Streaming cursor of the table "auth_users" */
+  ["auth_users_stream_cursor_input"]: {
+    /** Stream column input with initial value */
+    initial_value: ResolverInputTypes["auth_users_stream_cursor_value_input"];
+    /** cursor ordering */
+    ordering?: ResolverInputTypes["cursor_ordering"] | undefined | null;
+  };
+  /** Initial value of the column from where the streaming should start */
+  ["auth_users_stream_cursor_value_input"]: {
+    created_at?: ResolverInputTypes["timestamptz"] | undefined | null;
+    id?: ResolverInputTypes["uuid"] | undefined | null;
+    invitation_id?: ResolverInputTypes["uuid"] | undefined | null;
+    last_active_at?: ResolverInputTypes["timestamptz"] | undefined | null;
+    updated_at?: ResolverInputTypes["timestamptz"] | undefined | null;
+    username?: ResolverInputTypes["citext"] | undefined | null;
+  };
+  /** update columns of table "auth.users" */
+  ["auth_users_update_column"]: auth_users_update_column;
+  ["auth_users_updates"]: {
+    /** sets the columns of the filtered rows to the given values */
+    _set?: ResolverInputTypes["auth_users_set_input"] | undefined | null;
+    where: ResolverInputTypes["auth_users_bool_exp"];
+  };
+  ["citext"]: unknown;
+  /** Boolean expression to compare columns of type "citext". All fields are combined with logical 'AND'. */
+  ["citext_comparison_exp"]: {
+    _eq?: ResolverInputTypes["citext"] | undefined | null;
+    _gt?: ResolverInputTypes["citext"] | undefined | null;
+    _gte?: ResolverInputTypes["citext"] | undefined | null;
+    /** does the column match the given case-insensitive pattern */
+    _ilike?: ResolverInputTypes["citext"] | undefined | null;
+    _in?: Array<ResolverInputTypes["citext"]> | undefined | null;
+    /** does the column match the given POSIX regular expression, case insensitive */
+    _iregex?: ResolverInputTypes["citext"] | undefined | null;
+    _is_null?: boolean | undefined | null;
+    /** does the column match the given pattern */
+    _like?: ResolverInputTypes["citext"] | undefined | null;
+    _lt?: ResolverInputTypes["citext"] | undefined | null;
+    _lte?: ResolverInputTypes["citext"] | undefined | null;
+    _neq?: ResolverInputTypes["citext"] | undefined | null;
+    /** does the column NOT match the given case-insensitive pattern */
+    _nilike?: ResolverInputTypes["citext"] | undefined | null;
+    _nin?: Array<ResolverInputTypes["citext"]> | undefined | null;
+    /** does the column NOT match the given POSIX regular expression, case insensitive */
+    _niregex?: ResolverInputTypes["citext"] | undefined | null;
+    /** does the column NOT match the given pattern */
+    _nlike?: ResolverInputTypes["citext"] | undefined | null;
+    /** does the column NOT match the given POSIX regular expression, case sensitive */
+    _nregex?: ResolverInputTypes["citext"] | undefined | null;
+    /** does the column NOT match the given SQL regular expression */
+    _nsimilar?: ResolverInputTypes["citext"] | undefined | null;
+    /** does the column match the given POSIX regular expression, case sensitive */
+    _regex?: ResolverInputTypes["citext"] | undefined | null;
+    /** does the column match the given SQL regular expression */
+    _similar?: ResolverInputTypes["citext"] | undefined | null;
+  };
+  /** ordering argument of a cursor */
+  ["cursor_ordering"]: cursor_ordering;
+  ["jsonb"]: unknown;
+  ["jsonb_cast_exp"]: {
+    String?: ResolverInputTypes["String_comparison_exp"] | undefined | null;
+  };
+  /** Boolean expression to compare columns of type "jsonb". All fields are combined with logical 'AND'. */
+  ["jsonb_comparison_exp"]: {
+    _cast?: ResolverInputTypes["jsonb_cast_exp"] | undefined | null;
+    /** is the column contained in the given json value */
+    _contained_in?: ResolverInputTypes["jsonb"] | undefined | null;
+    /** does the column contain the given json value at the top level */
+    _contains?: ResolverInputTypes["jsonb"] | undefined | null;
+    _eq?: ResolverInputTypes["jsonb"] | undefined | null;
+    _gt?: ResolverInputTypes["jsonb"] | undefined | null;
+    _gte?: ResolverInputTypes["jsonb"] | undefined | null;
+    /** does the string exist as a top-level key in the column */
+    _has_key?: string | undefined | null;
+    /** do all of these strings exist as top-level keys in the column */
+    _has_keys_all?: Array<string> | undefined | null;
+    /** do any of these strings exist as top-level keys in the column */
+    _has_keys_any?: Array<string> | undefined | null;
+    _in?: Array<ResolverInputTypes["jsonb"]> | undefined | null;
+    _is_null?: boolean | undefined | null;
+    _lt?: ResolverInputTypes["jsonb"] | undefined | null;
+    _lte?: ResolverInputTypes["jsonb"] | undefined | null;
+    _neq?: ResolverInputTypes["jsonb"] | undefined | null;
+    _nin?: Array<ResolverInputTypes["jsonb"]> | undefined | null;
+  };
+  /** mutation root */
+  ["mutation_root"]: AliasType<{
+    delete_auth_invitations?: [
+      {
+        /** filter the rows which have to be deleted */
+        where: ResolverInputTypes["auth_invitations_bool_exp"];
+      },
+      ResolverInputTypes["auth_invitations_mutation_response"]
+    ];
+    delete_auth_invitations_by_pk?: [
+      { id: ResolverInputTypes["uuid"] },
+      ResolverInputTypes["auth_invitations"]
+    ];
+    delete_auth_users?: [
+      {
+        /** filter the rows which have to be deleted */
+        where: ResolverInputTypes["auth_users_bool_exp"];
+      },
+      ResolverInputTypes["auth_users_mutation_response"]
+    ];
+    delete_auth_users_by_pk?: [
+      { id: ResolverInputTypes["uuid"] },
+      ResolverInputTypes["auth_users"]
+    ];
+    insert_auth_invitations?: [
+      {
+        /** the rows to be inserted */
+        objects: Array<
+          ResolverInputTypes["auth_invitations_insert_input"]
+        > /** upsert condition */;
+        on_conflict?:
+          | ResolverInputTypes["auth_invitations_on_conflict"]
+          | undefined
+          | null;
+      },
+      ResolverInputTypes["auth_invitations_mutation_response"]
+    ];
+    insert_auth_invitations_one?: [
+      {
+        /** the row to be inserted */
+        object: ResolverInputTypes["auth_invitations_insert_input"] /** upsert condition */;
+        on_conflict?:
+          | ResolverInputTypes["auth_invitations_on_conflict"]
+          | undefined
+          | null;
+      },
+      ResolverInputTypes["auth_invitations"]
+    ];
+    insert_auth_users?: [
+      {
+        /** the rows to be inserted */
+        objects: Array<
+          ResolverInputTypes["auth_users_insert_input"]
+        > /** upsert condition */;
+        on_conflict?:
+          | ResolverInputTypes["auth_users_on_conflict"]
+          | undefined
+          | null;
+      },
+      ResolverInputTypes["auth_users_mutation_response"]
+    ];
+    insert_auth_users_one?: [
+      {
+        /** the row to be inserted */
+        object: ResolverInputTypes["auth_users_insert_input"] /** upsert condition */;
+        on_conflict?:
+          | ResolverInputTypes["auth_users_on_conflict"]
+          | undefined
+          | null;
+      },
+      ResolverInputTypes["auth_users"]
+    ];
+    update_auth_invitations?: [
+      {
+        /** append existing jsonb value of filtered columns with new jsonb value */
+        _append?:
+          | ResolverInputTypes["auth_invitations_append_input"]
+          | undefined
+          | null /** delete the field or element with specified path (for JSON arrays, negative integers count from the end) */;
+        _delete_at_path?:
+          | ResolverInputTypes["auth_invitations_delete_at_path_input"]
+          | undefined
+          | null /** delete the array element with specified index (negative integers count from the end). throws an error if top level container is not an array */;
+        _delete_elem?:
+          | ResolverInputTypes["auth_invitations_delete_elem_input"]
+          | undefined
+          | null /** delete key/value pair or string element. key/value pairs are matched based on their key value */;
+        _delete_key?:
+          | ResolverInputTypes["auth_invitations_delete_key_input"]
+          | undefined
+          | null /** prepend existing jsonb value of filtered columns with new jsonb value */;
+        _prepend?:
+          | ResolverInputTypes["auth_invitations_prepend_input"]
+          | undefined
+          | null /** sets the columns of the filtered rows to the given values */;
+        _set?:
+          | ResolverInputTypes["auth_invitations_set_input"]
+          | undefined
+          | null /** filter the rows which have to be updated */;
+        where: ResolverInputTypes["auth_invitations_bool_exp"];
+      },
+      ResolverInputTypes["auth_invitations_mutation_response"]
+    ];
+    update_auth_invitations_by_pk?: [
+      {
+        /** append existing jsonb value of filtered columns with new jsonb value */
+        _append?:
+          | ResolverInputTypes["auth_invitations_append_input"]
+          | undefined
+          | null /** delete the field or element with specified path (for JSON arrays, negative integers count from the end) */;
+        _delete_at_path?:
+          | ResolverInputTypes["auth_invitations_delete_at_path_input"]
+          | undefined
+          | null /** delete the array element with specified index (negative integers count from the end). throws an error if top level container is not an array */;
+        _delete_elem?:
+          | ResolverInputTypes["auth_invitations_delete_elem_input"]
+          | undefined
+          | null /** delete key/value pair or string element. key/value pairs are matched based on their key value */;
+        _delete_key?:
+          | ResolverInputTypes["auth_invitations_delete_key_input"]
+          | undefined
+          | null /** prepend existing jsonb value of filtered columns with new jsonb value */;
+        _prepend?:
+          | ResolverInputTypes["auth_invitations_prepend_input"]
+          | undefined
+          | null /** sets the columns of the filtered rows to the given values */;
+        _set?:
+          | ResolverInputTypes["auth_invitations_set_input"]
+          | undefined
+          | null;
+        pk_columns: ResolverInputTypes["auth_invitations_pk_columns_input"];
+      },
+      ResolverInputTypes["auth_invitations"]
+    ];
+    update_auth_invitations_many?: [
+      {
+        /** updates to execute, in order */
+        updates: Array<ResolverInputTypes["auth_invitations_updates"]>;
+      },
+      ResolverInputTypes["auth_invitations_mutation_response"]
+    ];
+    update_auth_users?: [
+      {
+        /** sets the columns of the filtered rows to the given values */
+        _set?:
+          | ResolverInputTypes["auth_users_set_input"]
+          | undefined
+          | null /** filter the rows which have to be updated */;
+        where: ResolverInputTypes["auth_users_bool_exp"];
+      },
+      ResolverInputTypes["auth_users_mutation_response"]
+    ];
+    update_auth_users_by_pk?: [
+      {
+        /** sets the columns of the filtered rows to the given values */
+        _set?: ResolverInputTypes["auth_users_set_input"] | undefined | null;
+        pk_columns: ResolverInputTypes["auth_users_pk_columns_input"];
+      },
+      ResolverInputTypes["auth_users"]
+    ];
+    update_auth_users_many?: [
+      {
+        /** updates to execute, in order */
+        updates: Array<ResolverInputTypes["auth_users_updates"]>;
+      },
+      ResolverInputTypes["auth_users_mutation_response"]
+    ];
+    __typename?: boolean | `@${string}`;
+  }>;
+  /** column ordering options */
+  ["order_by"]: order_by;
+  ["query_root"]: AliasType<{
+    auth_invitations?: [
+      {
+        /** distinct select on columns */
+        distinct_on?:
+          | Array<ResolverInputTypes["auth_invitations_select_column"]>
+          | undefined
+          | null /** limit the number of rows returned */;
+        limit?:
+          | number
+          | undefined
+          | null /** skip the first n rows. Use only with order_by */;
+        offset?:
+          | number
+          | undefined
+          | null /** sort the rows by one or more columns */;
+        order_by?:
+          | Array<ResolverInputTypes["auth_invitations_order_by"]>
+          | undefined
+          | null /** filter the rows returned */;
+        where?:
+          | ResolverInputTypes["auth_invitations_bool_exp"]
+          | undefined
+          | null;
+      },
+      ResolverInputTypes["auth_invitations"]
+    ];
+    auth_invitations_aggregate?: [
+      {
+        /** distinct select on columns */
+        distinct_on?:
+          | Array<ResolverInputTypes["auth_invitations_select_column"]>
+          | undefined
+          | null /** limit the number of rows returned */;
+        limit?:
+          | number
+          | undefined
+          | null /** skip the first n rows. Use only with order_by */;
+        offset?:
+          | number
+          | undefined
+          | null /** sort the rows by one or more columns */;
+        order_by?:
+          | Array<ResolverInputTypes["auth_invitations_order_by"]>
+          | undefined
+          | null /** filter the rows returned */;
+        where?:
+          | ResolverInputTypes["auth_invitations_bool_exp"]
+          | undefined
+          | null;
+      },
+      ResolverInputTypes["auth_invitations_aggregate"]
+    ];
+    auth_invitations_by_pk?: [
+      { id: ResolverInputTypes["uuid"] },
+      ResolverInputTypes["auth_invitations"]
+    ];
+    auth_users?: [
+      {
+        /** distinct select on columns */
+        distinct_on?:
+          | Array<ResolverInputTypes["auth_users_select_column"]>
+          | undefined
+          | null /** limit the number of rows returned */;
+        limit?:
+          | number
+          | undefined
+          | null /** skip the first n rows. Use only with order_by */;
+        offset?:
+          | number
+          | undefined
+          | null /** sort the rows by one or more columns */;
+        order_by?:
+          | Array<ResolverInputTypes["auth_users_order_by"]>
+          | undefined
+          | null /** filter the rows returned */;
+        where?: ResolverInputTypes["auth_users_bool_exp"] | undefined | null;
+      },
+      ResolverInputTypes["auth_users"]
+    ];
+    auth_users_aggregate?: [
+      {
+        /** distinct select on columns */
+        distinct_on?:
+          | Array<ResolverInputTypes["auth_users_select_column"]>
+          | undefined
+          | null /** limit the number of rows returned */;
+        limit?:
+          | number
+          | undefined
+          | null /** skip the first n rows. Use only with order_by */;
+        offset?:
+          | number
+          | undefined
+          | null /** sort the rows by one or more columns */;
+        order_by?:
+          | Array<ResolverInputTypes["auth_users_order_by"]>
+          | undefined
+          | null /** filter the rows returned */;
+        where?: ResolverInputTypes["auth_users_bool_exp"] | undefined | null;
+      },
+      ResolverInputTypes["auth_users_aggregate"]
+    ];
+    auth_users_by_pk?: [
+      { id: ResolverInputTypes["uuid"] },
+      ResolverInputTypes["auth_users"]
+    ];
+    __typename?: boolean | `@${string}`;
+  }>;
+  ["subscription_root"]: AliasType<{
+    auth_invitations?: [
+      {
+        /** distinct select on columns */
+        distinct_on?:
+          | Array<ResolverInputTypes["auth_invitations_select_column"]>
+          | undefined
+          | null /** limit the number of rows returned */;
+        limit?:
+          | number
+          | undefined
+          | null /** skip the first n rows. Use only with order_by */;
+        offset?:
+          | number
+          | undefined
+          | null /** sort the rows by one or more columns */;
+        order_by?:
+          | Array<ResolverInputTypes["auth_invitations_order_by"]>
+          | undefined
+          | null /** filter the rows returned */;
+        where?:
+          | ResolverInputTypes["auth_invitations_bool_exp"]
+          | undefined
+          | null;
+      },
+      ResolverInputTypes["auth_invitations"]
+    ];
+    auth_invitations_aggregate?: [
+      {
+        /** distinct select on columns */
+        distinct_on?:
+          | Array<ResolverInputTypes["auth_invitations_select_column"]>
+          | undefined
+          | null /** limit the number of rows returned */;
+        limit?:
+          | number
+          | undefined
+          | null /** skip the first n rows. Use only with order_by */;
+        offset?:
+          | number
+          | undefined
+          | null /** sort the rows by one or more columns */;
+        order_by?:
+          | Array<ResolverInputTypes["auth_invitations_order_by"]>
+          | undefined
+          | null /** filter the rows returned */;
+        where?:
+          | ResolverInputTypes["auth_invitations_bool_exp"]
+          | undefined
+          | null;
+      },
+      ResolverInputTypes["auth_invitations_aggregate"]
+    ];
+    auth_invitations_by_pk?: [
+      { id: ResolverInputTypes["uuid"] },
+      ResolverInputTypes["auth_invitations"]
+    ];
+    auth_invitations_stream?: [
+      {
+        /** maximum number of rows returned in a single batch */
+        batch_size: number /** cursor to stream the results returned by the query */;
+        cursor: Array<
+          | ResolverInputTypes["auth_invitations_stream_cursor_input"]
+          | undefined
+          | null
+        > /** filter the rows returned */;
+        where?:
+          | ResolverInputTypes["auth_invitations_bool_exp"]
+          | undefined
+          | null;
+      },
+      ResolverInputTypes["auth_invitations"]
+    ];
+    auth_users?: [
+      {
+        /** distinct select on columns */
+        distinct_on?:
+          | Array<ResolverInputTypes["auth_users_select_column"]>
+          | undefined
+          | null /** limit the number of rows returned */;
+        limit?:
+          | number
+          | undefined
+          | null /** skip the first n rows. Use only with order_by */;
+        offset?:
+          | number
+          | undefined
+          | null /** sort the rows by one or more columns */;
+        order_by?:
+          | Array<ResolverInputTypes["auth_users_order_by"]>
+          | undefined
+          | null /** filter the rows returned */;
+        where?: ResolverInputTypes["auth_users_bool_exp"] | undefined | null;
+      },
+      ResolverInputTypes["auth_users"]
+    ];
+    auth_users_aggregate?: [
+      {
+        /** distinct select on columns */
+        distinct_on?:
+          | Array<ResolverInputTypes["auth_users_select_column"]>
+          | undefined
+          | null /** limit the number of rows returned */;
+        limit?:
+          | number
+          | undefined
+          | null /** skip the first n rows. Use only with order_by */;
+        offset?:
+          | number
+          | undefined
+          | null /** sort the rows by one or more columns */;
+        order_by?:
+          | Array<ResolverInputTypes["auth_users_order_by"]>
+          | undefined
+          | null /** filter the rows returned */;
+        where?: ResolverInputTypes["auth_users_bool_exp"] | undefined | null;
+      },
+      ResolverInputTypes["auth_users_aggregate"]
+    ];
+    auth_users_by_pk?: [
+      { id: ResolverInputTypes["uuid"] },
+      ResolverInputTypes["auth_users"]
+    ];
+    auth_users_stream?: [
+      {
+        /** maximum number of rows returned in a single batch */
+        batch_size: number /** cursor to stream the results returned by the query */;
+        cursor: Array<
+          | ResolverInputTypes["auth_users_stream_cursor_input"]
+          | undefined
+          | null
+        > /** filter the rows returned */;
+        where?: ResolverInputTypes["auth_users_bool_exp"] | undefined | null;
+      },
+      ResolverInputTypes["auth_users"]
+    ];
+    __typename?: boolean | `@${string}`;
+  }>;
+  ["timestamptz"]: unknown;
+  /** Boolean expression to compare columns of type "timestamptz". All fields are combined with logical 'AND'. */
+  ["timestamptz_comparison_exp"]: {
+    _eq?: ResolverInputTypes["timestamptz"] | undefined | null;
+    _gt?: ResolverInputTypes["timestamptz"] | undefined | null;
+    _gte?: ResolverInputTypes["timestamptz"] | undefined | null;
+    _in?: Array<ResolverInputTypes["timestamptz"]> | undefined | null;
+    _is_null?: boolean | undefined | null;
+    _lt?: ResolverInputTypes["timestamptz"] | undefined | null;
+    _lte?: ResolverInputTypes["timestamptz"] | undefined | null;
+    _neq?: ResolverInputTypes["timestamptz"] | undefined | null;
+    _nin?: Array<ResolverInputTypes["timestamptz"]> | undefined | null;
+  };
+  ["uuid"]: unknown;
+  /** Boolean expression to compare columns of type "uuid". All fields are combined with logical 'AND'. */
+  ["uuid_comparison_exp"]: {
+    _eq?: ResolverInputTypes["uuid"] | undefined | null;
+    _gt?: ResolverInputTypes["uuid"] | undefined | null;
+    _gte?: ResolverInputTypes["uuid"] | undefined | null;
+    _in?: Array<ResolverInputTypes["uuid"]> | undefined | null;
+    _is_null?: boolean | undefined | null;
+    _lt?: ResolverInputTypes["uuid"] | undefined | null;
+    _lte?: ResolverInputTypes["uuid"] | undefined | null;
+    _neq?: ResolverInputTypes["uuid"] | undefined | null;
+    _nin?: Array<ResolverInputTypes["uuid"]> | undefined | null;
+  };
+};
+
+export type ModelTypes = {
+  /** Boolean expression to compare columns of type "String". All fields are combined with logical 'AND'. */
+  ["String_comparison_exp"]: {
+    _eq?: string | undefined;
+    _gt?: string | undefined;
+    _gte?: string | undefined;
+    /** does the column match the given case-insensitive pattern */
+    _ilike?: string | undefined;
+    _in?: Array<string> | undefined;
+    /** does the column match the given POSIX regular expression, case insensitive */
+    _iregex?: string | undefined;
+    _is_null?: boolean | undefined;
+    /** does the column match the given pattern */
+    _like?: string | undefined;
+    _lt?: string | undefined;
+    _lte?: string | undefined;
+    _neq?: string | undefined;
+    /** does the column NOT match the given case-insensitive pattern */
+    _nilike?: string | undefined;
+    _nin?: Array<string> | undefined;
+    /** does the column NOT match the given POSIX regular expression, case insensitive */
+    _niregex?: string | undefined;
+    /** does the column NOT match the given pattern */
+    _nlike?: string | undefined;
+    /** does the column NOT match the given POSIX regular expression, case sensitive */
+    _nregex?: string | undefined;
+    /** does the column NOT match the given SQL regular expression */
+    _nsimilar?: string | undefined;
+    /** does the column match the given POSIX regular expression, case sensitive */
+    _regex?: string | undefined;
+    /** does the column match the given SQL regular expression */
+    _similar?: string | undefined;
+  };
+  /** ids are beta invite codes */
+  ["auth_invitations"]: {
+    created_at: ModelTypes["timestamptz"];
+    data?: ModelTypes["jsonb"] | undefined;
+    id: ModelTypes["uuid"];
+  };
+  /** aggregated selection of "auth.invitations" */
+  ["auth_invitations_aggregate"]: {
+    aggregate?: ModelTypes["auth_invitations_aggregate_fields"] | undefined;
+    nodes: Array<ModelTypes["auth_invitations"]>;
+  };
+  /** aggregate fields of "auth.invitations" */
+  ["auth_invitations_aggregate_fields"]: {
+    count: number;
+    max?: ModelTypes["auth_invitations_max_fields"] | undefined;
+    min?: ModelTypes["auth_invitations_min_fields"] | undefined;
+  };
+  /** append existing jsonb value of filtered columns with new jsonb value */
+  ["auth_invitations_append_input"]: {
+    data?: ModelTypes["jsonb"] | undefined;
+  };
+  /** Boolean expression to filter rows from the table "auth.invitations". All fields are combined with a logical 'AND'. */
+  ["auth_invitations_bool_exp"]: {
+    _and?: Array<ModelTypes["auth_invitations_bool_exp"]> | undefined;
+    _not?: ModelTypes["auth_invitations_bool_exp"] | undefined;
+    _or?: Array<ModelTypes["auth_invitations_bool_exp"]> | undefined;
+    created_at?: ModelTypes["timestamptz_comparison_exp"] | undefined;
+    data?: ModelTypes["jsonb_comparison_exp"] | undefined;
+    id?: ModelTypes["uuid_comparison_exp"] | undefined;
+  };
+  ["auth_invitations_constraint"]: auth_invitations_constraint;
+  /** delete the field or element with specified path (for JSON arrays, negative integers count from the end) */
+  ["auth_invitations_delete_at_path_input"]: {
+    data?: Array<string> | undefined;
+  };
+  /** delete the array element with specified index (negative integers count from the end). throws an error if top level container is not an array */
+  ["auth_invitations_delete_elem_input"]: {
+    data?: number | undefined;
+  };
+  /** delete key/value pair or string element. key/value pairs are matched based on their key value */
+  ["auth_invitations_delete_key_input"]: {
+    data?: string | undefined;
+  };
+  /** input type for inserting data into table "auth.invitations" */
+  ["auth_invitations_insert_input"]: {
+    created_at?: ModelTypes["timestamptz"] | undefined;
+    data?: ModelTypes["jsonb"] | undefined;
+    id?: ModelTypes["uuid"] | undefined;
+  };
+  /** aggregate max on columns */
+  ["auth_invitations_max_fields"]: {
+    created_at?: ModelTypes["timestamptz"] | undefined;
+    id?: ModelTypes["uuid"] | undefined;
+  };
+  /** aggregate min on columns */
+  ["auth_invitations_min_fields"]: {
+    created_at?: ModelTypes["timestamptz"] | undefined;
+    id?: ModelTypes["uuid"] | undefined;
+  };
+  /** response of any mutation on the table "auth.invitations" */
+  ["auth_invitations_mutation_response"]: {
+    /** number of rows affected by the mutation */
+    affected_rows: number;
+    /** data from the rows affected by the mutation */
+    returning: Array<ModelTypes["auth_invitations"]>;
+  };
+  /** on_conflict condition type for table "auth.invitations" */
+  ["auth_invitations_on_conflict"]: {
+    constraint: ModelTypes["auth_invitations_constraint"];
+    update_columns: Array<ModelTypes["auth_invitations_update_column"]>;
+    where?: ModelTypes["auth_invitations_bool_exp"] | undefined;
+  };
+  /** Ordering options when selecting data from "auth.invitations". */
+  ["auth_invitations_order_by"]: {
+    created_at?: ModelTypes["order_by"] | undefined;
+    data?: ModelTypes["order_by"] | undefined;
+    id?: ModelTypes["order_by"] | undefined;
+  };
+  /** primary key columns input for table: auth_invitations */
+  ["auth_invitations_pk_columns_input"]: {
+    id: ModelTypes["uuid"];
+  };
+  /** prepend existing jsonb value of filtered columns with new jsonb value */
+  ["auth_invitations_prepend_input"]: {
+    data?: ModelTypes["jsonb"] | undefined;
+  };
+  ["auth_invitations_select_column"]: auth_invitations_select_column;
+  /** input type for updating data in table "auth.invitations" */
+  ["auth_invitations_set_input"]: {
+    created_at?: ModelTypes["timestamptz"] | undefined;
+    data?: ModelTypes["jsonb"] | undefined;
+    id?: ModelTypes["uuid"] | undefined;
+  };
+  /** Streaming cursor of the table "auth_invitations" */
+  ["auth_invitations_stream_cursor_input"]: {
+    /** Stream column input with initial value */
+    initial_value: ModelTypes["auth_invitations_stream_cursor_value_input"];
+    /** cursor ordering */
+    ordering?: ModelTypes["cursor_ordering"] | undefined;
+  };
+  /** Initial value of the column from where the streaming should start */
+  ["auth_invitations_stream_cursor_value_input"]: {
+    created_at?: ModelTypes["timestamptz"] | undefined;
+    data?: ModelTypes["jsonb"] | undefined;
+    id?: ModelTypes["uuid"] | undefined;
+  };
+  ["auth_invitations_update_column"]: auth_invitations_update_column;
+  ["auth_invitations_updates"]: {
+    /** append existing jsonb value of filtered columns with new jsonb value */
+    _append?: ModelTypes["auth_invitations_append_input"] | undefined;
+    /** delete the field or element with specified path (for JSON arrays, negative integers count from the end) */
+    _delete_at_path?:
+      | ModelTypes["auth_invitations_delete_at_path_input"]
+      | undefined;
+    /** delete the array element with specified index (negative integers count from the end). throws an error if top level container is not an array */
+    _delete_elem?: ModelTypes["auth_invitations_delete_elem_input"] | undefined;
+    /** delete key/value pair or string element. key/value pairs are matched based on their key value */
+    _delete_key?: ModelTypes["auth_invitations_delete_key_input"] | undefined;
+    /** prepend existing jsonb value of filtered columns with new jsonb value */
+    _prepend?: ModelTypes["auth_invitations_prepend_input"] | undefined;
+    /** sets the columns of the filtered rows to the given values */
+    _set?: ModelTypes["auth_invitations_set_input"] | undefined;
+    where: ModelTypes["auth_invitations_bool_exp"];
+  };
+  /** columns and relationships of "auth.users" */
+  ["auth_users"]: {
+    created_at: ModelTypes["timestamptz"];
+    id: ModelTypes["uuid"];
+    invitation_id: ModelTypes["uuid"];
+    last_active_at: ModelTypes["timestamptz"];
+    updated_at: ModelTypes["timestamptz"];
+    username: ModelTypes["citext"];
+  };
+  /** aggregated selection of "auth.users" */
+  ["auth_users_aggregate"]: {
+    aggregate?: ModelTypes["auth_users_aggregate_fields"] | undefined;
+    nodes: Array<ModelTypes["auth_users"]>;
+  };
+  /** aggregate fields of "auth.users" */
+  ["auth_users_aggregate_fields"]: {
+    count: number;
+    max?: ModelTypes["auth_users_max_fields"] | undefined;
+    min?: ModelTypes["auth_users_min_fields"] | undefined;
+  };
+  /** Boolean expression to filter rows from the table "auth.users". All fields are combined with a logical 'AND'. */
+  ["auth_users_bool_exp"]: {
+    _and?: Array<ModelTypes["auth_users_bool_exp"]> | undefined;
+    _not?: ModelTypes["auth_users_bool_exp"] | undefined;
+    _or?: Array<ModelTypes["auth_users_bool_exp"]> | undefined;
+    created_at?: ModelTypes["timestamptz_comparison_exp"] | undefined;
+    id?: ModelTypes["uuid_comparison_exp"] | undefined;
+    invitation_id?: ModelTypes["uuid_comparison_exp"] | undefined;
+    last_active_at?: ModelTypes["timestamptz_comparison_exp"] | undefined;
+    updated_at?: ModelTypes["timestamptz_comparison_exp"] | undefined;
+    username?: ModelTypes["citext_comparison_exp"] | undefined;
+  };
+  ["auth_users_constraint"]: auth_users_constraint;
+  /** input type for inserting data into table "auth.users" */
+  ["auth_users_insert_input"]: {
+    created_at?: ModelTypes["timestamptz"] | undefined;
+    id?: ModelTypes["uuid"] | undefined;
+    invitation_id?: ModelTypes["uuid"] | undefined;
+    last_active_at?: ModelTypes["timestamptz"] | undefined;
+    updated_at?: ModelTypes["timestamptz"] | undefined;
+    username?: ModelTypes["citext"] | undefined;
+  };
+  /** aggregate max on columns */
+  ["auth_users_max_fields"]: {
+    created_at?: ModelTypes["timestamptz"] | undefined;
+    id?: ModelTypes["uuid"] | undefined;
+    invitation_id?: ModelTypes["uuid"] | undefined;
+    last_active_at?: ModelTypes["timestamptz"] | undefined;
+    updated_at?: ModelTypes["timestamptz"] | undefined;
+    username?: ModelTypes["citext"] | undefined;
+  };
+  /** aggregate min on columns */
+  ["auth_users_min_fields"]: {
+    created_at?: ModelTypes["timestamptz"] | undefined;
+    id?: ModelTypes["uuid"] | undefined;
+    invitation_id?: ModelTypes["uuid"] | undefined;
+    last_active_at?: ModelTypes["timestamptz"] | undefined;
+    updated_at?: ModelTypes["timestamptz"] | undefined;
+    username?: ModelTypes["citext"] | undefined;
+  };
+  /** response of any mutation on the table "auth.users" */
+  ["auth_users_mutation_response"]: {
+    /** number of rows affected by the mutation */
+    affected_rows: number;
+    /** data from the rows affected by the mutation */
+    returning: Array<ModelTypes["auth_users"]>;
+  };
+  /** on_conflict condition type for table "auth.users" */
+  ["auth_users_on_conflict"]: {
+    constraint: ModelTypes["auth_users_constraint"];
+    update_columns: Array<ModelTypes["auth_users_update_column"]>;
+    where?: ModelTypes["auth_users_bool_exp"] | undefined;
+  };
+  /** Ordering options when selecting data from "auth.users". */
+  ["auth_users_order_by"]: {
+    created_at?: ModelTypes["order_by"] | undefined;
+    id?: ModelTypes["order_by"] | undefined;
+    invitation_id?: ModelTypes["order_by"] | undefined;
+    last_active_at?: ModelTypes["order_by"] | undefined;
+    updated_at?: ModelTypes["order_by"] | undefined;
+    username?: ModelTypes["order_by"] | undefined;
+  };
+  /** primary key columns input for table: auth_users */
+  ["auth_users_pk_columns_input"]: {
+    id: ModelTypes["uuid"];
+  };
+  ["auth_users_select_column"]: auth_users_select_column;
+  /** input type for updating data in table "auth.users" */
+  ["auth_users_set_input"]: {
+    created_at?: ModelTypes["timestamptz"] | undefined;
+    id?: ModelTypes["uuid"] | undefined;
+    invitation_id?: ModelTypes["uuid"] | undefined;
+    last_active_at?: ModelTypes["timestamptz"] | undefined;
+    updated_at?: ModelTypes["timestamptz"] | undefined;
+    username?: ModelTypes["citext"] | undefined;
+  };
+  /** Streaming cursor of the table "auth_users" */
+  ["auth_users_stream_cursor_input"]: {
+    /** Stream column input with initial value */
+    initial_value: ModelTypes["auth_users_stream_cursor_value_input"];
+    /** cursor ordering */
+    ordering?: ModelTypes["cursor_ordering"] | undefined;
+  };
+  /** Initial value of the column from where the streaming should start */
+  ["auth_users_stream_cursor_value_input"]: {
+    created_at?: ModelTypes["timestamptz"] | undefined;
+    id?: ModelTypes["uuid"] | undefined;
+    invitation_id?: ModelTypes["uuid"] | undefined;
+    last_active_at?: ModelTypes["timestamptz"] | undefined;
+    updated_at?: ModelTypes["timestamptz"] | undefined;
+    username?: ModelTypes["citext"] | undefined;
+  };
+  ["auth_users_update_column"]: auth_users_update_column;
+  ["auth_users_updates"]: {
+    /** sets the columns of the filtered rows to the given values */
+    _set?: ModelTypes["auth_users_set_input"] | undefined;
+    where: ModelTypes["auth_users_bool_exp"];
+  };
+  ["citext"]: any;
+  /** Boolean expression to compare columns of type "citext". All fields are combined with logical 'AND'. */
+  ["citext_comparison_exp"]: {
+    _eq?: ModelTypes["citext"] | undefined;
+    _gt?: ModelTypes["citext"] | undefined;
+    _gte?: ModelTypes["citext"] | undefined;
+    /** does the column match the given case-insensitive pattern */
+    _ilike?: ModelTypes["citext"] | undefined;
+    _in?: Array<ModelTypes["citext"]> | undefined;
+    /** does the column match the given POSIX regular expression, case insensitive */
+    _iregex?: ModelTypes["citext"] | undefined;
+    _is_null?: boolean | undefined;
+    /** does the column match the given pattern */
+    _like?: ModelTypes["citext"] | undefined;
+    _lt?: ModelTypes["citext"] | undefined;
+    _lte?: ModelTypes["citext"] | undefined;
+    _neq?: ModelTypes["citext"] | undefined;
+    /** does the column NOT match the given case-insensitive pattern */
+    _nilike?: ModelTypes["citext"] | undefined;
+    _nin?: Array<ModelTypes["citext"]> | undefined;
+    /** does the column NOT match the given POSIX regular expression, case insensitive */
+    _niregex?: ModelTypes["citext"] | undefined;
+    /** does the column NOT match the given pattern */
+    _nlike?: ModelTypes["citext"] | undefined;
+    /** does the column NOT match the given POSIX regular expression, case sensitive */
+    _nregex?: ModelTypes["citext"] | undefined;
+    /** does the column NOT match the given SQL regular expression */
+    _nsimilar?: ModelTypes["citext"] | undefined;
+    /** does the column match the given POSIX regular expression, case sensitive */
+    _regex?: ModelTypes["citext"] | undefined;
+    /** does the column match the given SQL regular expression */
+    _similar?: ModelTypes["citext"] | undefined;
+  };
+  ["cursor_ordering"]: cursor_ordering;
+  ["jsonb"]: any;
+  ["jsonb_cast_exp"]: {
+    String?: ModelTypes["String_comparison_exp"] | undefined;
+  };
+  /** Boolean expression to compare columns of type "jsonb". All fields are combined with logical 'AND'. */
+  ["jsonb_comparison_exp"]: {
+    _cast?: ModelTypes["jsonb_cast_exp"] | undefined;
+    /** is the column contained in the given json value */
+    _contained_in?: ModelTypes["jsonb"] | undefined;
+    /** does the column contain the given json value at the top level */
+    _contains?: ModelTypes["jsonb"] | undefined;
+    _eq?: ModelTypes["jsonb"] | undefined;
+    _gt?: ModelTypes["jsonb"] | undefined;
+    _gte?: ModelTypes["jsonb"] | undefined;
+    /** does the string exist as a top-level key in the column */
+    _has_key?: string | undefined;
+    /** do all of these strings exist as top-level keys in the column */
+    _has_keys_all?: Array<string> | undefined;
+    /** do any of these strings exist as top-level keys in the column */
+    _has_keys_any?: Array<string> | undefined;
+    _in?: Array<ModelTypes["jsonb"]> | undefined;
+    _is_null?: boolean | undefined;
+    _lt?: ModelTypes["jsonb"] | undefined;
+    _lte?: ModelTypes["jsonb"] | undefined;
+    _neq?: ModelTypes["jsonb"] | undefined;
+    _nin?: Array<ModelTypes["jsonb"]> | undefined;
+  };
+  /** mutation root */
+  ["mutation_root"]: {
+    /** delete data from the table: "auth.invitations" */
+    delete_auth_invitations?:
+      | ModelTypes["auth_invitations_mutation_response"]
+      | undefined;
+    /** delete single row from the table: "auth.invitations" */
+    delete_auth_invitations_by_pk?: ModelTypes["auth_invitations"] | undefined;
+    /** delete data from the table: "auth.users" */
+    delete_auth_users?: ModelTypes["auth_users_mutation_response"] | undefined;
+    /** delete single row from the table: "auth.users" */
+    delete_auth_users_by_pk?: ModelTypes["auth_users"] | undefined;
+    /** insert data into the table: "auth.invitations" */
+    insert_auth_invitations?:
+      | ModelTypes["auth_invitations_mutation_response"]
+      | undefined;
+    /** insert a single row into the table: "auth.invitations" */
+    insert_auth_invitations_one?: ModelTypes["auth_invitations"] | undefined;
+    /** insert data into the table: "auth.users" */
+    insert_auth_users?: ModelTypes["auth_users_mutation_response"] | undefined;
+    /** insert a single row into the table: "auth.users" */
+    insert_auth_users_one?: ModelTypes["auth_users"] | undefined;
+    /** update data of the table: "auth.invitations" */
+    update_auth_invitations?:
+      | ModelTypes["auth_invitations_mutation_response"]
+      | undefined;
+    /** update single row of the table: "auth.invitations" */
+    update_auth_invitations_by_pk?: ModelTypes["auth_invitations"] | undefined;
+    /** update multiples rows of table: "auth.invitations" */
+    update_auth_invitations_many?:
+      | Array<ModelTypes["auth_invitations_mutation_response"] | undefined>
+      | undefined;
+    /** update data of the table: "auth.users" */
+    update_auth_users?: ModelTypes["auth_users_mutation_response"] | undefined;
+    /** update single row of the table: "auth.users" */
+    update_auth_users_by_pk?: ModelTypes["auth_users"] | undefined;
+    /** update multiples rows of table: "auth.users" */
+    update_auth_users_many?:
+      | Array<ModelTypes["auth_users_mutation_response"] | undefined>
+      | undefined;
+  };
+  ["order_by"]: order_by;
+  ["query_root"]: {
+    /** fetch data from the table: "auth.invitations" */
+    auth_invitations: Array<ModelTypes["auth_invitations"]>;
+    /** fetch aggregated fields from the table: "auth.invitations" */
+    auth_invitations_aggregate: ModelTypes["auth_invitations_aggregate"];
+    /** fetch data from the table: "auth.invitations" using primary key columns */
+    auth_invitations_by_pk?: ModelTypes["auth_invitations"] | undefined;
+    /** fetch data from the table: "auth.users" */
+    auth_users: Array<ModelTypes["auth_users"]>;
+    /** fetch aggregated fields from the table: "auth.users" */
+    auth_users_aggregate: ModelTypes["auth_users_aggregate"];
+    /** fetch data from the table: "auth.users" using primary key columns */
+    auth_users_by_pk?: ModelTypes["auth_users"] | undefined;
+  };
+  ["subscription_root"]: {
+    /** fetch data from the table: "auth.invitations" */
+    auth_invitations: Array<ModelTypes["auth_invitations"]>;
+    /** fetch aggregated fields from the table: "auth.invitations" */
+    auth_invitations_aggregate: ModelTypes["auth_invitations_aggregate"];
+    /** fetch data from the table: "auth.invitations" using primary key columns */
+    auth_invitations_by_pk?: ModelTypes["auth_invitations"] | undefined;
+    /** fetch data from the table in a streaming manner : "auth.invitations" */
+    auth_invitations_stream: Array<ModelTypes["auth_invitations"]>;
+    /** fetch data from the table: "auth.users" */
+    auth_users: Array<ModelTypes["auth_users"]>;
+    /** fetch aggregated fields from the table: "auth.users" */
+    auth_users_aggregate: ModelTypes["auth_users_aggregate"];
+    /** fetch data from the table: "auth.users" using primary key columns */
+    auth_users_by_pk?: ModelTypes["auth_users"] | undefined;
+    /** fetch data from the table in a streaming manner : "auth.users" */
+    auth_users_stream: Array<ModelTypes["auth_users"]>;
+  };
+  ["timestamptz"]: any;
+  /** Boolean expression to compare columns of type "timestamptz". All fields are combined with logical 'AND'. */
+  ["timestamptz_comparison_exp"]: {
+    _eq?: ModelTypes["timestamptz"] | undefined;
+    _gt?: ModelTypes["timestamptz"] | undefined;
+    _gte?: ModelTypes["timestamptz"] | undefined;
+    _in?: Array<ModelTypes["timestamptz"]> | undefined;
+    _is_null?: boolean | undefined;
+    _lt?: ModelTypes["timestamptz"] | undefined;
+    _lte?: ModelTypes["timestamptz"] | undefined;
+    _neq?: ModelTypes["timestamptz"] | undefined;
+    _nin?: Array<ModelTypes["timestamptz"]> | undefined;
+  };
+  ["uuid"]: any;
+  /** Boolean expression to compare columns of type "uuid". All fields are combined with logical 'AND'. */
+  ["uuid_comparison_exp"]: {
+    _eq?: ModelTypes["uuid"] | undefined;
+    _gt?: ModelTypes["uuid"] | undefined;
+    _gte?: ModelTypes["uuid"] | undefined;
+    _in?: Array<ModelTypes["uuid"]> | undefined;
+    _is_null?: boolean | undefined;
+    _lt?: ModelTypes["uuid"] | undefined;
+    _lte?: ModelTypes["uuid"] | undefined;
+    _neq?: ModelTypes["uuid"] | undefined;
+    _nin?: Array<ModelTypes["uuid"]> | undefined;
+  };
+};
+
+export type GraphQLTypes = {
+  /** Boolean expression to compare columns of type "String". All fields are combined with logical 'AND'. */
+  ["String_comparison_exp"]: {
+    _eq?: string | undefined;
+    _gt?: string | undefined;
+    _gte?: string | undefined;
+    /** does the column match the given case-insensitive pattern */
+    _ilike?: string | undefined;
+    _in?: Array<string> | undefined;
+    /** does the column match the given POSIX regular expression, case insensitive */
+    _iregex?: string | undefined;
+    _is_null?: boolean | undefined;
+    /** does the column match the given pattern */
+    _like?: string | undefined;
+    _lt?: string | undefined;
+    _lte?: string | undefined;
+    _neq?: string | undefined;
+    /** does the column NOT match the given case-insensitive pattern */
+    _nilike?: string | undefined;
+    _nin?: Array<string> | undefined;
+    /** does the column NOT match the given POSIX regular expression, case insensitive */
+    _niregex?: string | undefined;
+    /** does the column NOT match the given pattern */
+    _nlike?: string | undefined;
+    /** does the column NOT match the given POSIX regular expression, case sensitive */
+    _nregex?: string | undefined;
+    /** does the column NOT match the given SQL regular expression */
+    _nsimilar?: string | undefined;
+    /** does the column match the given POSIX regular expression, case sensitive */
+    _regex?: string | undefined;
+    /** does the column match the given SQL regular expression */
+    _similar?: string | undefined;
+  };
+  /** ids are beta invite codes */
+  ["auth_invitations"]: {
+    __typename: "auth_invitations";
+    created_at: GraphQLTypes["timestamptz"];
+    data?: GraphQLTypes["jsonb"] | undefined;
+    id: GraphQLTypes["uuid"];
+  };
+  /** aggregated selection of "auth.invitations" */
+  ["auth_invitations_aggregate"]: {
+    __typename: "auth_invitations_aggregate";
+    aggregate?: GraphQLTypes["auth_invitations_aggregate_fields"] | undefined;
+    nodes: Array<GraphQLTypes["auth_invitations"]>;
+  };
+  /** aggregate fields of "auth.invitations" */
+  ["auth_invitations_aggregate_fields"]: {
+    __typename: "auth_invitations_aggregate_fields";
+    count: number;
+    max?: GraphQLTypes["auth_invitations_max_fields"] | undefined;
+    min?: GraphQLTypes["auth_invitations_min_fields"] | undefined;
+  };
+  /** append existing jsonb value of filtered columns with new jsonb value */
+  ["auth_invitations_append_input"]: {
+    data?: GraphQLTypes["jsonb"] | undefined;
+  };
+  /** Boolean expression to filter rows from the table "auth.invitations". All fields are combined with a logical 'AND'. */
+  ["auth_invitations_bool_exp"]: {
+    _and?: Array<GraphQLTypes["auth_invitations_bool_exp"]> | undefined;
+    _not?: GraphQLTypes["auth_invitations_bool_exp"] | undefined;
+    _or?: Array<GraphQLTypes["auth_invitations_bool_exp"]> | undefined;
+    created_at?: GraphQLTypes["timestamptz_comparison_exp"] | undefined;
+    data?: GraphQLTypes["jsonb_comparison_exp"] | undefined;
+    id?: GraphQLTypes["uuid_comparison_exp"] | undefined;
+  };
+  /** unique or primary key constraints on table "auth.invitations" */
+  ["auth_invitations_constraint"]: auth_invitations_constraint;
+  /** delete the field or element with specified path (for JSON arrays, negative integers count from the end) */
+  ["auth_invitations_delete_at_path_input"]: {
+    data?: Array<string> | undefined;
+  };
+  /** delete the array element with specified index (negative integers count from the end). throws an error if top level container is not an array */
+  ["auth_invitations_delete_elem_input"]: {
+    data?: number | undefined;
+  };
+  /** delete key/value pair or string element. key/value pairs are matched based on their key value */
+  ["auth_invitations_delete_key_input"]: {
+    data?: string | undefined;
+  };
+  /** input type for inserting data into table "auth.invitations" */
+  ["auth_invitations_insert_input"]: {
+    created_at?: GraphQLTypes["timestamptz"] | undefined;
+    data?: GraphQLTypes["jsonb"] | undefined;
+    id?: GraphQLTypes["uuid"] | undefined;
+  };
+  /** aggregate max on columns */
+  ["auth_invitations_max_fields"]: {
+    __typename: "auth_invitations_max_fields";
+    created_at?: GraphQLTypes["timestamptz"] | undefined;
+    id?: GraphQLTypes["uuid"] | undefined;
+  };
+  /** aggregate min on columns */
+  ["auth_invitations_min_fields"]: {
+    __typename: "auth_invitations_min_fields";
+    created_at?: GraphQLTypes["timestamptz"] | undefined;
+    id?: GraphQLTypes["uuid"] | undefined;
+  };
+  /** response of any mutation on the table "auth.invitations" */
+  ["auth_invitations_mutation_response"]: {
+    __typename: "auth_invitations_mutation_response";
+    /** number of rows affected by the mutation */
+    affected_rows: number;
+    /** data from the rows affected by the mutation */
+    returning: Array<GraphQLTypes["auth_invitations"]>;
+  };
+  /** on_conflict condition type for table "auth.invitations" */
+  ["auth_invitations_on_conflict"]: {
+    constraint: GraphQLTypes["auth_invitations_constraint"];
+    update_columns: Array<GraphQLTypes["auth_invitations_update_column"]>;
+    where?: GraphQLTypes["auth_invitations_bool_exp"] | undefined;
+  };
+  /** Ordering options when selecting data from "auth.invitations". */
+  ["auth_invitations_order_by"]: {
+    created_at?: GraphQLTypes["order_by"] | undefined;
+    data?: GraphQLTypes["order_by"] | undefined;
+    id?: GraphQLTypes["order_by"] | undefined;
+  };
+  /** primary key columns input for table: auth_invitations */
+  ["auth_invitations_pk_columns_input"]: {
+    id: GraphQLTypes["uuid"];
+  };
+  /** prepend existing jsonb value of filtered columns with new jsonb value */
+  ["auth_invitations_prepend_input"]: {
+    data?: GraphQLTypes["jsonb"] | undefined;
+  };
+  /** select columns of table "auth.invitations" */
+  ["auth_invitations_select_column"]: auth_invitations_select_column;
+  /** input type for updating data in table "auth.invitations" */
+  ["auth_invitations_set_input"]: {
+    created_at?: GraphQLTypes["timestamptz"] | undefined;
+    data?: GraphQLTypes["jsonb"] | undefined;
+    id?: GraphQLTypes["uuid"] | undefined;
+  };
+  /** Streaming cursor of the table "auth_invitations" */
+  ["auth_invitations_stream_cursor_input"]: {
+    /** Stream column input with initial value */
+    initial_value: GraphQLTypes["auth_invitations_stream_cursor_value_input"];
+    /** cursor ordering */
+    ordering?: GraphQLTypes["cursor_ordering"] | undefined;
+  };
+  /** Initial value of the column from where the streaming should start */
+  ["auth_invitations_stream_cursor_value_input"]: {
+    created_at?: GraphQLTypes["timestamptz"] | undefined;
+    data?: GraphQLTypes["jsonb"] | undefined;
+    id?: GraphQLTypes["uuid"] | undefined;
+  };
+  /** update columns of table "auth.invitations" */
+  ["auth_invitations_update_column"]: auth_invitations_update_column;
+  ["auth_invitations_updates"]: {
+    /** append existing jsonb value of filtered columns with new jsonb value */
+    _append?: GraphQLTypes["auth_invitations_append_input"] | undefined;
+    /** delete the field or element with specified path (for JSON arrays, negative integers count from the end) */
+    _delete_at_path?:
+      | GraphQLTypes["auth_invitations_delete_at_path_input"]
+      | undefined;
+    /** delete the array element with specified index (negative integers count from the end). throws an error if top level container is not an array */
+    _delete_elem?:
+      | GraphQLTypes["auth_invitations_delete_elem_input"]
+      | undefined;
+    /** delete key/value pair or string element. key/value pairs are matched based on their key value */
+    _delete_key?: GraphQLTypes["auth_invitations_delete_key_input"] | undefined;
+    /** prepend existing jsonb value of filtered columns with new jsonb value */
+    _prepend?: GraphQLTypes["auth_invitations_prepend_input"] | undefined;
+    /** sets the columns of the filtered rows to the given values */
+    _set?: GraphQLTypes["auth_invitations_set_input"] | undefined;
+    where: GraphQLTypes["auth_invitations_bool_exp"];
+  };
+  /** columns and relationships of "auth.users" */
+  ["auth_users"]: {
+    __typename: "auth_users";
+    created_at: GraphQLTypes["timestamptz"];
+    id: GraphQLTypes["uuid"];
+    invitation_id: GraphQLTypes["uuid"];
+    last_active_at: GraphQLTypes["timestamptz"];
+    updated_at: GraphQLTypes["timestamptz"];
+    username: GraphQLTypes["citext"];
+  };
+  /** aggregated selection of "auth.users" */
+  ["auth_users_aggregate"]: {
+    __typename: "auth_users_aggregate";
+    aggregate?: GraphQLTypes["auth_users_aggregate_fields"] | undefined;
+    nodes: Array<GraphQLTypes["auth_users"]>;
+  };
+  /** aggregate fields of "auth.users" */
+  ["auth_users_aggregate_fields"]: {
+    __typename: "auth_users_aggregate_fields";
+    count: number;
+    max?: GraphQLTypes["auth_users_max_fields"] | undefined;
+    min?: GraphQLTypes["auth_users_min_fields"] | undefined;
+  };
+  /** Boolean expression to filter rows from the table "auth.users". All fields are combined with a logical 'AND'. */
+  ["auth_users_bool_exp"]: {
+    _and?: Array<GraphQLTypes["auth_users_bool_exp"]> | undefined;
+    _not?: GraphQLTypes["auth_users_bool_exp"] | undefined;
+    _or?: Array<GraphQLTypes["auth_users_bool_exp"]> | undefined;
+    created_at?: GraphQLTypes["timestamptz_comparison_exp"] | undefined;
+    id?: GraphQLTypes["uuid_comparison_exp"] | undefined;
+    invitation_id?: GraphQLTypes["uuid_comparison_exp"] | undefined;
+    last_active_at?: GraphQLTypes["timestamptz_comparison_exp"] | undefined;
+    updated_at?: GraphQLTypes["timestamptz_comparison_exp"] | undefined;
+    username?: GraphQLTypes["citext_comparison_exp"] | undefined;
+  };
+  /** unique or primary key constraints on table "auth.users" */
+  ["auth_users_constraint"]: auth_users_constraint;
+  /** input type for inserting data into table "auth.users" */
+  ["auth_users_insert_input"]: {
+    created_at?: GraphQLTypes["timestamptz"] | undefined;
+    id?: GraphQLTypes["uuid"] | undefined;
+    invitation_id?: GraphQLTypes["uuid"] | undefined;
+    last_active_at?: GraphQLTypes["timestamptz"] | undefined;
+    updated_at?: GraphQLTypes["timestamptz"] | undefined;
+    username?: GraphQLTypes["citext"] | undefined;
+  };
+  /** aggregate max on columns */
+  ["auth_users_max_fields"]: {
+    __typename: "auth_users_max_fields";
+    created_at?: GraphQLTypes["timestamptz"] | undefined;
+    id?: GraphQLTypes["uuid"] | undefined;
+    invitation_id?: GraphQLTypes["uuid"] | undefined;
+    last_active_at?: GraphQLTypes["timestamptz"] | undefined;
+    updated_at?: GraphQLTypes["timestamptz"] | undefined;
+    username?: GraphQLTypes["citext"] | undefined;
+  };
+  /** aggregate min on columns */
+  ["auth_users_min_fields"]: {
+    __typename: "auth_users_min_fields";
+    created_at?: GraphQLTypes["timestamptz"] | undefined;
+    id?: GraphQLTypes["uuid"] | undefined;
+    invitation_id?: GraphQLTypes["uuid"] | undefined;
+    last_active_at?: GraphQLTypes["timestamptz"] | undefined;
+    updated_at?: GraphQLTypes["timestamptz"] | undefined;
+    username?: GraphQLTypes["citext"] | undefined;
+  };
+  /** response of any mutation on the table "auth.users" */
+  ["auth_users_mutation_response"]: {
+    __typename: "auth_users_mutation_response";
+    /** number of rows affected by the mutation */
+    affected_rows: number;
+    /** data from the rows affected by the mutation */
+    returning: Array<GraphQLTypes["auth_users"]>;
+  };
+  /** on_conflict condition type for table "auth.users" */
+  ["auth_users_on_conflict"]: {
+    constraint: GraphQLTypes["auth_users_constraint"];
+    update_columns: Array<GraphQLTypes["auth_users_update_column"]>;
+    where?: GraphQLTypes["auth_users_bool_exp"] | undefined;
+  };
+  /** Ordering options when selecting data from "auth.users". */
+  ["auth_users_order_by"]: {
+    created_at?: GraphQLTypes["order_by"] | undefined;
+    id?: GraphQLTypes["order_by"] | undefined;
+    invitation_id?: GraphQLTypes["order_by"] | undefined;
+    last_active_at?: GraphQLTypes["order_by"] | undefined;
+    updated_at?: GraphQLTypes["order_by"] | undefined;
+    username?: GraphQLTypes["order_by"] | undefined;
+  };
+  /** primary key columns input for table: auth_users */
+  ["auth_users_pk_columns_input"]: {
+    id: GraphQLTypes["uuid"];
+  };
+  /** select columns of table "auth.users" */
+  ["auth_users_select_column"]: auth_users_select_column;
+  /** input type for updating data in table "auth.users" */
+  ["auth_users_set_input"]: {
+    created_at?: GraphQLTypes["timestamptz"] | undefined;
+    id?: GraphQLTypes["uuid"] | undefined;
+    invitation_id?: GraphQLTypes["uuid"] | undefined;
+    last_active_at?: GraphQLTypes["timestamptz"] | undefined;
+    updated_at?: GraphQLTypes["timestamptz"] | undefined;
+    username?: GraphQLTypes["citext"] | undefined;
+  };
+  /** Streaming cursor of the table "auth_users" */
+  ["auth_users_stream_cursor_input"]: {
+    /** Stream column input with initial value */
+    initial_value: GraphQLTypes["auth_users_stream_cursor_value_input"];
+    /** cursor ordering */
+    ordering?: GraphQLTypes["cursor_ordering"] | undefined;
+  };
+  /** Initial value of the column from where the streaming should start */
+  ["auth_users_stream_cursor_value_input"]: {
+    created_at?: GraphQLTypes["timestamptz"] | undefined;
+    id?: GraphQLTypes["uuid"] | undefined;
+    invitation_id?: GraphQLTypes["uuid"] | undefined;
+    last_active_at?: GraphQLTypes["timestamptz"] | undefined;
+    updated_at?: GraphQLTypes["timestamptz"] | undefined;
+    username?: GraphQLTypes["citext"] | undefined;
+  };
+  /** update columns of table "auth.users" */
+  ["auth_users_update_column"]: auth_users_update_column;
+  ["auth_users_updates"]: {
+    /** sets the columns of the filtered rows to the given values */
+    _set?: GraphQLTypes["auth_users_set_input"] | undefined;
+    where: GraphQLTypes["auth_users_bool_exp"];
+  };
+  ["citext"]: "scalar" & { name: "citext" };
+  /** Boolean expression to compare columns of type "citext". All fields are combined with logical 'AND'. */
+  ["citext_comparison_exp"]: {
+    _eq?: GraphQLTypes["citext"] | undefined;
+    _gt?: GraphQLTypes["citext"] | undefined;
+    _gte?: GraphQLTypes["citext"] | undefined;
+    /** does the column match the given case-insensitive pattern */
+    _ilike?: GraphQLTypes["citext"] | undefined;
+    _in?: Array<GraphQLTypes["citext"]> | undefined;
+    /** does the column match the given POSIX regular expression, case insensitive */
+    _iregex?: GraphQLTypes["citext"] | undefined;
+    _is_null?: boolean | undefined;
+    /** does the column match the given pattern */
+    _like?: GraphQLTypes["citext"] | undefined;
+    _lt?: GraphQLTypes["citext"] | undefined;
+    _lte?: GraphQLTypes["citext"] | undefined;
+    _neq?: GraphQLTypes["citext"] | undefined;
+    /** does the column NOT match the given case-insensitive pattern */
+    _nilike?: GraphQLTypes["citext"] | undefined;
+    _nin?: Array<GraphQLTypes["citext"]> | undefined;
+    /** does the column NOT match the given POSIX regular expression, case insensitive */
+    _niregex?: GraphQLTypes["citext"] | undefined;
+    /** does the column NOT match the given pattern */
+    _nlike?: GraphQLTypes["citext"] | undefined;
+    /** does the column NOT match the given POSIX regular expression, case sensitive */
+    _nregex?: GraphQLTypes["citext"] | undefined;
+    /** does the column NOT match the given SQL regular expression */
+    _nsimilar?: GraphQLTypes["citext"] | undefined;
+    /** does the column match the given POSIX regular expression, case sensitive */
+    _regex?: GraphQLTypes["citext"] | undefined;
+    /** does the column match the given SQL regular expression */
+    _similar?: GraphQLTypes["citext"] | undefined;
+  };
+  /** ordering argument of a cursor */
+  ["cursor_ordering"]: cursor_ordering;
+  ["jsonb"]: "scalar" & { name: "jsonb" };
+  ["jsonb_cast_exp"]: {
+    String?: GraphQLTypes["String_comparison_exp"] | undefined;
+  };
+  /** Boolean expression to compare columns of type "jsonb". All fields are combined with logical 'AND'. */
+  ["jsonb_comparison_exp"]: {
+    _cast?: GraphQLTypes["jsonb_cast_exp"] | undefined;
+    /** is the column contained in the given json value */
+    _contained_in?: GraphQLTypes["jsonb"] | undefined;
+    /** does the column contain the given json value at the top level */
+    _contains?: GraphQLTypes["jsonb"] | undefined;
+    _eq?: GraphQLTypes["jsonb"] | undefined;
+    _gt?: GraphQLTypes["jsonb"] | undefined;
+    _gte?: GraphQLTypes["jsonb"] | undefined;
+    /** does the string exist as a top-level key in the column */
+    _has_key?: string | undefined;
+    /** do all of these strings exist as top-level keys in the column */
+    _has_keys_all?: Array<string> | undefined;
+    /** do any of these strings exist as top-level keys in the column */
+    _has_keys_any?: Array<string> | undefined;
+    _in?: Array<GraphQLTypes["jsonb"]> | undefined;
+    _is_null?: boolean | undefined;
+    _lt?: GraphQLTypes["jsonb"] | undefined;
+    _lte?: GraphQLTypes["jsonb"] | undefined;
+    _neq?: GraphQLTypes["jsonb"] | undefined;
+    _nin?: Array<GraphQLTypes["jsonb"]> | undefined;
+  };
+  /** mutation root */
+  ["mutation_root"]: {
+    __typename: "mutation_root";
+    /** delete data from the table: "auth.invitations" */
+    delete_auth_invitations?:
+      | GraphQLTypes["auth_invitations_mutation_response"]
+      | undefined;
+    /** delete single row from the table: "auth.invitations" */
+    delete_auth_invitations_by_pk?:
+      | GraphQLTypes["auth_invitations"]
+      | undefined;
+    /** delete data from the table: "auth.users" */
+    delete_auth_users?:
+      | GraphQLTypes["auth_users_mutation_response"]
+      | undefined;
+    /** delete single row from the table: "auth.users" */
+    delete_auth_users_by_pk?: GraphQLTypes["auth_users"] | undefined;
+    /** insert data into the table: "auth.invitations" */
+    insert_auth_invitations?:
+      | GraphQLTypes["auth_invitations_mutation_response"]
+      | undefined;
+    /** insert a single row into the table: "auth.invitations" */
+    insert_auth_invitations_one?: GraphQLTypes["auth_invitations"] | undefined;
+    /** insert data into the table: "auth.users" */
+    insert_auth_users?:
+      | GraphQLTypes["auth_users_mutation_response"]
+      | undefined;
+    /** insert a single row into the table: "auth.users" */
+    insert_auth_users_one?: GraphQLTypes["auth_users"] | undefined;
+    /** update data of the table: "auth.invitations" */
+    update_auth_invitations?:
+      | GraphQLTypes["auth_invitations_mutation_response"]
+      | undefined;
+    /** update single row of the table: "auth.invitations" */
+    update_auth_invitations_by_pk?:
+      | GraphQLTypes["auth_invitations"]
+      | undefined;
+    /** update multiples rows of table: "auth.invitations" */
+    update_auth_invitations_many?:
+      | Array<GraphQLTypes["auth_invitations_mutation_response"] | undefined>
+      | undefined;
+    /** update data of the table: "auth.users" */
+    update_auth_users?:
+      | GraphQLTypes["auth_users_mutation_response"]
+      | undefined;
+    /** update single row of the table: "auth.users" */
+    update_auth_users_by_pk?: GraphQLTypes["auth_users"] | undefined;
+    /** update multiples rows of table: "auth.users" */
+    update_auth_users_many?:
+      | Array<GraphQLTypes["auth_users_mutation_response"] | undefined>
+      | undefined;
+  };
+  /** column ordering options */
+  ["order_by"]: order_by;
+  ["query_root"]: {
+    __typename: "query_root";
+    /** fetch data from the table: "auth.invitations" */
+    auth_invitations: Array<GraphQLTypes["auth_invitations"]>;
+    /** fetch aggregated fields from the table: "auth.invitations" */
+    auth_invitations_aggregate: GraphQLTypes["auth_invitations_aggregate"];
+    /** fetch data from the table: "auth.invitations" using primary key columns */
+    auth_invitations_by_pk?: GraphQLTypes["auth_invitations"] | undefined;
+    /** fetch data from the table: "auth.users" */
+    auth_users: Array<GraphQLTypes["auth_users"]>;
+    /** fetch aggregated fields from the table: "auth.users" */
+    auth_users_aggregate: GraphQLTypes["auth_users_aggregate"];
+    /** fetch data from the table: "auth.users" using primary key columns */
+    auth_users_by_pk?: GraphQLTypes["auth_users"] | undefined;
+  };
+  ["subscription_root"]: {
+    __typename: "subscription_root";
+    /** fetch data from the table: "auth.invitations" */
+    auth_invitations: Array<GraphQLTypes["auth_invitations"]>;
+    /** fetch aggregated fields from the table: "auth.invitations" */
+    auth_invitations_aggregate: GraphQLTypes["auth_invitations_aggregate"];
+    /** fetch data from the table: "auth.invitations" using primary key columns */
+    auth_invitations_by_pk?: GraphQLTypes["auth_invitations"] | undefined;
+    /** fetch data from the table in a streaming manner : "auth.invitations" */
+    auth_invitations_stream: Array<GraphQLTypes["auth_invitations"]>;
+    /** fetch data from the table: "auth.users" */
+    auth_users: Array<GraphQLTypes["auth_users"]>;
+    /** fetch aggregated fields from the table: "auth.users" */
+    auth_users_aggregate: GraphQLTypes["auth_users_aggregate"];
+    /** fetch data from the table: "auth.users" using primary key columns */
+    auth_users_by_pk?: GraphQLTypes["auth_users"] | undefined;
+    /** fetch data from the table in a streaming manner : "auth.users" */
+    auth_users_stream: Array<GraphQLTypes["auth_users"]>;
+  };
+  ["timestamptz"]: "scalar" & { name: "timestamptz" };
+  /** Boolean expression to compare columns of type "timestamptz". All fields are combined with logical 'AND'. */
+  ["timestamptz_comparison_exp"]: {
+    _eq?: GraphQLTypes["timestamptz"] | undefined;
+    _gt?: GraphQLTypes["timestamptz"] | undefined;
+    _gte?: GraphQLTypes["timestamptz"] | undefined;
+    _in?: Array<GraphQLTypes["timestamptz"]> | undefined;
+    _is_null?: boolean | undefined;
+    _lt?: GraphQLTypes["timestamptz"] | undefined;
+    _lte?: GraphQLTypes["timestamptz"] | undefined;
+    _neq?: GraphQLTypes["timestamptz"] | undefined;
+    _nin?: Array<GraphQLTypes["timestamptz"]> | undefined;
+  };
+  ["uuid"]: "scalar" & { name: "uuid" };
+  /** Boolean expression to compare columns of type "uuid". All fields are combined with logical 'AND'. */
+  ["uuid_comparison_exp"]: {
+    _eq?: GraphQLTypes["uuid"] | undefined;
+    _gt?: GraphQLTypes["uuid"] | undefined;
+    _gte?: GraphQLTypes["uuid"] | undefined;
+    _in?: Array<GraphQLTypes["uuid"]> | undefined;
+    _is_null?: boolean | undefined;
+    _lt?: GraphQLTypes["uuid"] | undefined;
+    _lte?: GraphQLTypes["uuid"] | undefined;
+    _neq?: GraphQLTypes["uuid"] | undefined;
+    _nin?: Array<GraphQLTypes["uuid"]> | undefined;
+  };
+};
+/** unique or primary key constraints on table "auth.invitations" */
+export const enum auth_invitations_constraint {
+  invitations_pkey = "invitations_pkey",
+}
+/** select columns of table "auth.invitations" */
+export const enum auth_invitations_select_column {
+  created_at = "created_at",
+  data = "data",
+  id = "id",
+}
+/** update columns of table "auth.invitations" */
+export const enum auth_invitations_update_column {
+  created_at = "created_at",
+  data = "data",
+  id = "id",
+}
+/** unique or primary key constraints on table "auth.users" */
+export const enum auth_users_constraint {
+  users_invitation_id_key = "users_invitation_id_key",
+  users_pkey = "users_pkey",
+  users_username_key = "users_username_key",
+}
+/** select columns of table "auth.users" */
+export const enum auth_users_select_column {
+  created_at = "created_at",
+  id = "id",
+  invitation_id = "invitation_id",
+  last_active_at = "last_active_at",
+  updated_at = "updated_at",
+  username = "username",
+}
+/** update columns of table "auth.users" */
+export const enum auth_users_update_column {
+  created_at = "created_at",
+  id = "id",
+  invitation_id = "invitation_id",
+  last_active_at = "last_active_at",
+  updated_at = "updated_at",
+  username = "username",
+}
+/** ordering argument of a cursor */
+export const enum cursor_ordering {
+  ASC = "ASC",
+  DESC = "DESC",
+}
+/** column ordering options */
+export const enum order_by {
+  asc = "asc",
+  asc_nulls_first = "asc_nulls_first",
+  asc_nulls_last = "asc_nulls_last",
+  desc = "desc",
+  desc_nulls_first = "desc_nulls_first",
+  desc_nulls_last = "desc_nulls_last",
+}
+
+type ZEUS_VARIABLES = {
+  ["String_comparison_exp"]: ValueTypes["String_comparison_exp"];
+  ["auth_invitations_append_input"]: ValueTypes["auth_invitations_append_input"];
+  ["auth_invitations_bool_exp"]: ValueTypes["auth_invitations_bool_exp"];
+  ["auth_invitations_constraint"]: ValueTypes["auth_invitations_constraint"];
+  ["auth_invitations_delete_at_path_input"]: ValueTypes["auth_invitations_delete_at_path_input"];
+  ["auth_invitations_delete_elem_input"]: ValueTypes["auth_invitations_delete_elem_input"];
+  ["auth_invitations_delete_key_input"]: ValueTypes["auth_invitations_delete_key_input"];
+  ["auth_invitations_insert_input"]: ValueTypes["auth_invitations_insert_input"];
+  ["auth_invitations_on_conflict"]: ValueTypes["auth_invitations_on_conflict"];
+  ["auth_invitations_order_by"]: ValueTypes["auth_invitations_order_by"];
+  ["auth_invitations_pk_columns_input"]: ValueTypes["auth_invitations_pk_columns_input"];
+  ["auth_invitations_prepend_input"]: ValueTypes["auth_invitations_prepend_input"];
+  ["auth_invitations_select_column"]: ValueTypes["auth_invitations_select_column"];
+  ["auth_invitations_set_input"]: ValueTypes["auth_invitations_set_input"];
+  ["auth_invitations_stream_cursor_input"]: ValueTypes["auth_invitations_stream_cursor_input"];
+  ["auth_invitations_stream_cursor_value_input"]: ValueTypes["auth_invitations_stream_cursor_value_input"];
+  ["auth_invitations_update_column"]: ValueTypes["auth_invitations_update_column"];
+  ["auth_invitations_updates"]: ValueTypes["auth_invitations_updates"];
+  ["auth_users_bool_exp"]: ValueTypes["auth_users_bool_exp"];
+  ["auth_users_constraint"]: ValueTypes["auth_users_constraint"];
+  ["auth_users_insert_input"]: ValueTypes["auth_users_insert_input"];
+  ["auth_users_on_conflict"]: ValueTypes["auth_users_on_conflict"];
+  ["auth_users_order_by"]: ValueTypes["auth_users_order_by"];
+  ["auth_users_pk_columns_input"]: ValueTypes["auth_users_pk_columns_input"];
+  ["auth_users_select_column"]: ValueTypes["auth_users_select_column"];
+  ["auth_users_set_input"]: ValueTypes["auth_users_set_input"];
+  ["auth_users_stream_cursor_input"]: ValueTypes["auth_users_stream_cursor_input"];
+  ["auth_users_stream_cursor_value_input"]: ValueTypes["auth_users_stream_cursor_value_input"];
+  ["auth_users_update_column"]: ValueTypes["auth_users_update_column"];
+  ["auth_users_updates"]: ValueTypes["auth_users_updates"];
+  ["citext"]: ValueTypes["citext"];
+  ["citext_comparison_exp"]: ValueTypes["citext_comparison_exp"];
+  ["cursor_ordering"]: ValueTypes["cursor_ordering"];
+  ["jsonb"]: ValueTypes["jsonb"];
+  ["jsonb_cast_exp"]: ValueTypes["jsonb_cast_exp"];
+  ["jsonb_comparison_exp"]: ValueTypes["jsonb_comparison_exp"];
+  ["order_by"]: ValueTypes["order_by"];
+  ["timestamptz"]: ValueTypes["timestamptz"];
+  ["timestamptz_comparison_exp"]: ValueTypes["timestamptz_comparison_exp"];
+  ["uuid"]: ValueTypes["uuid"];
+  ["uuid_comparison_exp"]: ValueTypes["uuid_comparison_exp"];
+};

--- a/backend/workers/auth/tsconfig.json
+++ b/backend/workers/auth/tsconfig.json
@@ -1,0 +1,3 @@
+{
+  "extends": "../tsconfig.json"
+}

--- a/backend/workers/auth/wrangler.toml
+++ b/backend/workers/auth/wrangler.toml
@@ -1,0 +1,8 @@
+name = "auth"
+main = "src/index.ts"
+compatibility_date = "2022-09-24"
+node_compat = true
+
+[vars]
+HASURA_URL = "http://localhost:8112/v1/graphql"
+HASURA_SECRET = "myadminsecretkey"

--- a/yarn.lock
+++ b/yarn.lock
@@ -5096,7 +5096,7 @@
     "@solana/wallet-adapter-tokenpocket" "^0.4.7"
     "@solana/wallet-adapter-torus" "^0.11.14"
 
-"@solana/web3.js@1.43.2", "@solana/web3.js@1.52.0", "@solana/web3.js@^1.17.0", "@solana/web3.js@^1.21.0", "@solana/web3.js@^1.32.0", "@solana/web3.js@^1.35.1", "@solana/web3.js@^1.36.0", "@solana/web3.js@^1.37.1", "@solana/web3.js@^1.43.2", "@solana/web3.js@^1.50.1", "@solana/web3.js@^1.62.1":
+"@solana/web3.js@1.43.2", "@solana/web3.js@1.52.0", "@solana/web3.js@^1.17.0", "@solana/web3.js@^1.21.0", "@solana/web3.js@^1.32.0", "@solana/web3.js@^1.35.1", "@solana/web3.js@^1.36.0", "@solana/web3.js@^1.37.1", "@solana/web3.js@^1.43.2", "@solana/web3.js@^1.50.1", "@solana/web3.js@^1.62.1", "@solana/web3.js@^1.63.1":
   version "1.43.2"
   resolved "https://registry.yarnpkg.com/@solana/web3.js/-/web3.js-1.43.2.tgz#9a2b3e5709dc73f45137a9ab4eccbd4bc2f25bbf"
   integrity sha512-1f4Njy98f5dKa/x8fvMG3EaY4e5UNEXYRqCpAHpY8MkfROnedZOFHk+w6CD3+7UjJzjdQJzD7YdwYEQErEVYWQ==
@@ -21146,6 +21146,11 @@ zip-stream@^4.1.0:
     archiver-utils "^2.1.0"
     compress-commons "^4.1.0"
     readable-stream "^3.6.0"
+
+zod@^3.19.1:
+  version "3.19.1"
+  resolved "https://registry.yarnpkg.com/zod/-/zod-3.19.1.tgz#112f074a97b50bfc4772d4ad1576814bd8ac4473"
+  integrity sha512-LYjZsEDhCdYET9ikFu6dVPGp2YH9DegXjdJToSzD9rO6fy4qiRYFoyEYwps88OseJlPyl2NOe2iJuhEhL7IpEA==
 
 zustand@^4.0.0:
   version "4.0.0"


### PR DESCRIPTION
this is only using the local hasura and db right now, and I haven't set up role-based auth to hasura yet but this is the first half of creating users in the db

it first validates a POST JSON payload that looks like this

```json
{
  "username": "user",
  "publicKey": "6CUcaS1BiRf7hWSDkrfYTt8devdz4U1dnFmJ4PzY7PUe",
  "inviteCode": "de30651d-4a4f-4837-8a4c-7ac89259d947"
}
```

if it looks valid it then sends the data to hasura as an insert user query

if the invite code has been used or is invalid, of if the username has been taken or is invalid the insert will fail

it's using [zeus](https://zeus.graphqleditor.com/) for typed graphql calls but the equivelent in fetch would look something like

```typescript
const res = await fetch(HASURA_URL, {
  method: "POST",
  headers: {
    "Content-Type": "application/json",
    "x-hasura-admin-secret": HASURA_SECRET,
  },
  body: JSON.stringify({
    query: `mutation  CreateUser($username:  citext!,  $invitation_id:  uuid!)  {
    insert_auth_users_one(object:  {username:  $username,  invitation_id:  $invitation_id})  {
      id
    }
  }`,
    variables: {
      username: variables.username,
      invitation_id: variables.inviteCode,
    },
  }),
});
const json = await res.json<HasuraMutationResponse>();
if (json.errors) throw new DatabaseError(json.errors);
return c.json(json, res.status as StatusCode);
```

next steps are

- signing the payload with the wallet before submitting
- storing both the publicKey and waitlistId (if present) in the db
- probably converting data sent over the wire to snake_case for consistency
- deploying to prod