### PR TITLE
Custom types in reconciler

### DIFF
--- a/examples/xnft/custom-components/package.json
+++ b/examples/xnft/custom-components/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "@coral-xyz/custom-components",
+  "version": "0.1.0",
+  "scripts": {
+    "build": "xnft build",
+    "start": "xnft watch",
+    "dev": "xnft dev"
+  },
+  "devDependencies": {
+    "@coral-xyz/xnft-cli": "*"
+  },
+  "dependencies": {
+    "react-xnft": "*",
+    "react": "^17.0.2"
+  }
+}

--- a/examples/xnft/custom-components/src/app.tsx
+++ b/examples/xnft/custom-components/src/app.tsx
@@ -1,0 +1,23 @@
+import React from "react";
+import { View, Text } from "react-xnft";
+import { Video } from "./components/Video";
+import { Audio } from "./components/Audio";
+
+export function App() {
+  return (
+    <View>
+      <Text>Video</Text>
+      <Video
+        src={"https://www.w3schools.com/html/mov_bbb.mp4"}
+        autoplay={false}
+        controls={true}
+      />
+      <Text>Audio</Text>
+      <Audio
+        autoplay={false}
+        controls={true}
+        src={"https://www.w3schools.com/html/horse.mp3"}
+      />
+    </View>
+  );
+}

--- a/examples/xnft/custom-components/src/components/Audio.tsx
+++ b/examples/xnft/custom-components/src/components/Audio.tsx
@@ -1,0 +1,21 @@
+import { Custom } from "react-xnft";
+import { Centralize } from "./Centralize";
+
+interface AudioProps {
+  autoplay: boolean;
+  controls: boolean;
+  src: string;
+}
+
+export const Audio = ({ autoplay, controls, src }: AudioProps) => {
+  return (
+    <Centralize>
+      <Custom
+        component={"audio"}
+        autoplay={autoplay}
+        controls={controls}
+        src={src}
+      />
+    </Centralize>
+  );
+};

--- a/examples/xnft/custom-components/src/components/Centralize.tsx
+++ b/examples/xnft/custom-components/src/components/Centralize.tsx
@@ -1,0 +1,12 @@
+import { Custom } from "react-xnft";
+
+export const Centralize = ({ children }) => {
+  return (
+    <Custom
+      component={"div"}
+      style={{ display: "flex", justifyContent: "center" }}
+    >
+      {children}
+    </Custom>
+  );
+};

