### PR TITLE
Fixed chain requests

### DIFF
--- a/packages/provider-core/src/chained-request-manager.ts
+++ b/packages/provider-core/src/chained-request-manager.ts
@@ -126,7 +126,7 @@ export class ChainedRequestManager {
         type: this._requestChannel,
         // this._url will always be set here, because this._parent is true.
         href: this._url!,
-        iframeIdentifiers: [window.name],
+        iframeIdentifiers: window.name ? [window.name] : [],
         detail: {
           id,
           method,


### PR DESCRIPTION
Issue raised by user here - https://discord.com/channels/985994296337498182/1011846320677462137/1034115909532536832

When using `react-xnft` natively, we don't need to pass in `iframeIdentifier` of the parent iframe