### PR TITLE
fix import flow with require signature disabled in onboarding

### DIFF
--- a/packages/app-extension/src/components/Onboarding/pages/HardwareOnboard.tsx
+++ b/packages/app-extension/src/components/Onboarding/pages/HardwareOnboard.tsx
@@ -62,9 +62,19 @@ export function HardwareOnboard({
               accounts: SelectedAccount[],
               derivationPath: DerivationPath
             ) => {
-              setAccounts(accounts);
-              setDerivationPath(derivationPath);
-              nextStep();
+              if (requireSignature) {
+                setAccounts(accounts);
+                setDerivationPath(derivationPath);
+                nextStep();
+              } else {
+                onComplete({
+                  blockchain,
+                  derivationPath: derivationPath!,
+                  accountIndex: accounts![0].index,
+                  publicKey: accounts![0].publicKey,
+                  signature: null,
+                });
+              }
             }}
             onError={() => {
               setTransportError(true);


### PR DESCRIPTION
If require signature is disabled the import accounts component is the last step, so it should call onComplete instead of next step.