### PR TITLE
Fixes redirects

### DIFF
--- a/packages/app-extension/src/components/common/Layout/Router.tsx
+++ b/packages/app-extension/src/components/common/Layout/Router.tsx
@@ -5,6 +5,7 @@ import {
   Routes,
   Route,
   Navigate,
+  useNavigate,
 } from "react-router-dom";
 import { AnimatePresence } from "framer-motion";
 import { Typography } from "@mui/material";
@@ -154,6 +155,7 @@ function PluginDrawer() {
   const pluginProps = searchParams.get("pluginProps");
   const { xnftAddress } = JSON.parse(decodeURIComponent(pluginProps!));
   const xnftPlugin = useFreshPlugin(xnftAddress);
+  const navigate = useNavigate();
 
   useEffect(() => {
     if (!openDrawer && xnftPlugin.state) {
@@ -166,7 +168,14 @@ function PluginDrawer() {
       {xnftPlugin.result && (
         <_PluginDisplay
           plugin={xnftPlugin.result!}
-          closePlugin={() => setOpenDrawer(false)}
+          closePlugin={() => {
+            setOpenDrawer(false);
+            setTimeout(() => {
+              searchParams.delete("pluginProps");
+              const newUrl = `${location.pathname}?${searchParams.toString()}`;
+              navigate(newUrl);
+            }, 100);
+          }}
         />
       )}
     </WithDrawer>


### PR DESCRIPTION
This was happening because `pluginProps` would linger as a query param in the URL causing the xnft opened from `xnft.gg` to keep lingering even after being closed.

Closes https://github.com/coral-xyz/backpack/issues/1275
Closes https://github.com/coral-xyz/backpack/issues/1273