### PR TITLE
Update @wallet-standard/wallets-backpack to 0.1.0-alpha.7

### DIFF
--- a/packages/provider-injection/package.json
+++ b/packages/provider-injection/package.json
@@ -11,7 +11,7 @@
     "@coral-xyz/provider-core": "*",
     "@project-serum/anchor": "^0.23.0",
     "@solana/web3.js": "^1.36.0",
-    "@wallet-standard/wallets-backpack": "0.1.0-alpha.6",
+    "@wallet-standard/wallets-backpack": "0.1.0-alpha.7",
     "bs58": "^5.0.0",
     "eth-rpc-errors": "^4.0.3",
     "eventemitter3": "^4.0.7"


### PR DESCRIPTION
This PR updates the Wallet Standard wrapper for Backpack. Internally, there are some API changes, and I've updated the Backpack icon to the same as the one used by Wallet Adapter. This has no effect on `window.backpack` or its consumers.