### PR TITLE
Copy update refactor from "Trusted apps" to "Trusted sites"

### DIFF
--- a/packages/app-extension/src/components/Unlocked/Settings/Preferences/TrustedSites.tsx
+++ b/packages/app-extension/src/components/Unlocked/Settings/Preferences/TrustedSites.tsx
@@ -8,20 +8,20 @@ import { useNavStack } from "../../../common/Layout/NavStack";
 import { List, ListItem, PrimaryButton } from "../../../common";
 import { EmptyState } from "../../../common/EmptyState";
 
-export function PreferencesTrustedApps() {
+export function PreferencesTrustedSites() {
   const theme = useCustomTheme();
   const nav = useNavStack();
   const approvedOrigins = useApprovedOrigins();
 
   useEffect(() => {
-    nav.setTitle("Trusted Apps");
+    nav.setTitle("Trusted Sites");
   }, [nav]);
 
   return approvedOrigins.length === 0 ? (
     <EmptyState
       icon={(props: any) => <GppBad {...props} />}
-      title={"No trusted apps"}
-      subtitle={"Trusted apps will be listed here"}
+      title={"No trusted sites"}
+      subtitle={"Trusted sites will be listed here"}
       contentStyle={{
         marginBottom: "64px", // Tab height offset.
       }}

--- a/packages/app-extension/src/components/Unlocked/Settings/Preferences/index.tsx
+++ b/packages/app-extension/src/components/Unlocked/Settings/Preferences/index.tsx
@@ -37,8 +37,8 @@ export function Preferences() {
     "Auto-lock timer": {
       onClick: () => nav.push("preferences-auto-lock"),
     },
-    "Trusted Apps": {
-      onClick: () => nav.push("preferences-trusted-apps"),
+    "Trusted Sites": {
+      onClick: () => nav.push("preferences-trusted-sites"),
     },
   };
 

--- a/packages/app-extension/src/components/Unlocked/Settings/index.tsx
+++ b/packages/app-extension/src/components/Unlocked/Settings/index.tsx
@@ -66,7 +66,7 @@ import { Preferences } from "./Preferences";
 import { PreferencesSolana } from "./Preferences/Solana";
 import { PreferencesEthereum } from "./Preferences/Ethereum";
 import { PreferencesAutoLock } from "./Preferences/AutoLock";
-import { PreferencesTrustedApps } from "./Preferences/TrustedApps";
+import { PreferencesTrustedSites } from "./Preferences/TrustedSites";
 import { PreferencesSolanaConnection } from "./Preferences/Solana/ConnectionSwitch";
 import { PreferencesSolanaCommitment } from "./Preferences/Solana/Commitment";
 import { PreferencesSolanaExplorer } from "./Preferences/Solana/Explorer";
@@ -200,8 +200,8 @@ function AvatarButton() {
               component={(props: any) => <PreferencesAutoLock {...props} />}
             />
             <NavStackScreen
-              name={"preferences-trusted-apps"}
-              component={(props: any) => <PreferencesTrustedApps {...props} />}
+              name={"preferences-trusted-sites"}
+              component={(props: any) => <PreferencesTrustedSites {...props} />}
             />
             <NavStackScreen
               name={"preferences-solana"}


### PR DESCRIPTION
Fixes #1129 

- Changed "Trusted Apps" to "Trusted Sites" everywhere in the UI
- renamed preferences text and files to reflect the above

<img width="359" alt="image" src="https://user-images.githubusercontent.com/51456744/196040564-727428bc-e388-4b17-ab95-fc8ef2c2e4b2.png">

<img width="363" alt="image" src="https://user-images.githubusercontent.com/51456744/196040578-052280dc-532c-42f0-9900-2014b310dbb2.png">
