### PR TITLE
Update @wallet-standard/wallets-backpack

### DIFF
--- a/packages/provider-injection/package.json
+++ b/packages/provider-injection/package.json
@@ -11,7 +11,7 @@
     "@coral-xyz/provider-core": "*",
     "@project-serum/anchor": "^0.23.0",
     "@solana/web3.js": "^1.36.0",
-    "@wallet-standard/wallets-backpack": "0.1.0-alpha.5",
+    "@wallet-standard/wallets-backpack": "0.1.0-alpha.6",
     "bs58": "^5.0.0",
     "eth-rpc-errors": "^4.0.3",
     "eventemitter3": "^4.0.7"


### PR DESCRIPTION
This PR updates the Wallet Standard adapter for Backpack to the latest release.

The code for this is here: https://github.com/wallet-standard/wallet-standard/tree/master/packages/wallets/backpack

The API has been restructured. This has no effect on `window.backpack`.