### PR TITLE
add an import accounts wrapper around the ledger flow for reuse

### DIFF
--- a/packages/app-extension/src/components/Unlocked/Settings/AddConnectWallet/ConnectHardware/ConnectHardwareImport.tsx
+++ b/packages/app-extension/src/components/Unlocked/Settings/AddConnectWallet/ConnectHardware/ConnectHardwareImport.tsx
@@ -10,7 +10,7 @@ import { SelectedAccount } from "../../../../common/Account/ImportAccounts";
 import { ConnectHardware } from "../ConnectHardware";
 
 //
-// This is a wrapper method around the ConnectHardware flow that providwes
+// This is a wrapper method around the ConnectHardware flow that provides
 // a function to import accounts and derivation paths into the keyring store
 // to the onImport prop.
 //

--- a/packages/app-extension/src/components/Unlocked/Settings/AddConnectWallet/ConnectHardware/ConnectHardwareImport.tsx
+++ b/packages/app-extension/src/components/Unlocked/Settings/AddConnectWallet/ConnectHardware/ConnectHardwareImport.tsx
@@ -1,0 +1,66 @@
+import {
+  Blockchain,
+  DerivationPath,
+  UI_RPC_METHOD_LEDGER_IMPORT,
+  UI_RPC_METHOD_KEYRING_ACTIVE_WALLET_UPDATE,
+} from "@coral-xyz/common";
+import { useBackgroundClient } from "@coral-xyz/recoil";
+import { OptionsContainer } from "../../../../Onboarding";
+import { SelectedAccount } from "../../../../common/Account/ImportAccounts";
+import { ConnectHardware } from "../ConnectHardware";
+
+//
+// This is a wrapper method around the ConnectHardware flow that providwes
+// a function to import accounts and derivation paths into the keyring store
+// to the onImport prop.
+//
+export function ConnectHardwareImport({
+  blockchain,
+  onComplete,
+}: {
+  blockchain: Blockchain;
+  onComplete: () => void;
+}) {
+  const background = useBackgroundClient();
+
+  //
+  // Add one or more pubkeys to the Ledger store.
+  //
+  const ledgerImport = async (
+    accounts: SelectedAccount[],
+    derivationPath: DerivationPath
+  ) => {
+    for (const account of accounts) {
+      await background.request({
+        method: UI_RPC_METHOD_LEDGER_IMPORT,
+        params: [
+          blockchain,
+          derivationPath,
+          account.index,
+          account.publicKey.toString(),
+        ],
+      });
+    }
+
+    //
+    // Automatically switch to the first wallet in the import list.
+    //
+    if (accounts.length > 0) {
+      const active = accounts[0].publicKey.toString();
+      await background.request({
+        method: UI_RPC_METHOD_KEYRING_ACTIVE_WALLET_UPDATE,
+        params: [active, blockchain],
+      });
+    }
+  };
+
+  return (
+    <OptionsContainer>
+      <ConnectHardware
+        blockchain={blockchain}
+        onImport={ledgerImport}
+        onComplete={onComplete}
+      />
+    </OptionsContainer>
+  );
+}

--- a/packages/app-extension/src/components/Unlocked/Settings/AddConnectWallet/ConnectHardware/index.tsx
+++ b/packages/app-extension/src/components/Unlocked/Settings/AddConnectWallet/ConnectHardware/index.tsx
@@ -1,29 +1,26 @@
 import { useState } from "react";
 import Transport from "@ledgerhq/hw-transport";
-import {
-  Blockchain,
-  DerivationPath,
-  UI_RPC_METHOD_LEDGER_IMPORT,
-  UI_RPC_METHOD_KEYRING_ACTIVE_WALLET_UPDATE,
-} from "@coral-xyz/common";
-import { useBackgroundClient } from "@coral-xyz/recoil";
+import { Blockchain, DerivationPath } from "@coral-xyz/common";
 import { useCustomTheme } from "@coral-xyz/themes";
 import { ConnectHardwareWelcome } from "./ConnectHardwareWelcome";
 import { ConnectHardwareSearching } from "./ConnectHardwareSearching";
 import { ConnectHardwareSuccess } from "./ConnectHardwareSuccess";
 import { ImportAccounts } from "../../../../common/Account/ImportAccounts";
 import type { SelectedAccount } from "../../../../common/Account/ImportAccounts";
