### PR TITLE
disable hardware signing if username feature is disabled

### DIFF
--- a/packages/app-extension/src/components/Onboarding/pages/OnboardAccount.tsx
+++ b/packages/app-extension/src/components/Onboarding/pages/OnboardAccount.tsx
@@ -220,6 +220,7 @@ export const OnboardAccount = ({
               setOpenDrawer(false);
             }}
             onClose={() => setOpenDrawer(false)}
+            requireSignature={!!BACKPACK_FEATURE_USERNAMES}
           />
         ) : (
           <ImportAccounts


### PR DESCRIPTION
Don't prompt for signing when there is nothing to sign (because usernames/invite codes are disabled).

Closes https://github.com/coral-xyz/backpack/issues/1300