### PR TITLE
XnftMetadata to common-public

### DIFF
--- a/packages/common-public/src/types.ts
+++ b/packages/common-public/src/types.ts
@@ -5,3 +5,9 @@ export type RpcRequest = {
 };
 
 export type Event = any;
+
+export interface XnftMetadata {
+  isDarkMode: boolean;
+  username?: string;
+  avatarUrl: string;
+}

--- a/packages/common/src/plugin.ts
+++ b/packages/common/src/plugin.ts
@@ -33,11 +33,11 @@ import {
   PLUGIN_NOTIFICATION_UPDATE_METADATA,
 } from "./constants";
 
-import { getLogger, Event } from "@coral-xyz/common-public";
+import { getLogger, Event, XnftMetadata } from "@coral-xyz/common-public";
 import { BackgroundClient } from "./channel/app-ui";
 import { PluginServer } from "./channel/plugin";
 
-import { XnftMetadata, Blockchain, RpcResponse } from "./types";
+import { Blockchain, RpcResponse } from "./types";
 
 const logger = getLogger("common/plugin");
 

--- a/packages/common/src/types.ts
+++ b/packages/common/src/types.ts
@@ -62,9 +62,3 @@ export type NftAttribute = {
   traitType: string;
   value: string;
 };
-
-export interface XnftMetadata {
-  isDarkMode: boolean;
-  username?: string;
-  avatarUrl: string;
-}

--- a/packages/provider-core/package.json
+++ b/packages/provider-core/package.json
@@ -9,6 +9,7 @@
   },
   "dependencies": {
     "@coral-xyz/common": "*",
+    "@coral-xyz/common-public": "*",
     "@project-serum/anchor": "^0.23.0",
     "@solana/web3.js": "^1.63.1",
     "bs58": "^5.0.0",

--- a/packages/provider-core/src/root-provider-xnft.ts
+++ b/packages/provider-core/src/root-provider-xnft.ts
@@ -1,4 +1,5 @@
-import type { Event, XnftMetadata } from "@coral-xyz/common";
+import type { Event } from "@coral-xyz/common";
+import type { XnftMetadata } from "@coral-xyz/common-public";
 import {
   getLogger,
   CHANNEL_SOLANA_CONNECTION_INJECTED_REQUEST,

--- a/packages/react-xnft-dom-renderer/package.json
+++ b/packages/react-xnft-dom-renderer/package.json
@@ -14,6 +14,7 @@
   "license": "ISC",
   "dependencies": {
     "@coral-xyz/common": "*",
+    "@coral-xyz/common-public": "*",
     "@coral-xyz/themes": "*",
     "@emotion/react": "^11.9.0",
     "@emotion/styled": "^11.8.1",

--- a/packages/react-xnft-dom-renderer/src/App.tsx
+++ b/packages/react-xnft-dom-renderer/src/App.tsx
@@ -3,7 +3,7 @@ import { WithTheme } from "./WithTheme";
 import { useEffect, useState } from "react";
 import { Event } from "@coral-xyz/common-public";
 import { RootRenderer } from "./Renderer";
-import { XnftMetadata } from "@coral-xyz/common";
+import { XnftMetadata } from "@coral-xyz/common-public";
 
 const DEFAULT_METADATA: XnftMetadata = {
   isDarkMode: false,

--- a/packages/react-xnft-dom-renderer/src/Context.tsx
+++ b/packages/react-xnft-dom-renderer/src/Context.tsx
@@ -1,6 +1,6 @@
 import React, { useContext } from "react";
 import { ReactDom } from "react-xnft";
-import { XnftMetadata } from "@coral-xyz/common";
+import { XnftMetadata } from "@coral-xyz/common-public";
 
 interface Metadata {
   isDarkMode: boolean;

--- a/packages/react-xnft/package.json
+++ b/packages/react-xnft/package.json
@@ -14,7 +14,6 @@
   "license": "ISC",
   "dependencies": {
     "@coral-xyz/common-public": "*",
-    "@coral-xyz/common": "*",
     "@coral-xyz/themes": "*",
     "@solana/web3.js": "^1.63.1",
     "eventemitter3": "^4.0.7",

--- a/packages/react-xnft/src/hooks.tsx
+++ b/packages/react-xnft/src/hooks.tsx
@@ -1,7 +1,6 @@
 import { useState, useEffect } from "react";
 import { Connection, PublicKey } from "@solana/web3.js";
-import { Event } from "@coral-xyz/common-public";
-import { XnftMetadata } from "@coral-xyz/common";
+import { Event, XnftMetadata } from "@coral-xyz/common-public";
 
 /*
  * @Depreciated over usePublicKeys


### PR DESCRIPTION
The PR moves `XnftMetadata` to common public to remove `@coral-xyz/common` dependency from `react-xnft`