### PR TITLE
New text input for invite code

### DIFF
--- a/packages/app-extension/src/components/Onboarding/pages/InviteCodeForm.tsx
+++ b/packages/app-extension/src/components/Onboarding/pages/InviteCodeForm.tsx
@@ -4,7 +4,7 @@ import { Box, Typography } from "@mui/material";
 import { createPopup } from "@typeform/embed";
 import { useCallback, useEffect, useState, type FormEvent } from "react";
 import { useNavigate } from "react-router-dom";
-import { PrimaryButton, SubtextParagraph, TextField } from "../../common";
+import { PrimaryButton, SubtextParagraph } from "../../common";
 import { BackpackHeader } from "../../Locked";
 import { getWaitlistId, setWaitlistId } from "../../common/WaitingRoom";
 import { TextInput } from "../../common/Inputs";
@@ -97,7 +97,7 @@ export const InviteCodeForm = ({
         noValidate
       >
         <Box style={{ marginBottom: 8 }} className={classes.inviteCodeBox}>
-          <TextField
+          <TextInput
             inputProps={{
               name: "inviteCode",
               autoComplete: "off",
@@ -111,8 +111,8 @@ export const InviteCodeForm = ({
             placeholder={"Invite code"}
             type="text"
             value={inviteCode}
-            setValue={(v: any) => {
-              setInviteCode(v.replace(/[^a-zA-Z0-9\\-]/g, ""));
+            setValue={(e: any) => {
+              setInviteCode(e.target.value.replace(/[^a-zA-Z0-9\\-]/g, ""));
             }}
             error={error ? true : false}
             errorMessage={error}


### PR DESCRIPTION
Follow up from https://github.com/coral-xyz/backpack/pull/1345 to use the new `TextInput` designs and show error messages when there is an erroneous input

<img width="539" alt="Screenshot 2022-10-31 at 4 45 47 AM" src="https://user-images.githubusercontent.com/8079861/198906692-063c934c-04da-4a29-b40e-0292f3416916.png">
<img width="623" alt="Screenshot 2022-10-31 at 4 44 49 AM" src="https://user-images.githubusercontent.com/8079861/198906699-95648270-888f-4c52-81da-0c754f38d901.png">
