### PR TITLE
Catches transaction errors in ApproveTransactionRequest

### DIFF
--- a/packages/app-extension/src/components/Unlocked/ApproveTransactionRequest.tsx
+++ b/packages/app-extension/src/components/Unlocked/ApproveTransactionRequest.tsx
@@ -312,12 +312,14 @@ function _SendTransactionRequest({
   // into this component because it can be modified by the user to set
   // transaction specific settings (i.e. Etheruem gas).
   //
-  const onConfirm = async () => {
-    const signature = await background.request({
-      method: uiRpcMethod,
-      params: [transactionToSend, publicKey],
-    });
-    onResolve(signature);
+  const onConfirm = () => {
+    background
+      .request({
+        method: uiRpcMethod,
+        params: [transactionToSend, publicKey],
+      })
+      .then((signature) => onResolve(signature))
+      .catch((_) => onReject());
   };
 
   //
@@ -480,12 +482,14 @@ function SignMessageRequest({
   //
   // Executes when the modal clicks "Approve" in the drawer popup
   //
-  const onConfirm = async () => {
-    const signature = await background.request({
-      method: uiRpcMethod,
-      params: [message, publicKey],
-    });
-    onResolve(signature);
+  const onConfirm = () => {
+    background
+      .request({
+        method: uiRpcMethod,
+        params: [message, publicKey],
+      })
+      .then((signature) => onResolve(signature))
+      .catch((_) => onReject());
   };
 
   return (


### PR DESCRIPTION
The PR catches errors in `ApproveTransactionRequest` that is causing unhandled rejections to remain uncaught. This prevents application developers from knowing if the underlying transaction failed.

I've now called the `onReject` callback in case the background requests fails which will cause `window.xnft.solana.send` throw, which the application developer can then handle according to their app.

Does it make sense to propagate the `error message` to the developer? Right now the `error message` that reaches them is `user rejected signature request` from [here](https://github.com/coral-xyz/backpack/blob/master/packages/app-extension/src/components/Unlocked/ApproveTransactionRequest.tsx#L124)

Closes #810