### PR TITLE
When validating secret key throw error if has already been added

### DIFF
--- a/packages/app-extension/src/components/Unlocked/Settings/index.tsx
+++ b/packages/app-extension/src/components/Unlocked/Settings/index.tsx
@@ -943,13 +943,15 @@ export function ImportSecretKey({ blockchain }: { blockchain: Blockchain }) {
   }, [theme]);
 
   const onClick = async () => {
-    const secretKeyHex = validateSecretKey(
-      blockchain,
-      secretKey,
-      existingPublicKeys
-    );
-    if (!secretKeyHex) {
-      setError("Invalid private key");
+    let secretKeyHex;
+    try {
+      secretKeyHex = validateSecretKey(
+        blockchain,
+        secretKey,
+        existingPublicKeys
+      );
+    } catch (e) {
+      setError((e as Error).message);
       return;
     }
 
@@ -1051,7 +1053,7 @@ function validateSecretKey(
   blockchain: Blockchain,
   secretKey: string,
   keyring: WalletPublicKeys
-): string | boolean {
+): string {
   // Extract public keys from keychain object into array of strings
   const existingPublicKeys = Object.values(keyring[blockchain])
     .map((k) => k.map((i) => i.publicKey))
@@ -1068,7 +1070,7 @@ function validateSecretKey(
         keypair = Keypair.fromSecretKey(new Uint8Array(bs58.decode(secretKey)));
       } catch (_) {
         // Failure
-        return false;
+        throw new Error("Invalid private key");
       }
     }
 
@@ -1087,7 +1089,7 @@ function validateSecretKey(
 
       return wallet.privateKey;
     } catch (_) {
-      return false;
+      throw new Error("Invalid private key");
     }
   }
   throw new Error("secret key validation not implemented for blockchain");

--- a/packages/app-extension/src/components/Unlocked/Settings/index.tsx
+++ b/packages/app-extension/src/components/Unlocked/Settings/index.tsx
@@ -20,6 +20,7 @@ import {
   useActiveWallets,
   useBlockchainLogo,
   useUsername,
+  WalletPublicKeys,
 } from "@coral-xyz/recoil";
 import {
   openPopupWindow,
@@ -924,6 +925,7 @@ function SettingsList({ close }: { close: () => void }) {
 export function ImportSecretKey({ blockchain }: { blockchain: Blockchain }) {
   const classes = useStyles();
   const background = useBackgroundClient();
+  const existingPublicKeys = useWalletPublicKeys();
   const nav = useNavStack();
   const theme = useCustomTheme();
   const [name, setName] = useState("");
@@ -941,7 +943,11 @@ export function ImportSecretKey({ blockchain }: { blockchain: Blockchain }) {
   }, [theme]);
 
   const onClick = async () => {
-    const secretKeyHex = validateSecretKey(blockchain, secretKey);
+    const secretKeyHex = validateSecretKey(
+      blockchain,
+      secretKey,
+      existingPublicKeys
+    );
     if (!secretKeyHex) {
       setError("Invalid private key");
       return;
@@ -1043,10 +1049,16 @@ export function ImportSecretKey({ blockchain }: { blockchain: Blockchain }) {
 // Validate a secret key and return a normalised hex representation
 function validateSecretKey(
   blockchain: Blockchain,
-  secretKey: string
+  secretKey: string,
+  keyring: WalletPublicKeys
 ): string | boolean {
+  // Extract public keys from keychain object into array of strings
+  const existingPublicKeys = Object.values(keyring[blockchain])
+    .map((k) => k.map((i) => i.publicKey))
+    .flat();
+
   if (blockchain === Blockchain.SOLANA) {
-    let keypair;
+    let keypair: Keypair | null = null;
     try {
       // Attempt to create a keypair from JSON secret key
       keypair = Keypair.fromSecretKey(new Uint8Array(JSON.parse(secretKey)));
@@ -1059,10 +1071,20 @@ function validateSecretKey(
         return false;
       }
     }
+
+    if (existingPublicKeys.includes(keypair.publicKey.toString())) {
+      throw new Error("Key already exists");
+    }
+
     return Buffer.from(keypair.secretKey).toString("hex");
   } else if (blockchain === Blockchain.ETHEREUM) {
     try {
       const wallet = new ethers.Wallet(secretKey);
+
+      if (existingPublicKeys.includes(wallet.publicKey)) {
+        throw new Error("Key already exists");
+      }
+
       return wallet.privateKey;
     } catch (_) {
       return false;


### PR DESCRIPTION
### Fix for [issue #621](https://github.com/coral-xyz/backpack/issues/621) 

### What this does:
This displays a new error message to the user when they import a private key that has already been added

### What code changed:
The useWalletPublicKeys hook was added to the ImportSecretKey component. The validateSecretKey function was changed to accept the existing keys as a parameter, and to throw an error if the key is invalid. Previously the validateSecretKey function would return false to indicate an invalid secret key but now it throws an error

### Additional notes
Please let me know what additional information I should provide, changes that need to be made to the code, or additional screens that need to have this check added to them
