### PR TITLE
Build: Use default generated-config.ts, remove .sh prompt, fix xnft-cli build.

### DIFF
--- a/packages/common-public/package.json
+++ b/packages/common-public/package.json
@@ -6,7 +6,7 @@
   "types": "dist/esm/index.d.ts",
   "scripts": {
     "start": "yarn build",
-    "build": "./scripts/config.sh && yarn lint && tsc && tsc-alias && tsc -p tsconfig.rn.json",
+    "build": "yarn lint && tsc && tsc-alias && tsc -p tsconfig.rn.json",
     "dev": "tsc --watch",
     "lint": "eslint ./src --ext .js,.jsx,.ts,.tsx"
   },

--- a/packages/common-public/src/generated-config.ts
+++ b/packages/common-public/src/generated-config.ts
@@ -1,0 +1,4 @@
+//
+// Config for @coral-xyz/common-public.
+//
+export const BACKPACK_CONFIG_LOG_LEVEL: "trace" | "debug" | "error" | "warning" | "info" = "debug";

--- a/packages/common/.gitignore
+++ b/packages/common/.gitignore
@@ -26,4 +26,4 @@ yarn-error.log*
 dist/
 
 # generated pre-build
-src/generated-config.ts
+src/generated-config.ts 

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -6,7 +6,7 @@
   "types": "dist/esm/index.d.ts",
   "scripts": {
     "start": "yarn build",
-    "build": "./scripts/config.sh && yarn lint && tsc && tsc-alias && tsc -p tsconfig.rn.json",
+    "build": "yarn lint && tsc && tsc-alias && tsc -p tsconfig.rn.json",
     "dev": "tsc --watch",
     "lint": "eslint ./src --ext .js,.jsx,.ts,.tsx"
   },

--- a/packages/common/src/generated-config.ts
+++ b/packages/common/src/generated-config.ts
@@ -1,0 +1,10 @@
+//
+// Config for @coral-xyz/common.
+//
+export const BACKPACK_CONFIG_VERSION: "development" | "production" | string = "development";
+export const BACKPACK_CONFIG_XNFT_PROXY: "development" | "production" = "production";
+export const BACKPACK_FEATURE_LIGHT_MODE = true;
+export const BACKPACK_FEATURE_POP_MODE = true;
+export const BACKPACK_FEATURE_MULTICHAIN = false;
+export const BACKPACK_FEATURE_USERNAMES = false;
+export const BACKPACK_FEATURE_XNFT = true;

--- a/packages/xnft-cli/package.json
+++ b/packages/xnft-cli/package.json
@@ -5,6 +5,7 @@
     "xnft": "./index.js"
   },
   "scripts": {
+    "common": "cd ../common/ && yarn build && cd ../common-public/ && yarn build",
     "prebuild": "cd ../../examples/xnft/iframe && npm run build",
     "build": "shx cp ../../examples/xnft/iframe/dist/index.js iframe.js"
   },

--- a/turbo.json
+++ b/turbo.json
@@ -5,6 +5,7 @@
     "build": {
       "dependsOn": [
         "^build",
+        "common",
         "$BACKPACK_CONFIG_VERSION",
         "$BACKPACK_CONFIG_LOG_LEVEL",
         "$BACKPACK_FEATURE_LIGHT_MODE",
@@ -17,6 +18,9 @@
     },
     "start": {
       "dependsOn": ["^build"]
+    },
+    "common": {
+      "outputs": ["build/**", "dist/**"]
     }
   },
   "globalDependencies": [".env"]


### PR DESCRIPTION
The motivation for this PR is that when installing backpack fresh from source, it requires some additional steps that result in a mouth full of glass such as:

- Configuring `config.sh` / `generated-config.ts`
- Building `common` and/or `common-public`

This PR fixes the issues by:

1. Hard-coding a default generated.config.ts with default values.
2. Removing repetitive pop-up of config.sh files (at least on Windows/powershell) during build.
3. Builds `common` and `common-public` before `xnft-cli`, to prevent the `npx cp (iframe dist)` error that is common.

Using this branch, I am able to clone the repo (checkout the branch), and only `yarn install` and `yarn build` from the root directory is needed for a successful build.

Open to suggestions on how to further remove the glass eating from build.