### PR TITLE
use root pubkey for authentication flow

### DIFF
--- a/packages/background/src/backend/core.ts
+++ b/packages/background/src/backend/core.ts
@@ -380,7 +380,7 @@ export class Backend {
       try {
         const bc = await this.keyringStore.activeBlockchainKeyring();
 
-        const publicKey = bc.getActiveWallet();
+        const publicKey = bc.getAuthenticationPublicKey(mnemonic);
 
         const body = JSON.stringify({
           username,

--- a/packages/background/src/backend/keyring/blockchain.ts
+++ b/packages/background/src/backend/keyring/blockchain.ts
@@ -141,6 +141,9 @@ export class BlockchainKeyring {
     return this.activeWallet;
   }
 
+  /**
+   * @returns a 'root' public key string for the mnemonic
+   */
   public getAuthenticationPublicKey(mnemonic: string): string {
     return this.hdKeyringFactory
       .fromMnemonic(mnemonic, "bip44", [0])

--- a/packages/background/src/backend/keyring/blockchain.ts
+++ b/packages/background/src/backend/keyring/blockchain.ts
@@ -148,6 +148,12 @@ export class BlockchainKeyring {
     return this.activeWallet;
   }
 
+  public getAuthenticationPublicKey(mnemonic: string): string {
+    return this.hdKeyringFactory
+      .fromMnemonic(mnemonic, "bip44", [0])
+      .getPublicKey(0);
+  }
+
   public async activeWalletUpdate(newWallet: string) {
     this.activeWallet = newWallet;
   }

--- a/packages/background/src/backend/keyring/blockchain.ts
+++ b/packages/background/src/backend/keyring/blockchain.ts
@@ -27,9 +27,6 @@ const logger = getLogger("background/backend/keyring");
 
 // Represents key data for a single blockchain network, e.g., solana or ethereum.
 export class BlockchainKeyring {
-  private hdKeyringFactory: HdKeyringFactory;
-  private keyringFactory: KeyringFactory;
-  private ledgerKeyringFactory: LedgerKeyringFactory;
   private hdKeyring?: HdKeyring;
   private importedKeyring?: Keyring;
   public ledgerKeyring?: LedgerKeyring;
@@ -37,14 +34,10 @@ export class BlockchainKeyring {
   private deletedWallets?: Array<string>;
 
   constructor(
-    hdKeyringFactory: HdKeyringFactory,
-    keyringFactory: KeyringFactory,
-    ledgerKeyringFactory: LedgerKeyringFactory
-  ) {
-    this.hdKeyringFactory = hdKeyringFactory;
-    this.keyringFactory = keyringFactory;
-    this.ledgerKeyringFactory = ledgerKeyringFactory;
-  }
+    private hdKeyringFactory: HdKeyringFactory,
+    private keyringFactory: KeyringFactory,
+    private ledgerKeyringFactory: LedgerKeyringFactory
+  ) {}
 
   public static solana(): BlockchainKeyring {
     return new BlockchainKeyring(


### PR DESCRIPTION
will unblock #1003 once merged

TODO

- [ ] fix `await bc.signMessage(encode(buffer), publicKey!);` so that it works even if importing keys from a different derivation path (related #1024)