### PR TITLE
Fixed CI/CD

### DIFF
--- a/packages/provider-injection/package.json
+++ b/packages/provider-injection/package.json
@@ -9,7 +9,7 @@
   "dependencies": {
     "@coral-xyz/common": "*",
     "@coral-xyz/provider-core": "*",
-    "@coral-xyz/wallet-standard": "1.0.0-rc.0",
+    "@coral-xyz/wallet-standard": "*",
     "@project-serum/anchor": "^0.23.0",
     "@solana/web3.js": "^1.63.1",
     "bs58": "^5.0.0",

--- a/packages/wallet-standard/package.json
+++ b/packages/wallet-standard/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@coral-xyz/wallet-standard",
-    "version": "1.0.0-rc.0",
+    "version": "0.1.0",
     "type": "module",
     "sideEffects": false,
     "main": "./lib/cjs/index.js",


### PR DESCRIPTION
Changes package version for `@coral-xyz/wallet-standard` so that `provider-injection` uses the version from the repo.
cc @jordansexton having alphabets (`rc`) seems to be confusing the mono repo to include `@coral-xyz/wallet-standard` hence changed the version to `0.1.0`