### PR TITLE
share toggle password visibility button with confirmation field

### DIFF
--- a/packages/app-extension/src/components/common/Account/CreatePassword.tsx
+++ b/packages/app-extension/src/components/common/Account/CreatePassword.tsx
@@ -42,7 +42,6 @@ export function CreatePassword({
   const [passwordConfirm, setPasswordConfirm] = useState("");
   const [error, setError] = useState<PasswordError | null>(null);
   const [showPassword, setShowPassword] = useState(false);
-  const [showPasswordConfirm, setShowPasswordConfirm] = useState(false);
 
   useEffect(() => {
     setError(null);
@@ -117,24 +116,11 @@ export function CreatePassword({
           <TextField
             inputProps={{ name: "password-confirmation" }}
             placeholder="Confirm Password"
-            type={showPasswordConfirm ? "text" : "password"}
+            type={showPassword ? "text" : "password"}
             value={passwordConfirm}
             setValue={setPasswordConfirm}
             rootClass={classes.passwordFieldRoot}
             isError={error === PasswordError.NO_MATCH}
-            endAdornment={
-              <InputAdornment position="end">
-                <IconButton
-                  disableRipple
-                  onClick={() => setShowPasswordConfirm(!showPasswordConfirm)}
-                  onMouseDown={() =>
-                    setShowPasswordConfirm(!showPasswordConfirm)
-                  }
-                >
-                  {showPasswordConfirm ? <VisibilityOff /> : <Visibility />}
-                </IconButton>
-              </InputAdornment>
-            }
           />
           {error !== null && (
             <Typography sx={{ color: theme.custom.colors.negative }}>


### PR DESCRIPTION
it feels like having a single button shared between both fields is a bit simpler, but maybe a bad idea?

https://user-images.githubusercontent.com/101902546/193170469-97c0832e-c98b-4ca8-b45d-7fac51c67ffc.mov