-import { OptionsContainer } from "../../../../Onboarding";
 import { WithNav, NavBackButton } from "../../../../common/Layout/Nav";
 
 export function ConnectHardware({
   blockchain,
+  onImport,
   onComplete,
 }: {
   blockchain: Blockchain;
+  onImport?: (
+    accounts: SelectedAccount[],
+    derivationPath: DerivationPath
+  ) => Promise<void>;
   onComplete: () => void;
 }) {
-  const background = useBackgroundClient();
   const theme = useCustomTheme();
   const [transport, setTransport] = useState<Transport | null>(null);
   const [transportError, setTransportError] = useState(false);
@@ -32,37 +29,6 @@ export function ConnectHardware({
   const nextStep = () => setStep(step + 1);
   const prevStep = () => {
     if (step > 0) setStep(step - 1);
-  };
-
-  //
-  // Add one or more pubkeys to the Ledger store.
-  //
-  const ledgerImport = async (
-    accounts: SelectedAccount[],
-    derivationPath: DerivationPath
-  ) => {
-    for (const account of accounts) {
-      await background.request({
-        method: UI_RPC_METHOD_LEDGER_IMPORT,
-        params: [
-          blockchain,
-          derivationPath,
-          account.index,
-          account.publicKey.toString(),
-        ],
-      });
-    }
-
-    //
-    // Automatically switch to the first wallet in the import list.
-    //
-    if (accounts.length > 0) {
-      const active = accounts[0].publicKey.toString();
-      await background.request({
-        method: UI_RPC_METHOD_KEYRING_ACTIVE_WALLET_UPDATE,
-        params: [active, blockchain],
-      });
-    }
   };
 
   //
@@ -85,7 +51,9 @@ export function ConnectHardware({
         accounts: SelectedAccount[],
         derivationPath: DerivationPath
       ) => {
-        await ledgerImport(accounts, derivationPath);
+        if (onImport) {
+          await onImport(accounts, derivationPath);
+        }
         nextStep();
       }}
       onError={() => {
@@ -97,23 +65,21 @@ export function ConnectHardware({
   ];
 
   return (
-    <OptionsContainer>
-      <WithNav
-        navButtonLeft={
-          step > 0 && step < connectHardwareFlow.length - 1 ? (
-            <NavBackButton onClick={prevStep} />
-          ) : null
-        }
-        navbarStyle={{
-          backgroundColor: theme.custom.colors.nav,
-        }}
-        navContentStyle={{
-          backgroundColor: theme.custom.colors.nav,
-          height: "100%",
-        }}
-      >
-        {connectHardwareFlow[step]}
-      </WithNav>
-    </OptionsContainer>
+    <WithNav
+      navButtonLeft={
+        step > 0 && step < connectHardwareFlow.length - 1 ? (
+          <NavBackButton onClick={prevStep} />
+        ) : null
+      }
+      navbarStyle={{
+        backgroundColor: theme.custom.colors.nav,
+      }}
+      navContentStyle={{
+        backgroundColor: theme.custom.colors.nav,
+        height: "400px",
+      }}
+    >
+      {connectHardwareFlow[step]}
+    </WithNav>
   );
 }

--- a/packages/app-extension/src/options/Options.tsx
+++ b/packages/app-extension/src/options/Options.tsx
@@ -9,7 +9,7 @@ import {
   NotificationsProvider,
 } from "@coral-xyz/recoil";
 import { WithSuspense } from "../app/Router";
-import { ConnectHardware } from "../components/Unlocked/Settings/AddConnectWallet/ConnectHardware";
+import { ConnectHardwareImport } from "../components/Unlocked/Settings/AddConnectWallet/ConnectHardware/ConnectHardwareImport";
 import { Onboarding } from "../components/Onboarding";
 import "../app/App.css";
 import { WithTheme } from "../components/common/WithTheme";
@@ -59,7 +59,7 @@ function Router() {
       const params = new URLSearchParams(window.location.search);
       const blockchain = params.get("blockchain") || Blockchain.SOLANA;
       return (
-        <ConnectHardware
+        <ConnectHardwareImport
           blockchain={blockchain as Blockchain}
           onComplete={window.close}
         />


### PR DESCRIPTION
Adds a wrapper component around `<ConnectHardware />` that does imports into the keyring store so we can reuse the `<ConnectHardware />` component for the onboarding flow where the account should not be imported immediately but at keyring store creation.