### PR TITLE
Added npmignore

### DIFF
--- a/packages/react-xnft-dom-renderer/.npmignore
+++ b/packages/react-xnft-dom-renderer/.npmignore
@@ -1,0 +1,4 @@
+index.js.map
+index.js
+src
+


### PR DESCRIPTION
The `dist` folder isn't being published now since it's part of `.gitignore`. 
`.npmignore` overrides it.