### PR TITLE
incorrect password keyring load state fix

### DIFF
--- a/packages/background/src/backend/keyring/index.ts
+++ b/packages/background/src/backend/keyring/index.ts
@@ -316,7 +316,7 @@ export class KeyringStore {
   }
 
   private isUnlocked(): boolean {
-    return this.lastUsedTs !== 0;
+    return this.blockchains.size > 0 && this.lastUsedTs !== 0;
   }
 
   private async persist(forceBecauseCalledFromInit = false) {

--- a/packages/background/src/backend/keyring/index.ts
+++ b/packages/background/src/backend/keyring/index.ts
@@ -436,7 +436,7 @@ export class KeyringStore {
         return blockchain as Blockchain;
       }
     }
-    throw new Error("no blockchain for public key");
+    throw new Error(`no blockchain for ${publicKey}`);
   }
 
   /**
@@ -447,7 +447,7 @@ export class KeyringStore {
     if (keyring) {
       return keyring;
     }
-    throw new Error("no keyring for blockchain");
+    throw new Error(`no keyring for ${blockchain}`);
   }
 
   /**
@@ -459,6 +459,6 @@ export class KeyringStore {
         return keyring;
       }
     }
-    throw new Error("no keyring for public key");
+    throw new Error(`no keyring for ${publicKey}`);
   }
 }


### PR DESCRIPTION
Closes https://github.com/coral-xyz/backpack/issues/1092

An incorrect password input [would update](https://github.com/coral-xyz/backpack/blob/master/packages/background/src/backend/keyring/index.ts#L357) `lastUsedTs` which made the keyring think it was unlocked even though no data had been loaded from the encrypted store. On the next unlock it would try and access data it expected to be there but the `blockchains` map would be empty.