### PR TITLE
Update wallet standard wrapper

### DIFF
--- a/packages/provider-injection/package.json
+++ b/packages/provider-injection/package.json
@@ -11,7 +11,7 @@
     "@coral-xyz/provider-core": "*",
     "@project-serum/anchor": "^0.23.0",
     "@solana/web3.js": "^1.63.1",
-    "@wallet-standard/wallets-backpack": "0.1.0-alpha.7",
+    "@wallet-standard/wallets-backpack": "0.1.0-alpha.10",
     "bs58": "^5.0.0",
     "eth-rpc-errors": "^4.0.3",
     "eventemitter3": "^4.0.7"

--- a/packages/provider-injection/src/index.ts
+++ b/packages/provider-injection/src/index.ts
@@ -54,11 +54,8 @@ function initProvider() {
       })(),
     },
   });
-  try {
-    register();
-  } catch (e) {
-    logger.error("standard wallet registration failed", e);
-  }
+
+  register();
 }
 
 main();


### PR DESCRIPTION
This updates to the latest `@wallet-standard/wallets-backpack` release. This may be the final test release of the package before it will be inlined with Backpack in this repo. The guard around the register function is no longer needed (it does this internally now). Everything works in testing so far.