### PR TITLE
Added textarea props to textfield component

### DIFF
--- a/packages/react-xnft-renderer/src/Component.tsx
+++ b/packages/react-xnft-renderer/src/Component.tsx
@@ -17,6 +17,7 @@ import {
   TextField as MuiTextField,
   CircularProgress,
 } from "@mui/material";
+import { TextareaAutosize as MuiTextArea } from "@mui/base";
 import { ExpandMore, ExpandLess } from "@mui/icons-material";
 import { usePluginContext } from "./Context";
 import { ViewRenderer } from "./ViewRenderer";
@@ -151,6 +152,23 @@ const useStyles = styles((theme) => ({
     fontSize: "16px",
     lineHeight: "24px",
     border: `${theme.custom.colors.borderFull}`,
+  },
+  textAreaInput: {
+    fontWeight: 500,
+    borderRadius: "12px",
+    fontSize: "16px",
+    lineHeight: "24px",
+    padding: "16.5px 14px",
+    font: "inherit",
+    background: theme.custom.colors.textBackground,
+    border: `2pt solid ${theme.custom.colors.textBackground}`,
+    "&:hover": {
+      border: `2pt solid ${theme.custom.colors.primaryButton}`,
+    },
+    "&:focus": {
+      border: `2pt solid ${theme.custom.colors.primaryButton}`,
+      outline: "none",
+    },
   },
   textFieldInputColorEmpty: {
     color: theme.custom.colors.textPlaceholder,
@@ -714,6 +732,19 @@ function _TextField({ id, props, children, style }: any) {
     : (value: any) => {
         plugin.pushOnChangeNotification(id, value);
       };
+  if (props.multiline) {
+    return (
+      <TextArea
+        placeholder={props.placeholder}
+        value={props.value}
+        maxRows={props.numberOfLines}
+        minRows={props.numberOfLines}
+        setValue={onChange}
+        children={children}
+        style={style}
+      />
+    );
+  }
   return (
     <TextField
       placeholder={props.placeholder}
@@ -721,6 +752,38 @@ function _TextField({ id, props, children, style }: any) {
       setValue={onChange}
       children={children}
       style={style}
+    />
+  );
+}
+
+export function TextArea({
+  maxRows,
+  minRows,
+  value,
+  setValue,
+  placeholder,
+  style,
+  className = "",
+}: any) {
+  const classes = useStyles();
+  className =
+    className +
+    `${classes.textAreaInput} ${
+      value ? classes.textFieldInputColor : classes.textFieldInputColorEmpty
+    }
+    `;
+  return (
+    <MuiTextArea
+      maxRows={maxRows}
+      minRows={minRows}
+      onChange={(e) => setValue(e.target.value)}
+      placeholder={placeholder}
+      style={{
+        width: "100%",
+        ...style,
+      }}
+      value={value}
+      className={className}
     />
   );
 }

--- a/packages/react-xnft/src/reconciler.ts
+++ b/packages/react-xnft/src/reconciler.ts
@@ -1142,6 +1142,8 @@ type TextFieldNodeSerialized = DefNodeSerialized<
 type TextFieldProps = {
   onChange?: ((event: Event) => void) | boolean;
   value?: any;
+  multiline?: boolean;
+  numberOfLines?: number;
   placeholder?: string;
   style: Style;
   children: undefined;


### PR DESCRIPTION
The PR adds `text area` props to the `TextField` component. 
This is in line with the react-native API - https://reactnative.dev/docs/textinput#multiline

```js
      <TextField
        multiline={true}
        numberOfLines={3}
        onChange={(e) => {setVal(e.data.value)}}
        value={val}
        placeholder={"placeholder"}
      />
```

Closes https://github.com/coral-xyz/backpack/issues/888

## Screenshots

<img width="387" alt="Screenshot 2022-09-28 at 4 44 52 AM" src="https://user-images.githubusercontent.com/8079861/192653995-dc6bc98d-845a-4f80-b9b1-78607a748d04.png">
<img width="402" alt="Screenshot 2022-09-28 at 4 44 48 AM" src="https://user-images.githubusercontent.com/8079861/192654000-0c224cb2-e343-4e55-a3ef-242278e1d432.png">
<img width="388" alt="Screenshot 2022-09-28 at 4 44 22 AM" src="https://user-images.githubusercontent.com/8079861/192654002-e2135677-a45b-44ab-ae8e-31169beab1f4.png">
