### PR TITLE
Fixed root provider, added metadata

### DIFF
--- a/examples/xnft/app/src/app.tsx
+++ b/examples/xnft/app/src/app.tsx
@@ -68,8 +68,8 @@ async function fetchOpenOrdersData(): Promise<
   // All open orders accounts for this wallet.
   //
   const openOrders = await OpenOrders.findForOwner(
-    window.xnft.connection,
-    window.xnft.publicKey,
+    window.xnft.solana.connection,
+    window.xnft.solana.publicKey,
     PID
   );
 
@@ -86,7 +86,7 @@ async function fetchOpenOrdersData(): Promise<
     })();
 
     const multipleMarkets = await anchor.utils.rpc.getMultipleAccounts(
-      window.xnft.connection,
+      window.xnft.solana.connection,
       Array.from(markets.values()).map((m) => new PublicKey(m))
     );
     return new Map(

--- a/examples/xnft/mango/src/app.tsx
+++ b/examples/xnft/mango/src/app.tsx
@@ -10,14 +10,15 @@ import AnchorUi, {
   BalancesTableFooter,
   BalancesTableRow,
   BalancesTableCell,
+  SOLANA_CONNECT,
 } from "react-xnft";
 import { MangoClient, Config } from "@blockworks-foundation/mango-client";
 
 //
 // On connection to the host environment, warm the cache.
 //
-AnchorUi.events.on("connect", () => {
-  fetchRowData(window.xnft.publicKey);
+AnchorUi.events.on(SOLANA_CONNECT, () => {
+  fetchRowData(window.xnft.solana.publicKey);
 });
 
 export function App() {
@@ -28,10 +29,10 @@ function MangoTable() {
   const [rowData, setRowData] = useState<Array<any> | null>(null);
   useEffect(() => {
     (async () => {
-      const { rowData } = await fetchRowData(window.xnft.publicKey);
+      const { rowData } = await fetchRowData(window.xnft.solana.publicKey);
       setRowData(rowData);
     })();
-  }, [window.xnft.publicKey]);
+  }, [window.xnft.solana.publicKey]);
   return (
     <BalancesTable>
       <BalancesTableHead
@@ -80,7 +81,7 @@ async function fetchRowData(wallet: PublicKey): Promise<any> {
 }
 
 async function fetchRowDataInner(wallet: PublicKey) {
-  const client = new MangoClient(window.xnft.connection, MANGO_PID);
+  const client = new MangoClient(window.xnft.solana.connection, MANGO_PID);
   const config = Config.ids().getGroupWithName("mainnet.1");
   if (!config) {
     throw new Error("config not found");
@@ -91,7 +92,7 @@ async function fetchRowDataInner(wallet: PublicKey) {
     wallet
   );
 
-  const mangoCache = await mangoGroup.loadCache(window.xnft.connection);
+  const mangoCache = await mangoGroup.loadCache(window.xnft.solana.connection);
 
   const rowData = await Promise.all(
     mangoAccounts.map(async (ma) => {

--- a/packages/app-extension/src/components/Unlocked/Apps/Plugin.tsx
+++ b/packages/app-extension/src/components/Unlocked/Apps/Plugin.tsx
@@ -54,7 +54,6 @@ export function _PluginDisplay({
   closePlugin: () => void;
 }) {
   const theme = useCustomTheme();
-  const isDarkMode = useDarkMode();
 
   // TODO: splash loading page.
   return (
@@ -65,11 +64,7 @@ export function _PluginDisplay({
       }}
     >
       <PluginControl closePlugin={closePlugin} />
-      <PluginRenderer
-        key={plugin.iframeRootUrl}
-        plugin={plugin}
-        metadata={{ isDarkMode }}
-      />
+      <PluginRenderer key={plugin.iframeRootUrl} plugin={plugin} />
     </div>
   );
 }

--- a/packages/app-extension/src/plugin/Renderer.tsx
+++ b/packages/app-extension/src/plugin/Renderer.tsx
@@ -1,20 +1,19 @@
 import { useEffect, useRef, useState } from "react";
 import { Loading } from "../components/common";
+import { useAvatarUrl, useDarkMode, useUsername } from "@coral-xyz/recoil";
 
-export function PluginRenderer({
-  plugin,
-  metadata,
-}: {
-  plugin: any;
-  metadata: any;
-}) {
+export function PluginRenderer({ plugin }: { plugin: any }) {
   const ref = useRef<any>();
   const [loaded, setLoaded] = useState(false);
+  const username = useUsername();
+  const isDarkMode = useDarkMode();
+  const avatarUrl = useAvatarUrl(100);
 
   useEffect(() => {
     if (plugin && ref && ref.current) {
-      plugin.mount(metadata);
+      plugin.mount();
       plugin.didFinishSetup!.then(() => {
+        plugin.pushAppUiMetadata({ isDarkMode, username, avatarUrl });
         plugin.iframeRoot.style.display = "";
         setLoaded(true);
       });
@@ -26,6 +25,10 @@ export function PluginRenderer({
     }
     return () => {};
   }, [plugin, ref]);
+
+  useEffect(() => {
+    plugin.pushAppUiMetadata({ isDarkMode, username, avatarUrl });
+  }, [username, isDarkMode, avatarUrl]);
 
   return (
     <div ref={ref} style={{ height: "100vh", overflow: "hidden" }}>

--- a/packages/common/src/plugin.ts
+++ b/packages/common/src/plugin.ts
@@ -37,7 +37,7 @@ import { getLogger, Event } from "@coral-xyz/common-public";
 import { BackgroundClient } from "./channel/app-ui";
 import { PluginServer } from "./channel/plugin";
 
-import { Metadata, Blockchain, RpcResponse } from "./types";
+import { XnftMetadata, Blockchain, RpcResponse } from "./types";
 
 const logger = getLogger("common/plugin");
 
@@ -211,11 +211,10 @@ export class Plugin {
   // Rendering.
   //////////////////////////////////////////////////////////////////////////////
 
-  public mount(metadata: Metadata) {
+  public mount() {
     this.createIframe();
     this.didFinishSetup!.then(() => {
       this.pushMountNotification();
-      this.pushAppUiMetadata(metadata);
     });
   }
 
@@ -242,7 +241,7 @@ export class Plugin {
     this.iframeRoot?.contentWindow?.postMessage(event, "*");
   }
 
-  public pushAppUiMetadata(metadata: Metadata) {
+  public pushAppUiMetadata(metadata: XnftMetadata) {
     const event = {
       type: CHANNEL_PLUGIN_NOTIFICATION,
       detail: {
@@ -270,11 +269,7 @@ export class Plugin {
       detail: {
         name: PLUGIN_NOTIFICATION_CONNECT,
         data: {
-          // Deprecate in favour of publicKeys
-          publicKey: this._activeWallets[Blockchain.SOLANA],
           publicKeys: this._activeWallets,
-          // Deprecate in favor of connectionUrls
-          connectionUrl: this._connectionUrls[Blockchain.SOLANA],
           connectionUrls: this._connectionUrls,
         },
       },

--- a/packages/common/src/types.ts
+++ b/packages/common/src/types.ts
@@ -63,6 +63,8 @@ export type NftAttribute = {
   value: string;
 };
 
-export interface Metadata {
+export interface XnftMetadata {
   isDarkMode: boolean;
+  username?: string;
+  avatarUrl: string;
 }

--- a/packages/provider-core/src/index.ts
+++ b/packages/provider-core/src/index.ts
@@ -3,3 +3,4 @@ export { ProviderSolanaInjection } from "./provider-solana";
 export { ProviderSolanaXnftInjection } from "./provider-solana-xnft";
 export { ProviderEthereumInjection } from "./provider-ethereum";
 export { ProviderEthereumXnftInjection } from "./provider-ethereum-xnft";
+export { ProviderRootXnftInjection } from "./root-provider-xnft";

--- a/packages/provider-core/src/provider-ethereum-xnft.ts
+++ b/packages/provider-core/src/provider-ethereum-xnft.ts
@@ -127,7 +127,6 @@ export class ProviderEthereumXnftInjection extends PrivateEventEmitter {
       publicKeys[Blockchain.ETHEREUM],
       connectionUrls[Blockchain.ETHEREUM]
     );
-    // Don't emit a connect even because the Solana xnft provider handles that
   }
 
   #handleConnectionUrlUpdated(event: Event) {

--- a/packages/provider-core/src/provider-ethereum-xnft.ts
+++ b/packages/provider-core/src/provider-ethereum-xnft.ts
@@ -127,6 +127,7 @@ export class ProviderEthereumXnftInjection extends PrivateEventEmitter {
       publicKeys[Blockchain.ETHEREUM],
       connectionUrls[Blockchain.ETHEREUM]
     );
+    this.emit("connect", event.data.detail);
   }
 
   #handleConnectionUrlUpdated(event: Event) {

--- a/packages/provider-core/src/provider-solana-xnft.ts
+++ b/packages/provider-core/src/provider-solana-xnft.ts
@@ -48,19 +48,8 @@ export class ProviderSolanaXnftInjection
   #publicKey?: PublicKey;
   #connection: Connection;
 
-  #childIframes: HTMLIFrameElement[];
-  #cachedNotifications: { [notification: string]: Event };
-
-  constructor(
-    requestManager: RequestManager,
-    additionalProperties: { [key: string]: PrivateEventEmitter } = {}
-  ) {
+  constructor(requestManager: RequestManager) {
     super();
-    const additionalPropertyConfig = {};
-    Object.keys(additionalProperties).forEach((prop) => {
-      additionalPropertyConfig[prop] = { value: additionalProperties[prop] };
-    });
-    Object.defineProperties(this, additionalPropertyConfig);
     if (new.target === ProviderSolanaXnftInjection) {
       Object.freeze(this);
     }
@@ -69,8 +58,6 @@ export class ProviderSolanaXnftInjection
       CHANNEL_SOLANA_CONNECTION_INJECTED_REQUEST,
       CHANNEL_SOLANA_CONNECTION_INJECTED_RESPONSE
     );
-    this.#childIframes = [];
-    this.#cachedNotifications = {};
     this.#setupChannels();
   }
 
@@ -172,51 +159,6 @@ export class ProviderSolanaXnftInjection
     );
   }
 
-  public async getStorage<T = any>(key: string): Promise<T> {
-    return await this.#requestManager.request({
-      method: PLUGIN_RPC_METHOD_LOCAL_STORAGE_GET,
-      params: [key],
-    });
-  }
-
-  public async setStorage<T = any>(key: string, val: T): Promise<void> {
-    await this.#requestManager.request({
-      method: PLUGIN_RPC_METHOD_LOCAL_STORAGE_PUT,
-      params: [key, val],
-    });
-  }
-
-  public async openWindow(url: string) {
-    await this.#requestManager.request({
-      method: PLUGIN_RPC_METHOD_WINDOW_OPEN,
-      params: [url],
-    });
-  }
-
-  public async addIframe(iframeEl) {
-    // Send across mount and connect notification to child iframes
-    if (this.#cachedNotifications[PLUGIN_NOTIFICATION_MOUNT]) {
-      iframeEl.contentWindow?.postMessage(
-        this.#cachedNotifications[PLUGIN_NOTIFICATION_MOUNT],
-        "*"
-      );
-    }
-
-    if (this.#cachedNotifications[PLUGIN_NOTIFICATION_CONNECT]) {
-      iframeEl.contentWindow?.postMessage(
-        this.#cachedNotifications[PLUGIN_NOTIFICATION_CONNECT],
-        "*"
-      );
-    }
-
-    this.#childIframes.push(iframeEl);
-  }
-
-  public async removeIframe(iframeEl) {
-    // @ts-ignore
-    this.#childIframes = this.#childIframes.filter((x) => x !== iframeEl);
-  }
-
   #setupChannels() {
     window.addEventListener("message", this.#handleNotifications.bind(this));
   }
@@ -227,15 +169,9 @@ export class ProviderSolanaXnftInjection
   async #handleNotifications(event: Event) {
     if (event.data.type !== CHANNEL_PLUGIN_NOTIFICATION) return;
 
-    // Send RPC message to all child iframes
-    this.#childIframes.forEach((iframe) => {
-      iframe.contentWindow?.postMessage(event, "*");
-    });
-
     logger.debug("handle notification", event);
 
     const { name } = event.data.detail;
-    this.#cachedNotifications[name] = event.data;
     switch (name) {
       case PLUGIN_NOTIFICATION_CONNECT:
         this.#handleConnect(event);
@@ -266,7 +202,6 @@ export class ProviderSolanaXnftInjection
     const publicKey = publicKeys[Blockchain.SOLANA];
     const connectionUrl = connectionUrls[Blockchain.SOLANA];
     this.#connect(publicKey, connectionUrl);
-    this.emit("connect", event.data.detail);
   }
 
   #handleMount(event: Event) {

--- a/packages/provider-core/src/provider-solana-xnft.ts
+++ b/packages/provider-core/src/provider-solana-xnft.ts
@@ -202,6 +202,7 @@ export class ProviderSolanaXnftInjection
     const publicKey = publicKeys[Blockchain.SOLANA];
     const connectionUrl = connectionUrls[Blockchain.SOLANA];
     this.#connect(publicKey, connectionUrl);
+    this.emit("connect", event.data.detail);
   }
 
   #handleMount(event: Event) {

--- a/packages/provider-core/src/root-provider-xnft.ts
+++ b/packages/provider-core/src/root-provider-xnft.ts
@@ -1,0 +1,194 @@
+import type { Event, XnftMetadata } from "@coral-xyz/common";
+import {
+  getLogger,
+  CHANNEL_SOLANA_CONNECTION_INJECTED_REQUEST,
+  CHANNEL_SOLANA_CONNECTION_INJECTED_RESPONSE,
+  CHANNEL_PLUGIN_NOTIFICATION,
+  PLUGIN_NOTIFICATION_CONNECT,
+  PLUGIN_NOTIFICATION_MOUNT,
+  PLUGIN_NOTIFICATION_UNMOUNT,
+  PLUGIN_RPC_METHOD_LOCAL_STORAGE_GET,
+  PLUGIN_RPC_METHOD_LOCAL_STORAGE_PUT,
+  PLUGIN_RPC_METHOD_WINDOW_OPEN,
+  PLUGIN_NOTIFICATION_UPDATE_METADATA,
+  Blockchain,
+  PLUGIN_NOTIFICATION_SOLANA_PUBLIC_KEY_UPDATED,
+  PLUGIN_NOTIFICATION_ETHEREUM_PUBLIC_KEY_UPDATED,
+} from "@coral-xyz/common";
+import { RequestManager } from "./request-manager";
+import { PrivateEventEmitter } from "./common/PrivateEventEmitter";
+
+const logger = getLogger("provider-xnft-injection");
+
+//
+// Injected provider for UI plugins.
+//
+export class ProviderRootXnftInjection extends PrivateEventEmitter {
+  #requestManager: RequestManager;
+  #connectionRequestManager: RequestManager;
+  #publicKeys: { [blockchain: string]: string };
+  #connectionUrls: { [blockchain: string]: string | null };
+
+  #childIframes: HTMLIFrameElement[];
+  #cachedNotifications: { [notification: string]: Event };
+  #metadata: XnftMetadata;
+
+  constructor(
+    requestManager: RequestManager,
+    additionalProperties: { [key: string]: PrivateEventEmitter } = {}
+  ) {
+    super();
+    const additionalPropertyConfig = {};
+    Object.keys(additionalProperties).forEach((prop) => {
+      additionalPropertyConfig[prop] = { value: additionalProperties[prop] };
+    });
+    Object.defineProperties(this, additionalPropertyConfig);
+    if (new.target === ProviderRootXnftInjection) {
+      Object.freeze(this);
+    }
+    this.#requestManager = requestManager;
+    this.#connectionRequestManager = new RequestManager(
+      CHANNEL_SOLANA_CONNECTION_INJECTED_REQUEST,
+      CHANNEL_SOLANA_CONNECTION_INJECTED_RESPONSE
+    );
+    this.#childIframes = [];
+    this.#cachedNotifications = {};
+    this.#setupChannels();
+  }
+
+  public async getStorage<T = any>(key: string): Promise<T> {
+    return await this.#requestManager.request({
+      method: PLUGIN_RPC_METHOD_LOCAL_STORAGE_GET,
+      params: [key],
+    });
+  }
+
+  public async setStorage<T = any>(key: string, val: T): Promise<void> {
+    await this.#requestManager.request({
+      method: PLUGIN_RPC_METHOD_LOCAL_STORAGE_PUT,
+      params: [key, val],
+    });
+  }
+
+  public async openWindow(url: string) {
+    await this.#requestManager.request({
+      method: PLUGIN_RPC_METHOD_WINDOW_OPEN,
+      params: [url],
+    });
+  }
+
+  public async addIframe(iframeEl) {
+    // Send across mount and connect notification to child iframes
+    if (this.#cachedNotifications[PLUGIN_NOTIFICATION_MOUNT]) {
+      iframeEl.contentWindow?.postMessage(
+        this.#cachedNotifications[PLUGIN_NOTIFICATION_MOUNT],
+        "*"
+      );
+    }
+
+    if (this.#cachedNotifications[PLUGIN_NOTIFICATION_CONNECT]) {
+      iframeEl.contentWindow?.postMessage(
+        this.#cachedNotifications[PLUGIN_NOTIFICATION_CONNECT],
+        "*"
+      );
+    }
+
+    this.#childIframes.push(iframeEl);
+  }
+
+  public async removeIframe(iframeEl) {
+    // @ts-ignore
+    this.#childIframes = this.#childIframes.filter((x) => x !== iframeEl);
+  }
+
+  #setupChannels() {
+    window.addEventListener("message", this.#handleNotifications.bind(this));
+  }
+
+  //
+  // Notifications from the extension UI -> plugin.
+  //
+  async #handleNotifications(event: Event) {
+    if (event.data.type !== CHANNEL_PLUGIN_NOTIFICATION) return;
+
+    // Send RPC message to all child iframes
+    this.#childIframes.forEach((iframe) => {
+      iframe.contentWindow?.postMessage(event, "*");
+    });
+
+    logger.debug("handle notification", event);
+
+    const { name } = event.data.detail;
+    this.#cachedNotifications[name] = event.data;
+    switch (name) {
+      case PLUGIN_NOTIFICATION_CONNECT:
+        this.#handleConnect(event);
+        break;
+      case PLUGIN_NOTIFICATION_MOUNT:
+        this.#handleMount(event);
+        break;
+      case PLUGIN_NOTIFICATION_UPDATE_METADATA:
+        this.#handleUpdateMetadata(event);
+        break;
+      case PLUGIN_NOTIFICATION_UNMOUNT:
+        this.#handleUnmount(event);
+        break;
+      case PLUGIN_NOTIFICATION_SOLANA_PUBLIC_KEY_UPDATED:
+        this.#handleSolanaPublicKeyUpdated(event);
+        break;
+      case PLUGIN_NOTIFICATION_ETHEREUM_PUBLIC_KEY_UPDATED:
+        this.#handleEthereumPublicKeyUpdated(event);
+      default:
+        console.error(event);
+        throw new Error("invalid notification");
+    }
+  }
+
+  #handleSolanaPublicKeyUpdated(event) {
+    const publicKey = event.data.detail.data.publicKey;
+    this.#publicKeys[Blockchain.SOLANA] = publicKey;
+    this.emit("publicKeysUpdate", this.#publicKeys);
+  }
+
+  #handleEthereumPublicKeyUpdated(event) {
+    const publicKey = event.data.detail.data.publicKey;
+    this.#publicKeys[Blockchain.ETHEREUM] = publicKey;
+    this.emit("publicKeysUpdate", this.#publicKeys);
+  }
+
+  #handleConnect(event: Event) {
+    this.#publicKeys = event.data.detail.publicKeys;
+    this.#connectionUrls = event.data.detail.connectionUrls;
+
+    this.emit("connect", event.data.detail);
+  }
+
+  #handleMount(event: Event) {
+    this.emit("mount", event.data.detail);
+  }
+
+  #handleUpdateMetadata(event: Event) {
+    this.#metadata = event.data.detail.data.metadata;
+    this.emit("metadata", event.data.detail);
+  }
+
+  #handleUnmount(event: Event) {
+    this.emit("unmount", event.data.detail);
+  }
+
+  public freeze() {
+    return Object.freeze(this);
+  }
+
+  public get publicKeys() {
+    return this.#publicKeys;
+  }
+
+  public get connectionUrls() {
+    return this.#connectionUrls;
+  }
+
+  public get metadata() {
+    return this.#metadata;
+  }
+}

