### PR TITLE
Added minimal selectors

### DIFF
--- a/packages/app-extension/src/components/Unlocked/Balances/TokensWidget/Send.tsx
+++ b/packages/app-extension/src/components/Unlocked/Balances/TokensWidget/Send.tsx
@@ -112,7 +112,7 @@ export function SendButton({
         {
           name: "send",
           component: (props: any) => <SendLoader {...props} />,
-          title: `${token.ticker} / Send`,
+          title: `${token?.ticker || ""} / Send`,
           props: {
             blockchain,
             address,

--- a/packages/recoil/src/atoms/ethereum/token.tsx
+++ b/packages/recoil/src/atoms/ethereum/token.tsx
@@ -2,7 +2,7 @@ import { atom, atomFamily, selector, selectorFamily } from "recoil";
 import { ethers, BigNumber } from "ethers";
 import { TokenInfo } from "@solana/spl-token-registry";
 import { fetchEthereumTokenBalances, ETH_NATIVE_MINT } from "@coral-xyz/common";
-import { TokenData } from "../../types";
+import { TokenData, TokenNativeData } from "../../types";
 import { priceData } from "../prices";
 import { ethereumPublicKey } from "../wallet";
 import { ethersContext } from "./provider";
@@ -63,8 +63,11 @@ export const erc20Balances = selector({
   },
 });
 
-export const ethereumTokenBalance = selectorFamily<TokenData | null, string>({
-  key: "ethereumTokenBalance",
+export const ethereumTokenNativeBalance = selectorFamily<
+  TokenNativeData | null,
+  string
+>({
+  key: "ethereumTokenNativeBalance",
   get:
     (contractAddress: string) =>
     ({ get }) => {
@@ -84,9 +87,33 @@ export const ethereumTokenBalance = selectorFamily<TokenData | null, string>({
         : BigNumber.from(0);
       const displayBalance = ethers.utils.formatUnits(nativeBalance, decimals);
 
+      return {
+        name,
+        decimals,
+        nativeBalance,
+        displayBalance,
+        ticker,
+        logo,
+        address: contractAddress,
+      };
+    },
+});
+
+export const ethereumTokenBalance = selectorFamily<TokenData | null, string>({
+  key: "ethereumTokenBalance",
+  get:
+    (contractAddress: string) =>
+    ({ get }) => {
+      const nativeTokenBalance = get(
+        ethereumTokenNativeBalance(contractAddress)
+      );
+      if (!nativeTokenBalance) {
+        return null;
+      }
+
       const price = get(priceData(contractAddress)) as any;
       const usdBalance =
-        price && price.usd ? price.usd * parseFloat(displayBalance) : 0;
+        (price?.usd ?? 0) * parseFloat(nativeTokenBalance.displayBalance);
       const oldUsdBalance =
         usdBalance === 0
           ? 0
@@ -98,16 +125,11 @@ export const ethereumTokenBalance = selectorFamily<TokenData | null, string>({
           : undefined;
 
       return {
-        name,
-        decimals,
-        nativeBalance,
-        displayBalance,
-        ticker,
-        logo,
-        address: contractAddress,
+        ...nativeTokenBalance,
         usdBalance,
         recentPercentChange,
         recentUsdBalanceChange,
-      } as TokenData;
+        priceData: price,
+      };
     },
 });

--- a/packages/recoil/src/hooks/useBlockchain.tsx
+++ b/packages/recoil/src/hooks/useBlockchain.tsx
@@ -1,6 +1,8 @@
 import { useRecoilValue } from "recoil";
 import { Blockchain } from "@coral-xyz/common";
 import * as atoms from "../atoms";
+import { TokenData } from "../types";
+import { blockchainNativeBalances } from "../atoms";
 
 export function useBlockchainExplorer(blockchain: Blockchain) {
   switch (blockchain) {
@@ -43,10 +45,14 @@ export function useBlockchainTokensSorted(blockchain: Blockchain) {
   return useRecoilValue(atoms.blockchainBalancesSorted(blockchain));
 }
 
+export function useBlockchainNativeTokens(blockchain: Blockchain) {
+  return useRecoilValue(atoms.blockchainNativeBalances(blockchain));
+}
+
 export function useBlockchainTokenAccount(
   blockchain: Blockchain,
   address: string
-): any {
+): TokenData | null {
   return useRecoilValue(atoms.blockchainTokenData({ blockchain, address }));
 }
 

--- a/packages/recoil/src/hooks/useTransactionData.tsx
+++ b/packages/recoil/src/hooks/useTransactionData.tsx
@@ -7,6 +7,7 @@ import { AccountLayout, u64, TOKEN_PROGRAM_ID } from "@solana/spl-token";
 import { Blockchain, UI_RPC_METHOD_SOLANA_SIMULATE } from "@coral-xyz/common";
 import {
   useBackgroundClient,
+  useBlockchainNativeTokens,
   useBlockchainTokensSorted,
   useEthereumCtx,
   useEthereumPrice,
@@ -180,7 +181,7 @@ export function useEthereumTxData(serializedTx: any): TransactionData {
 export function useSolanaTxData(serializedTx: any): TransactionData {
   const background = useBackgroundClient();
   const tokenRegistry = useSplTokenRegistry();
-  const tokenAccountsSorted = useBlockchainTokensSorted(Blockchain.SOLANA);
+  const tokenAccountsSorted = useBlockchainNativeTokens(Blockchain.SOLANA);
   const { connection, walletPublicKey } = useSolanaCtx();
 
   const [loading, setLoading] = useState(true);

--- a/packages/recoil/src/types.ts
+++ b/packages/recoil/src/types.ts
@@ -32,7 +32,7 @@ export type WalletPublicKeys = {
   };
 };
 
-export type TokenData = {
+export interface TokenNativeData {
   name: string;
   decimals: number;
   nativeBalance: BigNumber;
@@ -40,12 +40,15 @@ export type TokenData = {
   ticker: string;
   logo: string;
   address: string;
+  mint?: string;
+}
+
+export interface TokenData extends TokenNativeData {
   usdBalance: number;
   recentPercentChange: number | undefined;
   recentUsdBalanceChange: number;
   priceData: any;
-  mint?: string;
-};
+}
 
 export type TokenDisplay = {
   name: string;


### PR DESCRIPTION
Closes https://github.com/coral-xyz/backpack/issues/1019

The PR adds a bunch of new selectors that lets us get the token balances without their price information. In a bunch of places we don't need the price information and this way we can avoid an extra call to `coingecko` api and speed up the selector.