### PR TITLE
fix squished NFTs

### DIFF
--- a/packages/app-extension/src/components/Unlocked/Nfts/Detail.tsx
+++ b/packages/app-extension/src/components/Unlocked/Nfts/Detail.tsx
@@ -100,12 +100,13 @@ function Image({ nft }: { nft: any }) {
       style={{
         width: "100%",
         minHeight: "343px",
+        display: "flex",
+        alignItems: "center",
       }}
     >
       <img
         style={{
           width: "100%",
-          minHeight: "343px",
           borderRadius: "8px",
         }}
         src={nft.imageUrl}


### PR DESCRIPTION
### Fix for Issue #997 

### What changed

This removes the minimum height on the inner image and adds flexbox centering to the container image

### What the change did

The image was previously squished because the inner image had a minimum height the same as the container. An image with a wide aspect ratio needs to have a smaller height than its container or the edges overflow. In this case the edges did not overflow and the image got squished because the image also has a width set to 100%.

Images with a small aspect ratio are not affected by this change as their height will be larger than the container when their width is 100%.

### How the change looks

#### Before change
<img width="373" alt="Screen Shot 2022-10-05 at 1 37 37 PM" src="https://user-images.githubusercontent.com/7918955/194160845-d0b7e492-8fc7-4db3-abfe-3af5aaff7c4b.png">

#### After change
<img width="379" alt="Screen Shot 2022-10-05 at 1 23 24 PM" src="https://user-images.githubusercontent.com/7918955/194160444-52fa5b6b-48de-41be-90fd-5ec2e4942a24.png">

#### Same image on Phantom
<img width="362" alt="Screen Shot 2022-10-05 at 1 45 56 PM" src="https://user-images.githubusercontent.com/7918955/194161025-447b78e7-bb79-4a13-a25e-8874d1bc3e58.png">

