### PR TITLE
cleanup approval/locks

### DIFF
--- a/packages/background/src/frontend/server-injected.ts
+++ b/packages/background/src/frontend/server-injected.ts
@@ -16,7 +16,6 @@ import {
   ChannelAppUi,
   openLockedPopupWindow,
   openApprovalPopupWindow,
-  openLockedApprovalPopupWindow,
   openApproveTransactionPopupWindow,
   openApproveAllTransactionsPopupWindow,
   openApproveMessagePopupWindow,
@@ -215,18 +214,40 @@ async function handleConnect(
   if (locks.has(origin)) {
     throw new Error(`already handling a request from ${origin}`);
   }
+
   locks.add(origin);
 
   const keyringStoreState = await ctx.backend.keyringStoreState();
+
+  if (keyringStoreState === "needs-onboarding") {
+    locks.delete(origin);
+    throw new Error("invariant violation keyring not created");
+  }
+
   let didApprove = false;
   let resp: any;
 
-  // Use the UI to ask the user if it should connect.
-  if (keyringStoreState === "unlocked") {
+  if (
+    keyringStoreState === "locked" &&
+    (await ctx.backend.isApprovedOrigin(origin))
+  ) {
+    logger.debug("origin approved but need to unlock");
+    resp = await RequestManager.requestUiAction((requestId: number) => {
+      return openLockedPopupWindow(
+        ctx.sender.origin,
+        ctx.sender.tab.title,
+        requestId,
+        blockchain
+      );
+    });
+    didApprove = !resp.windowClosed && resp.result;
+  } else {
     if (await ctx.backend.isApprovedOrigin(origin)) {
-      logger.debug("already approved so automatically connecting");
+      logger.debug("origin approved so automatically connecting");
       didApprove = true;
     } else {
+      // Origin is not approved and wallet may or may not be locked
+      logger.debug("requesting approval for origin");
       resp = await RequestManager.requestUiAction((requestId: number) => {
         return openApprovalPopupWindow(
           ctx.sender.origin,
@@ -237,31 +258,6 @@ async function handleConnect(
       });
       didApprove = !resp.windowClosed && resp.result;
     }
-  } else if (keyringStoreState === "locked") {
-    if (await ctx.backend.isApprovedOrigin(origin)) {
-      resp = await RequestManager.requestUiAction((requestId: number) => {
-        return openLockedPopupWindow(
-          ctx.sender.origin,
-          ctx.sender.tab.title,
-          requestId,
-          blockchain
-        );
-      });
-      didApprove = !resp.windowClosed && resp.result;
-    } else {
-      resp = await RequestManager.requestUiAction((requestId: number) => {
-        return openLockedApprovalPopupWindow(
-          ctx.sender.origin,
-          ctx.sender.tab.title,
-          requestId,
-          blockchain
-        );
-      });
-      didApprove = !resp.windowClosed && resp.result;
-    }
-  } else {
-    locks.delete(origin);
-    throw new Error("invariant violation keyring not created");
   }
 
   locks.delete(origin);

--- a/packages/common/src/browser/extension.ts
+++ b/packages/common/src/browser/extension.ts
@@ -4,7 +4,6 @@ import {
   EXTENSION_HEIGHT,
   QUERY_LOCKED,
   QUERY_APPROVAL,
-  QUERY_LOCKED_APPROVAL,
   QUERY_APPROVE_MESSAGE,
   QUERY_APPROVE_TRANSACTION,
   QUERY_APPROVE_ALL_TRANSACTIONS,
@@ -107,17 +106,6 @@ export async function openXnft(
 ): Promise<chrome.windows.Window> {
   const props = encodeURIComponent(JSON.stringify({ xnftAddress }));
   const url = `${POPUP_HTML}#?pluginProps=${props}`;
-  return openPopupWindow(url);
-}
-
-export async function openLockedApprovalPopupWindow(
-  origin: string,
-  title: string,
-  requestId: number,
-  blockchain: Blockchain
-): Promise<chrome.windows.Window> {
-  const encodedTitle = encodeURIComponent(title);
-  const url = `${POPUP_HTML}?${QUERY_LOCKED_APPROVAL}&origin=${origin}&title=${encodedTitle}&requestId=${requestId}&blockchain=${blockchain}`;
   return openPopupWindow(url);
 }
 

--- a/packages/common/src/constants.ts
+++ b/packages/common/src/constants.ts
@@ -446,8 +446,7 @@ export const BACKEND_EVENT = "backend-event";
 // Popup query routes.
 //
 export const QUERY_LOCKED = "locked=true";
-export const QUERY_APPROVAL = "approval=true";
-export const QUERY_LOCKED_APPROVAL = "locked-approval=true";
+export const QUERY_APPROVAL = "approve-origin=true";
 export const QUERY_APPROVE_TRANSACTION = "approve-tx=true";
 export const QUERY_APPROVE_ALL_TRANSACTIONS = "approve-all-txs=true";
 export const QUERY_APPROVE_MESSAGE = "approve-message=true";


### PR DESCRIPTION
Uses a wrapper component for all the approvals to handle the unlock. Consequently removes the query locked approval popup because the query approval can handle it with the wrapper.

Closes #1335 