### PR TITLE
dont crash on rejected ethereum recent activity queries

### DIFF
--- a/packages/app-extension/src/components/Unlocked/Balances/RecentActivity.tsx
+++ b/packages/app-extension/src/components/Unlocked/Balances/RecentActivity.tsx
@@ -93,7 +93,6 @@ const useStyles = styles((theme) => ({
 
 export function RecentActivityButton() {
   const classes = useStyles();
-  const theme = useCustomTheme();
   const [openDrawer, setOpenDrawer] = useState(false);
   return (
     <div className={classes.networkSettingsButtonContainer}>

--- a/packages/recoil/src/atoms/recent-transactions.tsx
+++ b/packages/recoil/src/atoms/recent-transactions.tsx
@@ -9,6 +9,10 @@ import { anchorContext } from "./solana/wallet";
 import { ethersContext } from "./ethereum/provider";
 import { fetchRecentSolanaTransactions } from "./solana/recent-transactions";
 
+/**
+ * Retrieve recent Ethereum transactions using alchemy_getAssetTransfers.
+ * https://docs.alchemy.com/reference/alchemy-getassettransfers
+ */
 export const recentEthereumTransactions = atomFamily<
   Array<RecentTransaction>,
   {
@@ -78,13 +82,22 @@ export const recentEthereumTransactions = atomFamily<
             },
           ]
         );
-        const [from, to] = await Promise.all([
+        const results = await Promise.allSettled([
           fromTransferPromise,
           toTransferPromise,
         ]);
-        const merged = [...from.transfers, ...to.transfers].sort(
-          (a: string, b: string) => Number(b) - Number(a)
-        );
+
+        const isFulfilled = <T,>(
+          input: PromiseSettledResult<T>
+        ): input is PromiseFulfilledResult<T> => input.status === "fulfilled";
+
+        const merged = results
+          // Don't crash on promise rejections
+          .filter(isFulfilled)
+          .map((r) => r.value.transfers)
+          .flat()
+          .sort((a: string, b: string) => Number(b) - Number(a));
+
         return merged.map((t) => ({
           blockchain: Blockchain.ETHEREUM,
           date: new Date(t.metadata.blockTimestamp),
@@ -96,6 +109,9 @@ export const recentEthereumTransactions = atomFamily<
   }),
 });
 
+/**
+ * Retrieve recent Solana transactions.
+ */
 export const recentSolanaTransactions = atomFamily<
   Array<RecentTransaction>,
   {


### PR DESCRIPTION
Handle rejected promises so wallet doesn't crash if these queries fail.

Related #877 