### PR TITLE
fix BigNumber formatting decimal number

### DIFF
--- a/packages/recoil/src/hooks/useTransactionData.tsx
+++ b/packages/recoil/src/hooks/useTransactionData.tsx
@@ -194,9 +194,8 @@ export function useEthereumTxData(serializedTx: any): TransactionData {
   ]);
 
   const networkFeeUsd = (
-    (estimatedTxFee.toNumber() * ethPrice.usd) /
-    1e18
-  ).toFixed(2);
+    Number(ethers.utils.formatEther(estimatedTxFee)) * ethPrice.usd
+  )?.toFixed(2);
 
   return {
     loading,


### PR DESCRIPTION
fix `Error: overflow [ See: https://links.ethers.org/v5-errors-NUMERIC_FAULT-overflow ] (fault="overflow", operation="toNumber", value="13437519875157330", code=NUMERIC_FAULT, version=bignumber/5.7.0)`

when try to sign ETH tx

