### PR TITLE
Fixes iframe rpc messages

### DIFF
--- a/packages/common/src/channel/plugin.ts
+++ b/packages/common/src/channel/plugin.ts
@@ -32,10 +32,12 @@ export class PluginServer {
         return;
       }
       const id = event.data.detail.id;
+      const iframeIdentifiers = event.data.detail.iframeIdentifiers;
       const [result, error] = await handlerFn(event);
       if (this.responseChannel) {
         const msg = {
           type: this.responseChannel,
+          iframeIdentifiers,
           detail: {
             id,
             result,

--- a/packages/provider-core/src/chained-request-manager.ts
+++ b/packages/provider-core/src/chained-request-manager.ts
@@ -1,0 +1,160 @@
+// A request manager that is used for chaining requests form
+// child IFRAMES to parent IFRAMES.
+
+import { getLogger, PluginServer } from "@coral-xyz/common";
+import type {
+  RpcRequest,
+  RpcResponse,
+  Event,
+  ResponseHandler,
+} from "@coral-xyz/common";
+
+const logger = getLogger("common/request-manager");
+
+export class ChainedRequestManager {
+  private _responseResolvers: { [requestId: number]: ResponseHandler } = {};
+  private _requestId = 0;
+  private _requestChannel: string;
+  private _responseChannel: string;
+  private _url: string;
+  private _childIframes: {
+    element: HTMLIFrameElement;
+    id: string;
+    url: string;
+  }[] = [];
+
+  constructor(requestChannel: string, responseChannel: string) {
+    this._requestChannel = requestChannel;
+    this._responseChannel = responseChannel;
+    this._requestId = 0;
+    this._responseResolvers = {};
+    this._url = window.location.href;
+    this._childIframes = [];
+    this._initChannels();
+  }
+
+  public _initChannels() {
+    window.addEventListener(
+      "message",
+      this._handleRpcChildRequestAndParentResponse.bind(this)
+    );
+  }
+
+  private _handleRpcChildRequestAndParentResponse = (event: Event) => {
+    this._handleRpcParentResponse(event);
+    this._handleRpcChildRequest(event);
+  };
+
+  private _handleRpcChildRequest = (event: Event) => {
+    this._childIframes.forEach(({ url: iframeUrl }) => {
+      const url = new URL(iframeUrl);
+      if (
+        // TODO: hardcode allowed origin(s)
+        event.origin !== url.origin ||
+        event.data.href !== url.href ||
+        event.data.type !== this._requestChannel
+      ) {
+        return;
+      }
+      window.parent.postMessage(
+        {
+          type: this._requestChannel,
+          href: this._url,
+          iframeIdentifiers: [
+            ...[event.data.iframeIdentifiers || []],
+            window.frameElement?.id,
+          ],
+          detail: {
+            id: event.data.detail.id,
+            method: event.data.detail.method,
+            params: event.data.detail.params,
+          },
+        },
+        "*"
+      );
+    });
+  };
+
+  private _handleRpcParentResponse = (event: Event) => {
+    if (event.data.type !== this._responseChannel) return;
+    if (
+      event.data.iframeIdentifiers &&
+      event.data.iframeIdentifiers.length > 1
+    ) {
+      // need to propagate this event back to a child iframe, it doesn't
+      // belong to this iframe
+      const iframeIdentifiers = event.data.iframeIdentifiers;
+      const childIframeIdentifier = iframeIdentifiers.pop();
+      this._childIframes.forEach(({ id, element }) => {
+        if (childIframeIdentifier === id) {
+          const msg = {
+            type: this._responseChannel,
+            detail: event.data.detail,
+            iframeIdentifiers: iframeIdentifiers,
+          };
+          element.contentWindow?.postMessage(msg, "*");
+        }
+      });
+      return;
+    }
+    const { id, result, error } = event.data.detail;
+    const resolver = this._responseResolvers[id];
+    if (!resolver) {
+      logger.error("unexpected event", event);
+      throw new Error("unexpected event");
+    }
+    delete this._responseResolvers[id];
+    const [resolve, reject] = resolver;
+    if (error) {
+      reject(new Error(error));
+    } else {
+      resolve(result);
+    }
+  };
+
+  // Sends a request from this script to the content script across the
+  // window.postMessage channel.
+  public async request<T = any>({
+    method,
+    params,
+  }: RpcRequest): Promise<RpcResponse<T>> {
+    const id = this._requestId;
+    this._requestId += 1;
+
+    const [prom, resolve, reject] = this._addResponseResolver(id);
+    window.parent.postMessage(
+      {
+        type: this._requestChannel,
+        // this._url will always be set here, because this._parent is true.
+        href: this._url!,
+        iframeIdentifiers: [window.frameElement?.id],
+        detail: {
+          id,
+          method,
+          params,
+        },
+      },
+      "*"
+    );
+    return await prom;
+  }
+
+  addChildIframe(iframe) {
+    this._childIframes.push(iframe);
+  }
+
+  removeChildIframe(id) {
+    this._childIframes = this._childIframes.filter((x) => x.id !== id);
+  }
+
+  // This must be called before `window.dispatchEvent`.
+  private _addResponseResolver(requestId: number) {
+    let resolve, reject;
+    const prom = new Promise((_resolve, _reject) => {
+      resolve = _resolve;
+      reject = _reject;
+    });
+    this._responseResolvers[requestId] = [resolve, reject];
+    return [prom, resolve, reject];
+  }
+}

--- a/packages/provider-core/src/common/ethereum.ts
+++ b/packages/provider-core/src/common/ethereum.ts
@@ -7,12 +7,13 @@ import {
   ETHEREUM_RPC_METHOD_SIGN_AND_SEND_TX,
   ETHEREUM_RPC_METHOD_SIGN_MESSAGE,
 } from "@coral-xyz/common";
+import { ChainedRequestManager } from "../chained-request-manager";
 
 const { base58: bs58 } = ethers.utils;
 
 export async function signTransaction(
   publicKey: string,
-  requestManager: RequestManager,
+  requestManager: RequestManager | ChainedRequestManager,
   transaction: UnsignedTransaction
 ): Promise<TransactionRequest> {
   const serializedTx = encodeTransaction(transaction);
@@ -24,7 +25,7 @@ export async function signTransaction(
 
 export async function sendTransaction(
   publicKey: string,
-  requestManager: RequestManager,
+  requestManager: RequestManager | ChainedRequestManager,
   transaction: UnsignedTransaction
 ): Promise<any> {
   const serializedTx = encodeTransaction(transaction);
@@ -36,7 +37,7 @@ export async function sendTransaction(
 
 export async function sendAndConfirmTransaction(
   publicKey: string,
-  requestManager: RequestManager,
+  requestManager: RequestManager | ChainedRequestManager,
   transaction: UnsignedTransaction
 ): Promise<any> {
   const signature = this.sendTransaction(
@@ -50,7 +51,7 @@ export async function sendAndConfirmTransaction(
 
 export async function signMessage(
   publicKey: string,
-  requestManager: RequestManager,
+  requestManager: RequestManager | ChainedRequestManager,
   msg: string
 ): Promise<Uint8Array> {
   const encodedMsg = ethers.utils.base58.encode(ethers.utils.toUtf8Bytes(msg));

--- a/packages/provider-core/src/common/solana.ts
+++ b/packages/provider-core/src/common/solana.ts
@@ -21,12 +21,13 @@ import {
   SOLANA_RPC_METHOD_SIMULATE,
 } from "@coral-xyz/common";
 import { VersionedTransaction } from "@solana/web3.js";
+import { ChainedRequestManager } from "../chained-request-manager";
 
 export async function sendAndConfirm<
   T extends Transaction | VersionedTransaction
 >(
   publicKey: PublicKey,
-  requestManager: RequestManager,
+  requestManager: RequestManager | ChainedRequestManager,
   connection: Connection,
   tx: T,
   signers?: Signer[],
@@ -55,7 +56,7 @@ export async function sendAndConfirm<
 
 export async function send<T extends Transaction | VersionedTransaction>(
   publicKey: PublicKey,
-  requestManager: RequestManager,
+  requestManager: RequestManager | ChainedRequestManager,
   connection: Connection,
   tx: T,
   signers?: Signer[],
@@ -96,7 +97,7 @@ export async function signTransaction<
   T extends Transaction | VersionedTransaction
 >(
   publicKey: PublicKey,
-  requestManager: RequestManager,
+  requestManager: RequestManager | ChainedRequestManager,
   connection: Connection,
   tx: T
 ): Promise<T> {
@@ -124,7 +125,7 @@ export async function signAllTransactions<
   T extends Transaction | VersionedTransaction
 >(
   publicKey: PublicKey,
-  requestManager: RequestManager,
+  requestManager: RequestManager | ChainedRequestManager,
   connection: Connection,
   txs: Array<T>
 ): Promise<Array<T>> {
@@ -169,7 +170,7 @@ export async function signAllTransactions<
 
 export async function simulate<T extends Transaction | VersionedTransaction>(
   publicKey: PublicKey,
-  requestManager: RequestManager,
+  requestManager: RequestManager | ChainedRequestManager,
   connection: Connection,
   tx: T,
   signers?: Signer[],
@@ -207,7 +208,7 @@ export async function simulate<T extends Transaction | VersionedTransaction>(
 
 export async function signMessage(
   publicKey: PublicKey,
-  requestManager: RequestManager,
+  requestManager: RequestManager | ChainedRequestManager,
   msg: Uint8Array
 ): Promise<Uint8Array> {
   const msgStr = encode(msg);

--- a/packages/provider-core/src/index.ts
+++ b/packages/provider-core/src/index.ts
@@ -4,3 +4,4 @@ export { ProviderSolanaXnftInjection } from "./provider-solana-xnft";
 export { ProviderEthereumInjection } from "./provider-ethereum";
 export { ProviderEthereumXnftInjection } from "./provider-ethereum-xnft";
 export { ProviderRootXnftInjection } from "./root-provider-xnft";
+export { ChainedRequestManager } from "./chained-request-manager";

--- a/packages/provider-core/src/provider-ethereum-xnft.ts
+++ b/packages/provider-core/src/provider-ethereum-xnft.ts
@@ -15,6 +15,7 @@ import {
 import * as cmn from "./common/ethereum";
 import { RequestManager } from "./request-manager";
 import { PrivateEventEmitter } from "./common/PrivateEventEmitter";
+import { ChainedRequestManager } from "./chained-request-manager";
 
 const logger = getLogger("provider-xnft-injection");
 
@@ -22,14 +23,14 @@ const logger = getLogger("provider-xnft-injection");
 // Injected provider for UI plugins.
 //
 export class ProviderEthereumXnftInjection extends PrivateEventEmitter {
-  #requestManager: RequestManager;
+  #requestManager: ChainedRequestManager | ChainedRequestManager;
   #connectionRequestManager: RequestManager;
 
   #publicKey?: string;
   #connectionUrl?: string;
   #provider?: ethers.providers.JsonRpcProvider;
 
-  constructor(requestManager: RequestManager) {
+  constructor(requestManager: ChainedRequestManager) {
     super();
     if (new.target === ProviderEthereumXnftInjection) {
       Object.freeze(this);

--- a/packages/provider-core/src/provider-solana-xnft.ts
+++ b/packages/provider-core/src/provider-solana-xnft.ts
@@ -32,6 +32,7 @@ import {
 import * as cmn from "./common/solana";
 import { RequestManager } from "./request-manager";
 import { PrivateEventEmitter } from "./common/PrivateEventEmitter";
+import { ChainedRequestManager } from "./chained-request-manager";
 
 const logger = getLogger("provider-xnft-injection");
 
@@ -42,13 +43,13 @@ export class ProviderSolanaXnftInjection
   extends PrivateEventEmitter
   implements Provider
 {
-  #requestManager: RequestManager;
+  #requestManager: ChainedRequestManager;
   #connectionRequestManager: RequestManager;
 
   #publicKey?: PublicKey;
   #connection: Connection;
 
-  constructor(requestManager: RequestManager) {
+  constructor(requestManager: ChainedRequestManager) {
     super();
     if (new.target === ProviderSolanaXnftInjection) {
       Object.freeze(this);

--- a/packages/provider-core/src/root-provider-xnft.ts
+++ b/packages/provider-core/src/root-provider-xnft.ts
@@ -18,6 +18,7 @@ import {
 } from "@coral-xyz/common";
 import { RequestManager } from "./request-manager";
 import { PrivateEventEmitter } from "./common/PrivateEventEmitter";
+import { ChainedRequestManager } from "./chained-request-manager";
 
 const logger = getLogger("provider-xnft-injection");
 
@@ -25,17 +26,17 @@ const logger = getLogger("provider-xnft-injection");
 // Injected provider for UI plugins.
 //
 export class ProviderRootXnftInjection extends PrivateEventEmitter {
-  #requestManager: RequestManager;
+  #requestManager: ChainedRequestManager;
   #connectionRequestManager: RequestManager;
   #publicKeys: { [blockchain: string]: string };
   #connectionUrls: { [blockchain: string]: string | null };
 
-  #childIframes: HTMLIFrameElement[];
+  #childIframes: { element: HTMLIFrameElement; id: string; url: string }[];
   #cachedNotifications: { [notification: string]: Event };
   #metadata: XnftMetadata;
 
   constructor(
-    requestManager: RequestManager,
+    requestManager: ChainedRequestManager,
     additionalProperties: { [key: string]: PrivateEventEmitter } = {}
   ) {
     super();
@@ -78,7 +79,7 @@ export class ProviderRootXnftInjection extends PrivateEventEmitter {
     });
   }
 
-  public async addIframe(iframeEl) {
+  public async addIframe(iframeEl: HTMLIFrameElement, url: string, id: string) {
     // Send across mount and connect notification to child iframes
     if (this.#cachedNotifications[PLUGIN_NOTIFICATION_MOUNT]) {
       iframeEl.contentWindow?.postMessage(
@@ -94,12 +95,22 @@ export class ProviderRootXnftInjection extends PrivateEventEmitter {
       );
     }
 
-    this.#childIframes.push(iframeEl);
+    this.#requestManager.addChildIframe({
+      element: iframeEl,
+      url,
+      id,
+    });
+
+    this.#childIframes.push({
+      element: iframeEl,
+      url,
+      id,
+    });
   }
 
-  public async removeIframe(iframeEl) {
+  public async removeIframe(id) {
     // @ts-ignore
-    this.#childIframes = this.#childIframes.filter((x) => x !== iframeEl);
+    this.#childIframes = this.#childIframes.filter((x) => x.id !== id);
   }
 
   #setupChannels() {
@@ -113,8 +124,8 @@ export class ProviderRootXnftInjection extends PrivateEventEmitter {
     if (event.data.type !== CHANNEL_PLUGIN_NOTIFICATION) return;
 
     // Send RPC message to all child iframes
-    this.#childIframes.forEach((iframe) => {
-      iframe.contentWindow?.postMessage(event, "*");
+    this.#childIframes.forEach(({ element }) => {
+      element.contentWindow?.postMessage(event, "*");
     });
 
     logger.debug("handle notification", event);

--- a/packages/provider-injection/src/index.ts
+++ b/packages/provider-injection/src/index.ts
@@ -4,7 +4,7 @@ import {
   ProviderRootXnftInjection,
   ProviderSolanaInjection,
   ProviderSolanaXnftInjection,
-  RequestManager,
+  ChainedRequestManager,
 } from "@coral-xyz/provider-core";
 import {
   getLogger,
@@ -48,10 +48,9 @@ function initProvider() {
         //
         // XNFT Providers
         //
-        const requestManager = new RequestManager(
+        const requestManager = new ChainedRequestManager(
           CHANNEL_PLUGIN_RPC_REQUEST,
-          CHANNEL_PLUGIN_RPC_RESPONSE,
-          true
+          CHANNEL_PLUGIN_RPC_RESPONSE
         );
         const xnft = new ProviderRootXnftInjection(requestManager, {
           ethereum: new ProviderEthereumXnftInjection(requestManager),

--- a/packages/react-xnft-dom-renderer/src/Component.tsx
+++ b/packages/react-xnft-dom-renderer/src/Component.tsx
@@ -379,6 +379,7 @@ function Circle({ props }: any) {
 
 function Iframe({ props, style }: any) {
   const [xnftProp, setXnftProp] = useState(false);
+  const [id, _setId] = useState(Math.floor(Math.random() * 1000000) + "");
   const ref = useRef<any>();
 
   useEffect(() => {
@@ -389,14 +390,15 @@ function Iframe({ props, style }: any) {
       return () => {};
     }
     // @ts-ignore
-    window.xnft.addIframe(ref.current);
+    window.xnft.addIframe(ref.current, props.src, id);
     return () => {
       // @ts-ignore
-      window.xnft.removeIframe(ref.current);
+      window.xnft.removeIframe(id);
     };
   }, [props.src, ref, xnftProp]);
   return isValidSecureUrl(props.src) ? (
     <iframe
+      id={id}
       ref={ref}
       sandbox="allow-same-origin allow-scripts"
       src={props.src}


### PR DESCRIPTION
`CHANNEL_PLUGIN_RPC_REQUEST` request messages from child iframes inside an xnft are breaking.
This PR aims to fix that by introducing a `chain-request-manager` that chains requests and responses from a child iframe up to the `app-extension` and back to the child iframe