--- a/examples/xnft/custom-components/src/components/Video.tsx
+++ b/examples/xnft/custom-components/src/components/Video.tsx
@@ -11,7 +11,6 @@ export const Video = ({ autoplay, controls, src }: VideoProps) => {
   return (
     <Centralize>
       <Custom
-        style={{ alignCenter: "center" }}
         component={"video"}
         autoplay={autoplay}
         controls={controls}

--- a/examples/xnft/custom-components/src/components/Video.tsx
+++ b/examples/xnft/custom-components/src/components/Video.tsx
@@ -1,0 +1,22 @@
+import { Custom } from "react-xnft";
+import { Centralize } from "./Centralize";
+
+interface VideoProps {
+  autoplay: boolean;
+  controls: boolean;
+  src: string;
+}
+
+export const Video = ({ autoplay, controls, src }: VideoProps) => {
+  return (
+    <Centralize>
+      <Custom
+        style={{ alignCenter: "center" }}
+        component={"video"}
+        autoplay={autoplay}
+        controls={controls}
+        src={src}
+      />
+    </Centralize>
+  );
+};

--- a/examples/xnft/custom-components/src/index.tsx
+++ b/examples/xnft/custom-components/src/index.tsx
@@ -1,0 +1,9 @@
+import React from "react";
+import ReactXnft, { AnchorDom } from "react-xnft";
+import { App } from "./app";
+
+ReactXnft.render(
+  <AnchorDom>
+    <App />
+  </AnchorDom>
+);

--- a/packages/react-xnft-renderer/src/Component.tsx
+++ b/packages/react-xnft-renderer/src/Component.tsx
@@ -309,12 +309,29 @@ export function Component({ viewData }) {
           children={viewData.children}
         />
       );
+    case NodeKind.Custom:
+      return (
+        <Custom
+          children={viewData.children}
+          component={props.component}
+          props={props}
+        />
+      );
     case "raw":
       return <Raw text={viewData.text} />;
     default:
       console.error(viewData);
       throw new Error("unexpected view data");
   }
+}
+
+function Custom({ children, component, props }) {
+  const el = React.createElement(
+    component,
+    props,
+    children.map((c) => <ViewRenderer key={c.id} element={c} />)
+  );
+  return el;
 }
 
 function Svg({ props, children }: any) {

--- a/packages/react-xnft/src/elements.tsx
+++ b/packages/react-xnft/src/elements.tsx
@@ -25,3 +25,5 @@ export const BalancesTableHead = c("BalancesTableHead");
 export const BalancesTableRow = c("BalancesTableRow");
 export const BalancesTableCell = c("BalancesTableCell");
 export const BalancesTableFooter = c("BalancesTableFooter");
+
+export const Custom = c("Custom");

--- a/packages/react-xnft/src/reconciler.ts
+++ b/packages/react-xnft/src/reconciler.ts
@@ -106,7 +106,7 @@ const RECONCILER = ReactReconciler({
   // Create serialized nodes.
   //
   createInstance: (
-    kind: NodeKind,
+    kind: NodeKind | string,
     props: NodeProps,
     r: RootContainer,
     h: Host,
@@ -154,9 +154,13 @@ const RECONCILER = ReactReconciler({
         return createBalancesTableCellInstance(kind, props, r, h, o);
       case NodeKind.BalancesTableFooter:
         return createBalancesTableFooterInstance(kind, props, r, h, o);
+      case NodeKind.Custom:
+        if (!props.component) {
+          throw new Error("Component not found in Custom Node");
+        }
+        return createCustomInstance(kind, props, r, h, o);
       default:
-        logger.error("unexpected node kind", kind);
-        throw new Error("unexpected node kind");
+        throw new Error("New error found");
     }
   },
   createTextInstance: (
@@ -293,7 +297,8 @@ const RECONCILER = ReactReconciler({
       case NodeKind.BalancesTableFooter:
         return null;
       default:
-        throw new Error("unexpected node kind");
+        return null;
+      // throw new Error("unexpected node kind");
     }
   },
   finalizeInitialChildren: (
@@ -432,7 +437,7 @@ const RECONCILER = ReactReconciler({
       case NodeKind.Loading:
         throw new Error("commitUpdate Loading not yet implemented");
       default:
-        throw new Error("unexpected node kind");
+      // throw new Error("unexpected node kind");
     }
 
     ReconcilerBridgeManager.bridge({
@@ -850,6 +855,27 @@ function createIframeInstance(
   };
 }
 
+function createCustomInstance(
+  kind: string,
+  props: NodeProps,
+  _r: RootContainer,
+  h: Host,
+  _o: OpaqueHandle
+): CustomNodeSerialized {
+  return {
+    id: h.nextId(),
+    kind: NodeKind.Custom,
+    // @ts-ignore
+    props: {
+      ...props,
+      children: undefined,
+    },
+    style: props.style || {},
+    children: [],
+    component: kind,
+  };
+}
+
 function createNavAnimationInstance(
   _kind: NodeKind,
   props: NodeProps,
@@ -1049,7 +1075,8 @@ export type NodeSerialized =
   | BalancesTableContentNodeSerialized
   | BalancesTableRowNodeSerialized
   | BalancesTableCellNodeSerialized
-  | BalancesTableFooterNodeSerialized;
+  | BalancesTableFooterNodeSerialized
+  | CustomNodeSerialized;
 type NodeProps =
   | TableProps
   | TableRowProps
@@ -1071,7 +1098,8 @@ type NodeProps =
   | BalancesTableContentProps
   | BalancesTableRowProps
   | BalancesTableCellProps
-  | BalancesTableFooterProps;
+  | BalancesTableFooterProps
+  | CustomProps;
 export enum NodeKind {
   //
   // App.
@@ -1100,6 +1128,11 @@ export enum NodeKind {
   BalancesTableRow = "BalancesTableRow",
   BalancesTableCell = "BalancesTableCell",
   BalancesTableFooter = "BalancesTableFooter",
+
+  //
+  // Custom
+  //
+  Custom = "Custom",
 }
 
 //
@@ -1252,6 +1285,11 @@ type IframeProps = {
 };
 
 //
+// Custom.
+//
+type CustomProps = any;
+
+//
 // NavAnimation.
 //
 type NavAnimationNodeSerialized = DefNodeSerialized<
@@ -1352,6 +1390,15 @@ type DefNodeSerialized<K, P> = {
   props: P;
   style: Style;
   children: Array<Element>;
+};
+
+type CustomNodeSerialized = {
+  id: number;
+  kind: NodeKind.Custom;
+  props: CustomProps;
+  style: Style;
+  children: Array<Element>;
+  component: string;
 };
 
 export type UpdateDiff = any;

--- a/packages/react-xnft/src/reconciler.ts
+++ b/packages/react-xnft/src/reconciler.ts
@@ -297,8 +297,7 @@ const RECONCILER = ReactReconciler({
       case NodeKind.BalancesTableFooter:
         return null;
       default:
-        return null;
-      // throw new Error("unexpected node kind");
+        throw new Error("unexpected node kind");
     }
   },
   finalizeInitialChildren: (
@@ -437,7 +436,7 @@ const RECONCILER = ReactReconciler({
       case NodeKind.Loading:
         throw new Error("commitUpdate Loading not yet implemented");
       default:
-      // throw new Error("unexpected node kind");
+        throw new Error("unexpected node kind");
     }
 
     ReconcilerBridgeManager.bridge({


### PR DESCRIPTION
The PR adds a new `Custom` type in our renderer that allows users to define their own custom components.

I've kept this slightly different from the `createElement` approach that `react-native-web` uses so that we can contain all custom components in the `Custom` node type. That way if we have native renderers in the future, we can chose to either ignore these components completely or write native renderers based on the `component` property. This'll ensure that the xnfts don't completely break when rendering it on a native mobile device.

This will unblock users that are building xnfts for now, but we would need to figure out the best way to integrate this in native once we have RN support.

Closes https://github.com/coral-xyz/backpack/issues/1030 , https://github.com/coral-xyz/backpack/issues/872 , https://github.com/coral-xyz/backpack/issues/1026

## Screenshot of custom types xnft example - 
<img width="371" alt="Screenshot 2022-10-11 at 6 16 42 AM" src="https://user-images.githubusercontent.com/8079861/194973460-80c95642-fd07-4112-9a62-150551a6d9e5.png">
