### PR TITLE
remove is secondary prop from button

### DIFF
--- a/packages/app-extension/src/components/common/index.tsx
+++ b/packages/app-extension/src/components/common/index.tsx
@@ -236,7 +236,6 @@ export function PrimaryButton({
 }: {
   buttonLabelStyle?: React.CSSProperties;
   label?: string;
-  isSecondary?: boolean;
 } & React.ComponentProps<typeof Button>) {
   const theme = useCustomTheme();
   const classes = useStyles();
@@ -309,7 +308,6 @@ export function SecondaryButton({
       className={classes.secondaryButton}
       buttonLabelStyle={buttonLabelStyle}
       label={label}
-      isSecondary={true}
       {...buttonProps}
       style={buttonStyle}
     />


### PR DESCRIPTION
This do anything? Looks like it just gets passed down to the MUI button component and generates a console error.