### PR TITLE
fill => fit for proxying images

### DIFF
--- a/packages/common-public/src/utils.ts
+++ b/packages/common-public/src/utils.ts
@@ -59,5 +59,5 @@ export function proxyImageUrl(url: string): string {
   if (url.startsWith("/")) {
     return url;
   }
-  return `${IMAGE_PROXY_URL}/insecure/rs:fill:400:400:0:0/plain/${url}`;
+  return `${IMAGE_PROXY_URL}/insecure/rs:fit:400:400:0:0/plain/${url}`;
 }


### PR DESCRIPTION
Ensure when we're proxying images, we use `fit` resizing vs `fill` to avoid pixelating/stretching the image
Closes #1175