### PR TITLE
Export useTabContext

### DIFF
--- a/packages/react-xnft/src/sdk/Tab.tsx
+++ b/packages/react-xnft/src/sdk/Tab.tsx
@@ -174,7 +174,7 @@ function TabProvider({ initialTab, options, children }) {
   );
 }
 
-function useTabContext(): TabContext {
+export function useTabContext(): TabContext {
   const ctx = useContext(_TabContext);
   if (ctx === null) {
     throw new Error("Context not available");


### PR DESCRIPTION
Export useTabContext so that it can be used for navigation by other UIs.