### PR TITLE
`[docs]`: update discord invite link

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
   <p>
     <a href="https://github.com/coral-xyz/backpack/actions"><img alt="Build Status" src="https://github.com/coral-xyz/backpack/actions/workflows/pull_requests_and_merges.yml/badge.svg" /></a>
     <a href="https://docs.xnft.gg"><img alt="Tutorials" src="https://img.shields.io/badge/docs-tutorials-blueviolet" /></a>
-    <a href="https://discord.gg/w9P85Y9yBR"><img alt="Discord Chat" src="https://img.shields.io/badge/chat-discord-blueviolet" /></a>
+    <a href="https://discord.com/invite/RSpSuKp9"><img alt="Discord Chat" src="https://img.shields.io/badge/chat-discord-blueviolet" /></a>
   </p>
 </div>
 


### PR DESCRIPTION
The updated link was found from this [tweet](https://tinyurl.com/yx8z8exr)

closes #1374