### PR TITLE
fix deps so that packages/common* gets built before being used

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -95,12 +95,6 @@ jobs:
       #
       # Build the extension, edge release.
       #
-      - name: "pre-build-public"
-        working-directory: packages/common-public
-        run: yarn build
-      - name: "pre-build"
-        working-directory: packages/common
-        run: yarn build
       - name: "build edge"
         env:
           BACKPACK_CONFIG_VERSION: "latest-edge-${{ github.run_number }}"
@@ -119,12 +113,6 @@ jobs:
       #
       # Build the extension, beta release.
       #
-      - name: "pre-build-public"
-        working-directory: packages/common-public
-        run: yarn build
-      - name: "pre-build"
-        working-directory: packages/common
-        run: yarn build
       - name: "build beta"
         env:
           BACKPACK_CONFIG_VERSION: "latest-beta-${{ github.run_number }}"

--- a/packages/xnft-cli/package.json
+++ b/packages/xnft-cli/package.json
@@ -16,10 +16,8 @@
     "express": "^4.18.1"
   },
   "devDependencies": {
+    "react-xnft": "*",
     "shx": "^0.3.4"
-  },
-  "peerDependencies": {
-    "react-xnft": "*"
   },
   "files": [
     "index.js",

--- a/packages/xnft-cli/package.json
+++ b/packages/xnft-cli/package.json
@@ -18,6 +18,9 @@
   "devDependencies": {
     "shx": "^0.3.4"
   },
+  "peerDependencies": {
+    "react-xnft": "*"
+  },
   "files": [
     "index.js",
     "iframe.js"


### PR DESCRIPTION
- remove manual github actions build steps for `common-public` and `common`
- add `react-xnft` as a devDependency of `xnft-cli` so that it and its dependencies are registered in the turborepo dependency graph (turborepo ignores peerDependencies)