### PR TITLE
Moved username input to new design

### DIFF
--- a/packages/app-extension/src/components/Onboarding/pages/RecoverAccountUsernameForm.tsx
+++ b/packages/app-extension/src/components/Onboarding/pages/RecoverAccountUsernameForm.tsx
@@ -9,6 +9,7 @@ import {
   TextField,
 } from "../../common";
 import { getWaitlistId } from "../../common/WaitingRoom";
+import { TextInput } from "../../common/Inputs";
 
 export const RecoverAccountUsernameForm = ({
   onNext,
@@ -66,7 +67,7 @@ export const RecoverAccountUsernameForm = ({
         </SubtextParagraph>
       </Box>
       <Box style={{ flex: 1 }}>
-        <TextField
+        <TextInput
           inputProps={{
             name: "username",
             autoComplete: "off",
@@ -76,11 +77,13 @@ export const RecoverAccountUsernameForm = ({
           placeholder="Username"
           type="text"
           value={username}
-          setValue={(v: string) => {
-            setUsername(v.toLowerCase().replace(/[^a-z0-9_]/g, ""));
+          setValue={(e: any) => {
+            setUsername(
+              e.target.value.toLowerCase().replace(/[^a-z0-9_]/g, "")
+            );
           }}
-          isError={error}
-          auto
+          error={error ? true : false}
+          errorMessage={error}
           startAdornment={
             <InputAdornment position="start">
               <AlternateEmail
@@ -94,11 +97,6 @@ export const RecoverAccountUsernameForm = ({
             </InputAdornment>
           }
         />
-        {error && (
-          <Typography sx={{ color: theme.custom.colors.negative }}>
-            {error}
-          </Typography>
-        )}
       </Box>
       <Box>
         <PrimaryButton


### PR DESCRIPTION
Found another input where we were using the old design when I went through the recovery flow.
<img width="680" alt="Screenshot 2022-10-31 at 4 54 24 AM" src="https://user-images.githubusercontent.com/8079861/198906991-87f8d0b3-ef9f-4cde-b060-e8086712208d.png">

<img width="642" alt="Screenshot 2022-10-31 at 4 54 26 AM" src="https://user-images.githubusercontent.com/8079861/198906985-65796907-d9a7-4ee5-9b73-ede2aeef7a03.png">