--- a/packages/provider-injection/src/index.ts
+++ b/packages/provider-injection/src/index.ts
@@ -1,6 +1,7 @@
 import {
   ProviderEthereumInjection,
   ProviderEthereumXnftInjection,
+  ProviderRootXnftInjection,
   ProviderSolanaInjection,
   ProviderSolanaXnftInjection,
   RequestManager,
@@ -46,7 +47,7 @@ function initProvider() {
           CHANNEL_PLUGIN_RPC_RESPONSE,
           true
         );
-        const xnft = new ProviderSolanaXnftInjection(requestManager, {
+        const xnft = new ProviderRootXnftInjection(requestManager, {
           ethereum: new ProviderEthereumXnftInjection(requestManager),
           solana: new ProviderSolanaXnftInjection(requestManager),
         });

--- a/packages/react-xnft-dom-renderer/src/App.tsx
+++ b/packages/react-xnft-dom-renderer/src/App.tsx
@@ -2,10 +2,13 @@ import { DomProvider } from "./Context";
 import { WithTheme } from "./WithTheme";
 import { useEffect, useState } from "react";
 import { Event } from "@coral-xyz/common-public";
-import { Element } from "react-xnft";
 import { RootRenderer } from "./Renderer";
-const DEFAULT_METADATA = {
+import { XnftMetadata } from "@coral-xyz/common";
+
+const DEFAULT_METADATA: XnftMetadata = {
   isDarkMode: false,
+  username: "",
+  photo: "",
 };
 
 export const App = () => {
@@ -16,7 +19,7 @@ export const App = () => {
   useEffect(() => {
     window.addEventListener("load", () => {
       // @ts-ignore
-      window.xnft.on("metadata", (event: Event) => {
+      window.xnft.addListener("metadata", (event: Event) => {
         setMetadata(event.data.metadata);
       });
     });

--- a/packages/react-xnft-dom-renderer/src/Context.tsx
+++ b/packages/react-xnft-dom-renderer/src/Context.tsx
@@ -1,5 +1,6 @@
 import React, { useContext } from "react";
 import { ReactDom } from "react-xnft";
+import { XnftMetadata } from "@coral-xyz/common";
 
 interface Metadata {
   isDarkMode: boolean;
@@ -7,7 +8,7 @@ interface Metadata {
 
 type DomContext = {
   dom: ReactDom;
-  metadata: Metadata;
+  metadata: XnftMetadata;
 };
 
 export const _DomContext = React.createContext<DomContext | null>(null);

--- a/packages/react-xnft/package.json
+++ b/packages/react-xnft/package.json
@@ -14,6 +14,7 @@
   "license": "ISC",
   "dependencies": {
     "@coral-xyz/common-public": "*",
+    "@coral-xyz/common": "*",
     "@coral-xyz/themes": "*",
     "@solana/web3.js": "^1.63.1",
     "eventemitter3": "^4.0.7",

--- a/packages/react-xnft/src/EVENTS.ts
+++ b/packages/react-xnft/src/EVENTS.ts
@@ -1,0 +1,3 @@
+export const CONNECT = "connect";
+export const SOLANA_CONNECT = "solana-connect";
+export const ETHEREUM_CONNECT = "ethereum-connect";

--- a/packages/react-xnft/src/hooks.tsx
+++ b/packages/react-xnft/src/hooks.tsx
@@ -1,21 +1,61 @@
 import { useState, useEffect } from "react";
 import { Connection, PublicKey } from "@solana/web3.js";
+import { Event } from "@coral-xyz/common-public";
+import { XnftMetadata } from "@coral-xyz/common";
 
+/*
+ * @Depreciated over usePublicKeys
+ */
 export function usePublicKey(): PublicKey {
-  const [publicKey, setPublicKey] = useState(window.xnft.publicKey);
+  const [publicKey, setPublicKey] = useState(window.xnft.solana?.publicKey);
   useEffect(() => {
-    window.xnft.on("publicKeyUpdate", () => {
-      setPublicKey(window.xnft.publicKey);
+    window.xnft.solana?.on("publicKeyUpdate", () => {
+      setPublicKey(window.xnft.solana.publicKey);
     });
   }, [setPublicKey]);
   return publicKey;
 }
 
-export function useConnection(): Connection {
-  const [connection, setConnection] = useState(window.xnft.connection);
+export function usePublicKeys(): PublicKey {
+  const [publicKeys, setPublicKeys] = useState(window.xnft.publicKeys);
   useEffect(() => {
-    window.xnft.on("connectionUpdate", () => {
-      setConnection(window.xnft.connection);
+    window.xnft.on("publicKeysUpdate", () => {
+      setPublicKeys(window.xnft.publicKeys);
+    });
+  }, [setPublicKeys]);
+  return publicKeys;
+}
+
+/*
+ * @Depreciated over individual connections
+ */
+export function useConnection(): Connection {
+  const [connection, setConnection] = useState(window.xnft.solana?.connection);
+  useEffect(() => {
+    window.xnft.solana?.on("connectionUpdate", () => {
+      setConnection(window.xnft.solana.connection);
+    });
+  }, [setConnection]);
+  return connection;
+}
+
+export function useSolanaConnection(): Connection {
+  const [connection, setConnection] = useState(window.xnft.solana?.connection);
+  useEffect(() => {
+    window.xnft.solana?.on("connectionUpdate", () => {
+      setConnection(window.xnft.solana.connection);
+    });
+  }, [setConnection]);
+  return connection;
+}
+
+export function useEthereumConnection(): Connection {
+  const [connection, setConnection] = useState(
+    window.xnft.ethereum?.connection
+  );
+  useEffect(() => {
+    window.xnft.ethereum?.on("connectionUpdate", () => {
+      setConnection(window.xnft.ethereum.connection);
     });
   }, [setConnection]);
   return connection;
@@ -35,4 +75,16 @@ export function useDidLaunch() {
     });
   }, []);
   return didConnect;
+}
+
+export function useMetadata(): XnftMetadata {
+  const [metadata, setMetadata] = useState(window.xnft?.metadata || {});
+
+  useEffect(() => {
+    setMetadata(window.xnft?.metadata || {});
+    window.xnft.addListener("metadata", (event: Event) => {
+      setMetadata(event.data.metadata);
+    });
+  }, []);
+  return metadata;
 }

--- a/packages/react-xnft/src/index.ts
+++ b/packages/react-xnft/src/index.ts
@@ -15,3 +15,4 @@ export * from "./elements";
 export * from "./hooks";
 export * from "./sdk";
 export * from "./ReactDom";
+export * from "./EVENTS";

--- a/packages/react-xnft/src/reconciler.ts
+++ b/packages/react-xnft/src/reconciler.ts
@@ -273,6 +273,8 @@ const RECONCILER = ReactReconciler({
         return null;
       case NodeKind.BalancesTableFooter:
         return null;
+      case NodeKind.Custom:
+        return null;
       default:
         throw new Error("unexpected node kind");
     }

--- a/packages/react-xnft/src/reconciler.ts
+++ b/packages/react-xnft/src/reconciler.ts
@@ -3,6 +3,7 @@ import { EventEmitter } from "eventemitter3";
 import { ReactDom } from "./ReactDom";
 import { getLogger, Event } from "@coral-xyz/common-public";
 import { NAV_STACK } from "./Context";
+import { CONNECT, ETHEREUM_CONNECT, SOLANA_CONNECT } from "./EVENTS";
 
 const logger = getLogger("react-xnft/reconciler");
 const events = new EventEmitter();
@@ -14,7 +15,15 @@ export const ReactXnft = {
       window.xnft.on("connect", () => {
         logger.debug("connect");
         NAV_STACK.push(reactNode);
-        events.emit("connect");
+        events.emit(CONNECT);
+      });
+
+      window.xnft.solana.on("connect", () => {
+        events.emit(SOLANA_CONNECT);
+      });
+
+      window.xnft.ethereum.on("connect", () => {
+        events.emit(ETHEREUM_CONNECT);
       });
 
       window.xnft.on("mount", () => {


### PR DESCRIPTION
Closes https://github.com/coral-xyz/backpack/issues/1162 
Closes https://github.com/coral-xyz/backpack/issues/929

Added an example to show the new `username` and `avatarUrl` functionality (username is empty because I tested it locally) - 
<img width="371" alt="Screenshot 2022-10-20 at 6 59 14 PM" src="https://user-images.githubusercontent.com/8079861/196971414-48423bc9-6a06-4c72-8215-8897d1ffe368.png">


This will be a breaking change for folks using `window.xnft.send`, they'll need to replace these with `window.xnft.solana.send`.

Will have a few follow up PRs in this repo for `gh-pages` branch and [xnft-program-library](https://github.com/coral-xyz/xnft-program-library) to fix those for our internal examples
