### PR TITLE
remove hardcoded mainnet chain id from ethereum xnft provider

### DIFF
--- a/packages/common/src/ethereum/background-provider.ts
+++ b/packages/common/src/ethereum/background-provider.ts
@@ -47,9 +47,9 @@ export class BackgroundEthereumProvider extends JsonRpcProvider {
   constructor(
     backgroundClient: BackgroundClient,
     connectionUrl: string,
-    chainId = "0x1"
+    chainId?: string
   ) {
-    super(connectionUrl, parseInt(chainId));
+    super(connectionUrl, chainId ? parseInt(chainId) : undefined);
     this._backgroundClient = backgroundClient;
   }
 


### PR DESCRIPTION
The provider will query the network itself if its not provided. Hard coding it can lead to connection URL/network mismatches.