### PR TITLE
proper handling of connection url changes if blockchain disabled

### DIFF
--- a/packages/background/src/backend/core.ts
+++ b/packages/background/src/backend/core.ts
@@ -189,6 +189,15 @@ export class Backend {
       return false;
     }
 
+    let keyring: BlockchainKeyring | null;
+    try {
+      keyring = this.keyringStore.keyringForBlockchain(Blockchain.SOLANA);
+    } catch {
+      // Blockchain may be disabled
+      keyring = null;
+    }
+    const activeWallet = keyring ? keyring.getActiveWallet() : null;
+
     await setWalletData({
       ...data,
       solana: {
@@ -200,6 +209,7 @@ export class Backend {
     this.events.emit(BACKEND_EVENT, {
       name: NOTIFICATION_SOLANA_CONNECTION_URL_UPDATED,
       data: {
+        activeWallet,
         url: cluster,
       },
     });
@@ -328,6 +338,7 @@ export class Backend {
 
   async ethereumConnectionUrlUpdate(connectionUrl: string): Promise<string> {
     const data = await store.getWalletData();
+
     await store.setWalletData({
       ...data,
       ethereum: {
@@ -335,9 +346,20 @@ export class Backend {
         connectionUrl,
       },
     });
+
+    let keyring: BlockchainKeyring | null;
+    try {
+      keyring = this.keyringStore.keyringForBlockchain(Blockchain.ETHEREUM);
+    } catch {
+      // Blockchain may be disabled
+      keyring = null;
+    }
+    const activeWallet = keyring ? keyring.getActiveWallet() : null;
+
     this.events.emit(BACKEND_EVENT, {
       name: NOTIFICATION_ETHEREUM_CONNECTION_URL_UPDATED,
       data: {
+        activeWallet,
         connectionUrl,
       },
     });

--- a/packages/background/src/backend/solana-connection.ts
+++ b/packages/background/src/backend/solana-connection.ts
@@ -1,11 +1,4 @@
-import {
-  AddressLookupTableAccount,
-  Connection,
-  GetAccountInfoConfig,
-  PublicKey,
-  SimulateTransactionConfig,
-  VersionedMessage,
-} from "@solana/web3.js";
+import { Connection, PublicKey } from "@solana/web3.js";
 import type {
   Commitment,
   GetSupplyConfig,
@@ -68,6 +61,10 @@ import type {
   SignatureStatus,
   PerfSample,
   BlockheightBasedTransactionConfirmationStrategy,
+  AddressLookupTableAccount,
+  GetAccountInfoConfig,
+  SimulateTransactionConfig,
+  VersionedMessage,
 } from "@solana/web3.js";
 import type { Notification, EventEmitter } from "@coral-xyz/common";
 import { encode } from "bs58";
@@ -186,9 +183,13 @@ export class SolanaConnectionBackend {
       const { activeWallet, url } = notif.data;
       this.connection = new Connection(url, this.connection!.commitment);
       this.url = url;
-      this.stopPolling();
-      this.hookRpcRequest();
-      this.startPolling(new PublicKey(activeWallet));
+      // activeWallet can be null if the blockchain is disabled, in that case
+      // we don't want to start polling
+      if (activeWallet) {
+        this.stopPolling();
+        this.hookRpcRequest();
+        this.startPolling(new PublicKey(activeWallet));
+      }
     };
 
     const handleBlockchainEnabled = (notif: Notification) => {


### PR DESCRIPTION
Pass activeWallet with the connection url event (which will be null if blockchain is disabled) and don't restart polling if it is disabled.