### PR TITLE
single connect per origin and handle eth_accounts separately

### DIFF
--- a/packages/background/src/frontend/server-injected.ts
+++ b/packages/background/src/frontend/server-injected.ts
@@ -187,6 +187,9 @@ async function handle<T = any>(
   }
 }
 
+// Locks for limiting requests to one per origin
+const locks = new Set();
+
 // Automatically connect in the event we're unlocked and the origin
 // has been previously approved. Otherwise, open a new window to prompt
 // the user to unlock and approve.
@@ -199,6 +202,12 @@ async function handleConnect(
   blockchain: Blockchain
 ): Promise<RpcResponse<string>> {
   const origin = ctx.sender.origin;
+
+  if (locks.has(origin)) {
+    throw new Error(`already handling a request from ${origin}`);
+  }
+  locks.add(origin);
+
   const keyringStoreState = await ctx.backend.keyringStoreState();
   let didApprove = false;
   let resp: any;
@@ -242,8 +251,11 @@ async function handleConnect(
       didApprove = !resp.windowClosed && resp.result;
     }
   } else {
+    locks.delete(origin);
     throw new Error("invariant violation keyring not created");
   }
+
+  locks.delete(origin);
 
   if (resp && !resp.windowClosed) {
     BrowserRuntimeExtension.closeWindow(resp.window.id);


### PR DESCRIPTION
Restrict connect requests to one per origin and handle `eth_accounts` requests separately from `eth_requestAccounts`.

Closes https://github.com/coral-xyz/backpack/issues/829
Closes https://github.com/coral-xyz/backpack/issues/965