### PR TITLE
wallet create fixes

### DIFF
--- a/packages/app-extension/src/components/Unlocked/Settings/AddConnectWallet/index.tsx
+++ b/packages/app-extension/src/components/Unlocked/Settings/AddConnectWallet/index.tsx
@@ -5,6 +5,7 @@ import {
   Blockchain,
   openConnectHardware,
   TAB_BALANCES,
+  TAB_APPS,
   UI_RPC_METHOD_KEYRING_DERIVE_WALLET,
   UI_RPC_METHOD_KEYRING_ACTIVE_WALLET_UPDATE,
   UI_RPC_METHOD_NAVIGATION_ACTIVE_TAB_UPDATE,
@@ -184,20 +185,23 @@ export const ConfirmCreateWallet: React.FC<{
           blockchain={blockchain}
           name={walletName}
           publicKey={publicKey}
+          showDetailMenu={false}
           isFirst={true}
           isLast={true}
           onClick={() => {
             if (tab === TAB_BALANCES) {
-              background.request({
-                method: UI_RPC_METHOD_NAVIGATION_TO_ROOT,
-                params: [],
-              });
-            } else {
+              // Experience won't go back to TAB_BALANCES so we poke it
               background.request({
                 method: UI_RPC_METHOD_NAVIGATION_ACTIVE_TAB_UPDATE,
-                params: [TAB_BALANCES],
+                params: [TAB_APPS],
               });
             }
+
+            background.request({
+              method: UI_RPC_METHOD_NAVIGATION_ACTIVE_TAB_UPDATE,
+              params: [TAB_BALANCES],
+            });
+
             // Close mini drawer.
             setOpenDrawer(false);
             // Close main drawer.

--- a/packages/app-extension/src/components/Unlocked/Settings/YourAccount/EditWallets/index.tsx
+++ b/packages/app-extension/src/components/Unlocked/Settings/YourAccount/EditWallets/index.tsx
@@ -85,6 +85,7 @@ function WalletList({
             type={type}
             isFirst={idx === 0}
             isLast={idx === flattenedWallets.length - 1}
+            showDetailMenu={true}
           />
         ))}
       </List>
@@ -107,8 +108,18 @@ export const WalletListItem: React.FC<{
   type?: string;
   isFirst: boolean;
   isLast: boolean;
+  showDetailMenu: boolean;
   onClick?: () => void;
-}> = ({ blockchain, name, publicKey, type, isFirst, isLast, onClick }) => {
+}> = ({
+  blockchain,
+  name,
+  publicKey,
+  type,
+  isFirst,
+  isLast,
+  showDetailMenu,
+  onClick,
+}) => {
   const theme = useCustomTheme();
   const nav = useNavStack();
   return (
@@ -118,12 +129,14 @@ export const WalletListItem: React.FC<{
       isFirst={isFirst}
       isLast={isLast}
       detail={
-        <MoreHoriz
-          style={{
-            cursor: "pointer",
-            color: theme.custom.colors.secondary,
-          }}
-        />
+        showDetailMenu ? (
+          <MoreHoriz
+            style={{
+              cursor: "pointer",
+              color: theme.custom.colors.secondary,
+            }}
+          />
+        ) : null
       }
       onClick={
         onClick


### PR DESCRIPTION
1) Clicking on the created wallet correctly takes you back to the Balances tab

2) Removes triple dots menu from "Wallet Created":

![image](https://user-images.githubusercontent.com/1211905/197655480-10aad5b6-bddb-4fa6-a3dd-f5b0517bd539.png)

3) Continues to show triple dots menu from "Your Account / Edit Wallets":

![image](https://user-images.githubusercontent.com/1211905/197655552-3424681c-a17e-45be-ab89-c697852a9262.png)


