### PR TITLE
fix undefined nft name crash

### DIFF
--- a/packages/app-extension/src/components/Unlocked/Nfts/Collection.tsx
+++ b/packages/app-extension/src/components/Unlocked/Nfts/Collection.tsx
@@ -52,7 +52,7 @@ function NftCard({ nft }: any) {
   const { push } = useNavigation();
   const onClick = () => {
     push({
-      title: nft.name,
+      title: nft.name || "",
       componentId: NAV_COMPONENT_NFT_DETAIL,
       componentProps: {
         nftId: nft.id,

--- a/packages/app-extension/src/components/Unlocked/Nfts/Detail.tsx
+++ b/packages/app-extension/src/components/Unlocked/Nfts/Detail.tsx
@@ -205,7 +205,7 @@ function SendScreen({ nft }: { nft: any }) {
         });
       }
     })();
-  }, [openConfirm]);
+  }, [openConfirm, wasSent, background]);
 
   return (
     <>
@@ -382,7 +382,7 @@ export function NftOptionsButton() {
         });
       }
     })();
-  }, [openDrawer]);
+  }, [openDrawer, wasBurnt, background]);
 
   // @ts-ignore
   const nft: any = nfts.get(searchParams.props.nftId);

--- a/packages/app-extension/src/components/Unlocked/Nfts/Detail.tsx
+++ b/packages/app-extension/src/components/Unlocked/Nfts/Detail.tsx
@@ -159,7 +159,7 @@ function SendButton({ nft }: { nft: any }) {
           <NavStackEphemeral
             initialRoute={{ name: "send" }}
             options={() => ({
-              title: `${nft.name} / Send`,
+              title: nft.name ? `${nft.name} / Send` : "Send",
             })}
             navButtonLeft={<CloseButton onClick={() => setOpenDrawer(false)} />}
           >

--- a/packages/app-extension/src/components/Unlocked/Nfts/index.tsx
+++ b/packages/app-extension/src/components/Unlocked/Nfts/index.tsx
@@ -148,7 +148,7 @@ function NftCollectionCard({ collection }: { collection: NftCollection }) {
       }
       // If there is only one item in the collection, link straight to its detail page
       push({
-        title: collectionDisplayNft.name,
+        title: collectionDisplayNft.name || "",
         componentId: NAV_COMPONENT_NFT_DETAIL,
         componentProps: {
           nftId: collectionDisplayNft.id,

--- a/packages/recoil/src/hooks/navigation.tsx
+++ b/packages/recoil/src/hooks/navigation.tsx
@@ -100,7 +100,11 @@ export function useDecodedSearchParams<
   const ob = {};
   searchParams.forEach((v, k) => {
     if (k !== "nav") {
-      ob[k as keyof ExtensionSearchParams] = JSON.parse(decodeURIComponent(v));
+      try {
+        ob[k as keyof ExtensionSearchParams] = JSON.parse(
+          decodeURIComponent(v)
+        );
+      } catch {}
     }
   });
   return ob as SearchParamsType;


### PR DESCRIPTION
From Discord report and @euclidestesticle 

NFTs with no name parameter cause URLs like 

`popup.html#/nfts/detail?props=%7B%22nftId%22%3A%22CS6M8LDbj48jfVYiNxkx3mD449kJCrQSvEVL4RTQQhd6%22%7D&title=undefined`

JSON parsing fails on the `title=undefined` query param. This PR uses an empty string if nft name is undefined but also adds a try/catch to the query param parser so the wallet doesn't crash on bad URLs.



