### PR TITLE
window.xnft object unable to sign transactions after changing urls fix.

### DIFF
--- a/packages/provider-core/src/request-manager.ts
+++ b/packages/provider-core/src/request-manager.ts
@@ -14,6 +14,7 @@ export class RequestManager {
   private _requestChannel: string;
   private _responseChannel: string;
   private _parent?: boolean;
+  private _url?: string;
 
   constructor(
     requestChannel: string,
@@ -25,6 +26,9 @@ export class RequestManager {
     this._requestId = 0;
     this._responseResolvers = {};
     this._parent = parent;
+    if (parent) {
+      this._url = window.location.href;
+    }
     this._initChannels();
   }
 
@@ -63,7 +67,7 @@ export class RequestManager {
       window.parent.postMessage(
         {
           type: this._requestChannel,
-          href: window.location.href,
+          href: this._url ?? window.location.href,
           detail: {
             id,
             method,

--- a/packages/provider-core/src/request-manager.ts
+++ b/packages/provider-core/src/request-manager.ts
@@ -67,7 +67,8 @@ export class RequestManager {
       window.parent.postMessage(
         {
           type: this._requestChannel,
-          href: this._url ?? window.location.href,
+          // this._url will always be set here, because this._parent is true.
+          href: this._url!,
           detail: {
             id,
             method,


### PR DESCRIPTION
This commit fixes issue (#1081 ). I tried to fix it by saving url, in case parent object is true. Maybe this is not the best solution for other cases.