### PR TITLE
chore: disable change password button when password empty

### DIFF
--- a/packages/app-extension/src/components/Unlocked/Settings/YourAccount/ChangePassword.tsx
+++ b/packages/app-extension/src/components/Unlocked/Settings/YourAccount/ChangePassword.tsx
@@ -39,6 +39,7 @@ export function ChangePassword() {
 
   const [currentPasswordError, setCurrentPasswordError] = useState(false);
   const [passwordMismatchError, setPasswordMismatchError] = useState(false);
+  const missingNewPw = newPw1.trim() === "" || newPw2.trim() === "";
 
   useEffect(() => {
     const title = nav.title;
@@ -212,7 +213,11 @@ export function ChangePassword() {
           </SubtextParagraph>
         </div>
         <div style={{ padding: 16 }}>
-          <PrimaryButton label="Change password" type="submit" />
+          <PrimaryButton
+            label="Change password"
+            type="submit"
+            disabled={missingNewPw}
+          />
         </div>
       </form>
     </div>


### PR DESCRIPTION
Resolves #250

If you want we could modify line 60 to remove `newPw1.trim() === ""` but I figured it doesn't hurt to leave it in.