### PR TITLE
Fixed stuck popups while approving requests

### DIFF
--- a/packages/app-extension/src/components/Unlocked/ApproveTransactionRequest.tsx
+++ b/packages/app-extension/src/components/Unlocked/ApproveTransactionRequest.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useEffect, useState, Suspense } from "react";
 import {
   useActivePublicKeys,
   useBackgroundClient,
@@ -143,33 +143,35 @@ export function ApproveTransactionRequest() {
         setOpenDrawer(b);
       }}
     >
-      {isMessageSign ? (
-        <SignMessageRequest
-          publicKey={publicKey}
-          message={request!.data as string}
-          uiRpcMethod={rpcMethod}
-          onResolve={onResolve}
-          onReject={onReject}
-        />
-      ) : request.kind! === PLUGIN_REQUEST_SOLANA_SIGN_ALL_TRANSACTIONS ? (
-        <SignAllTransactionsRequest
-          publicKey={publicKey}
-          uiRpcMethod={rpcMethod}
-          blockchain={blockchain}
-          transactions={request!.data as string[]}
-          onResolve={onResolve}
-          onReject={onReject}
-        />
-      ) : (
-        <SendTransactionRequest
-          publicKey={publicKey}
-          uiRpcMethod={rpcMethod}
-          blockchain={blockchain}
-          transaction={request!.data as string}
-          onResolve={onResolve}
-          onReject={onReject}
-        />
-      )}
+      <Suspense fallback={<DisabledRequestPrompt />}>
+        {isMessageSign ? (
+          <SignMessageRequest
+            publicKey={publicKey}
+            message={request!.data as string}
+            uiRpcMethod={rpcMethod}
+            onResolve={onResolve}
+            onReject={onReject}
+          />
+        ) : request.kind! === PLUGIN_REQUEST_SOLANA_SIGN_ALL_TRANSACTIONS ? (
+          <SignAllTransactionsRequest
+            publicKey={publicKey}
+            uiRpcMethod={rpcMethod}
+            blockchain={blockchain}
+            transactions={request!.data as string[]}
+            onResolve={onResolve}
+            onReject={onReject}
+          />
+        ) : (
+          <SendTransactionRequest
+            publicKey={publicKey}
+            uiRpcMethod={rpcMethod}
+            blockchain={blockchain}
+            transaction={request!.data as string}
+            onResolve={onResolve}
+            onReject={onReject}
+          />
+        )}
+      </Suspense>
     </ApproveTransactionDrawer>
   );
 }
@@ -461,6 +463,14 @@ function SignMessageRequest({
           {displayMessage}
         </div>
       </Scrollbar>
+    </Request>
+  );
+}
+
+function DisabledRequestPrompt() {
+  return (
+    <Request onConfirm={() => {}} onReject={() => {}} buttonsDisabled={true}>
+      <Loading />
     </Request>
   );
 }


### PR DESCRIPTION
Noticed that when I had a bad internet and I tried approving a transaction, the popup that should appear would not appear and I would only see a `close` button at the bottom 
<img width="371" alt="Screenshot 2022-10-04 at 11 23 58 PM" src="https://user-images.githubusercontent.com/8079861/193927900-8931b328-3c78-4f51-a3dd-8ebb56d30f93.png">

This would happen because `useTransactionData` is async and the component wouldn't render until the hook returns - https://github.com/coral-xyz/backpack/blob/master/packages/app-extension/src/components/Unlocked/ApproveTransactionRequest.tsx#L305

The PR fallbacks the UI to the transaction popup with buttons disabled and a loader until the hook returns.