### PR TITLE
Reconciler cleanup

### DIFF
--- a/packages/react-xnft-dom-renderer/src/Component.tsx
+++ b/packages/react-xnft-dom-renderer/src/Component.tsx
@@ -157,7 +157,9 @@ const useStyles = styles((theme) => ({
 }));
 
 export function Component({ viewData }) {
-  const { id, props, style, kind } = viewData;
+  const { id, props, kind } = viewData;
+  const style = props?.style || {};
+
   switch (kind) {
     case NodeKind.View:
       return (

--- a/packages/react-xnft/src/ReactDom.ts
+++ b/packages/react-xnft/src/ReactDom.ts
@@ -115,51 +115,8 @@ export class ReactDom {
       throw new Error("element not found");
     }
 
-    switch (instance.kind) {
-      case NodeKind.View:
-        if (updatePayload.style) {
-          instance.style = updatePayload.style;
-        }
-        break;
-      case NodeKind.Text:
-        if (updatePayload.style) {
-          instance.style = updatePayload.style;
-        }
-        break;
-      case NodeKind.TextField:
-        if (updatePayload.value !== undefined && updatePayload.value !== null) {
-          instance.props.value = updatePayload.value;
-        }
-        break;
-      case NodeKind.NavAnimation:
-        if (
-          updatePayload.routeName !== undefined &&
-          updatePayload.routeName !== null
-        ) {
-          instance.props.routeName = updatePayload.routeName;
-        }
-        break;
-      case NodeKind.Path:
-        if (updatePayload.fill !== undefined && updatePayload.fill !== null) {
-          instance.props.fill = updatePayload.fill;
-        }
-        break;
-      case NodeKind.Button:
-        if (updatePayload.style !== undefined && updatePayload.style !== null) {
-          instance.style = updatePayload.style;
-        }
-        break;
-      case NodeKind.Image:
-        if (updatePayload.style) {
-          instance.style = updatePayload.style;
-        }
-        if (updatePayload.src) {
-          instance.props.src = updatePayload.src;
-        }
-        break;
-      default:
-        throw new Error("invariant violation");
-    }
+    instance.props = { ...updatePayload.props };
+
     this._render(instanceId);
   }
 

--- a/packages/react-xnft/src/reconciler.ts
+++ b/packages/react-xnft/src/reconciler.ts
@@ -179,116 +179,9 @@ const RECONCILER = ReactReconciler({
     host: Host
   ): UpdateDiff => {
     logger.debug("prepareUpdate", instance, type, oldProps, newProps);
-    let payload: UpdateDiff = {};
-    switch (type) {
-      case NodeKind.View:
-        // @ts-ignore
-        if (oldProps.style !== newProps.style) {
-          // @ts-ignore
-          payload = { ...payload, style: newProps.style };
-        }
-        // @ts-ignore
-        if (oldProps.onClick !== newProps.onClick) {
-          // @ts-ignore
-          payload = { ...payload, onClick: newProps.onClick };
-        }
-        return payload;
-      case NodeKind.Text:
-        // @ts-ignore
-        if (oldProps.style !== newProps.style) {
-          payload = {
-            ...payload,
-            // @ts-ignore
-            style: newProps.style,
-          };
-        }
-        return payload;
-      case NodeKind.TextField:
-        // @ts-ignore
-        if (oldProps.value !== newProps.value) {
-          // @ts-ignore
-          payload = { ...payload, value: newProps.value };
-        }
-        return payload;
-      case NodeKind.NavAnimation:
-        // @ts-ignore
-        if (oldProps.routeName !== newProps.routeName) {
-          // @ts-ignore
-          payload = { ...payload, routeName: newProps.routeName };
-        }
-        return payload;
-      case NodeKind.Path:
-        // @ts-ignore
-        if (oldProps.fill !== newProps.fill) {
-          // @ts-ignore
-          payload = { ...payload, fill: newProps.fill };
-        }
-        // @ts-ignore
-        if (oldProps.style !== newProps.style) {
-          // @ts-ignore
-          payload = { ...payload, style: newProps.style };
-        }
-        return payload;
-      case NodeKind.Button:
-        // @ts-ignore
-        if (oldProps.style !== newProps.style) {
-          // @ts-ignore
-          payload = { ...payload, style: newProps.style };
-        }
-        // @ts-ignore
-        if (oldProps.onClick !== newProps.onClick) {
-          // @ts-ignore
-          payload = { ...payload, onClick: newProps.onClick };
-        }
-        return payload;
-      case NodeKind.Image:
-        // @ts-ignore
-        if (oldProps.style !== newProps.style) {
-          // @ts-ignore
-          payload = { ...payload, style: newProps.style };
-        }
-        // @ts-ignore
-        if (oldProps.onClick !== newProps.onClick) {
-          // @ts-ignore
-          payload = { ...payload, onClick: newProps.onClick };
-        }
-        // @ts-ignore
-        if (oldProps.src !== newProps.src) {
-          // @ts-ignore
-          payload = { ...payload, src: newProps.src };
-        }
-        return payload;
-      case NodeKind.Iframe:
-        return null;
-      case NodeKind.Svg:
-        return null;
-      case NodeKind.Circle:
-        return null;
-      case NodeKind.Table:
-        return null;
-      case NodeKind.TableRow:
-        return null;
-      case NodeKind.Loading:
-        return null;
-      case NodeKind.ScrollBar:
-        return null;
-      case NodeKind.BalancesTable:
-        return null;
-      case NodeKind.BalancesTableHead:
-        return null;
-      case NodeKind.BalancesTableContent:
-        return null;
-      case NodeKind.BalancesTableRow:
-        return null;
-      case NodeKind.BalancesTableCell:
-        return null;
-      case NodeKind.BalancesTableFooter:
-        return null;
-      case NodeKind.Custom:
-        return null;
-      default:
-        throw new Error("unexpected node kind");
-    }
+    return {
+      props: newProps,
+    };
   },
   finalizeInitialChildren: (
     _parent: NodeSerialized,
@@ -339,93 +232,7 @@ const RECONCILER = ReactReconciler({
       return;
     }
 
-    switch (type) {
-      case NodeKind.View:
-        if (updatePayload.style) {
-          instance.style = updatePayload.style;
-        }
-        if (
-          updatePayload.onClick !== undefined &&
-          updatePayload.onClick !== null
-        ) {
-          // @ts-ignore
-          instance.props.onClick = updatePayload.onClick;
-          delete updatePayload["onClick"];
-        }
-        break;
-      case NodeKind.Text:
-        if (updatePayload.style !== undefined && updatePayload.style !== null) {
-          instance.style = updatePayload.style;
-        }
-        break;
-      case NodeKind.TextField:
-        if (updatePayload.value !== undefined && updatePayload.value !== null) {
-          // @ts-ignore
-          instance.props.value = updatePayload.value;
-        }
-        break;
-      case NodeKind.NavAnimation:
-        if (
-          updatePayload.routeName !== undefined &&
-          updatePayload.routeName !== null
-        ) {
-          // @ts-ignore
-          instance.props.routeName = updatePayload.routeName;
-        }
-        break;
-      case NodeKind.Path:
-        if (updatePayload.fill !== undefined && updatePayload.fill !== null) {
-          // @ts-ignore
-          instance.props.fill = updatePayload.fill;
-        }
-        if (updatePayload.style !== undefined && updatePayload.style !== null) {
-          // @ts-ignore
-          instance.props.style = updatePayload.style;
-        }
-        break;
-      case NodeKind.Button:
-        if (updatePayload.style !== undefined && updatePayload.style !== null) {
-          instance.style = updatePayload.style;
-        }
-        if (
-          updatePayload.onClick !== undefined &&
-          updatePayload.onClick !== null
-        ) {
-          // @ts-ignore
-          instance.props.onClick = updatePayload.onClick;
-          delete updatePayload["onClick"];
-        }
-        break;
-      case NodeKind.Image:
-        if (updatePayload.style) {
-          instance.style = updatePayload.style;
-        }
-        if (updatePayload.src) {
-          // @ts-ignore
-          instance.props.src = updatePayload.src;
-        }
-        if (
-          updatePayload.onClick !== undefined &&
-          updatePayload.onClick !== null
-        ) {
-          // @ts-ignore
-          instance.props.onClick = updatePayload.onClick;
-          delete updatePayload["onClick"];
-        }
-        break;
-      case NodeKind.Text:
-        throw new Error("commitUpdate Text not yet implemented");
-      case NodeKind.Svg:
-        throw new Error("commitUpdate Svg not yet implemented");
-      case NodeKind.Circle:
-        throw new Error("commitUpdate Circle not yet implemented");
-      case NodeKind.ScrollBar:
-        throw new Error("commitUpdate ScrollBar not yet implemented");
-      case NodeKind.Loading:
-        throw new Error("commitUpdate Loading not yet implemented");
-      default:
-        throw new Error("unexpected node kind");
-    }
+    instance.props = updatePayload.props;
 
     ReactDom.getInstance().commitUpdate(instance.id, updatePayload);
   },
@@ -499,7 +306,7 @@ const RECONCILER = ReactReconciler({
 
 function createViewInstance(
   _kind: NodeKind,
-  props: NodeProps,
+  props: ViewProps,
   _r: RootContainer,
   h: Host,
   _o: OpaqueHandle
@@ -510,10 +317,8 @@ function createViewInstance(
     kind: NodeKind.View,
     props: {
       ...props,
-      // onClick,
       children: undefined,
     },
-    style: props.style || {},
     children: [],
   };
 }
@@ -532,7 +337,6 @@ function createTableInstance(
       ...props,
       children: undefined,
     },
-    style: props.style || {},
     children: [],
   };
 }
@@ -551,7 +355,6 @@ function createTableRowInstance(
       ...props,
       children: undefined,
     },
-    style: props.style || {},
     children: [],
   };
 }
@@ -570,7 +373,6 @@ function createTextLabelInstance(
       ...props,
       children: undefined,
     },
-    style: props.style || {},
     children: [],
   };
 }
@@ -590,7 +392,6 @@ function createTextFieldInstance(
       ...props,
       children: undefined,
     },
-    style: props.style || {},
     children: [],
   };
 }
@@ -612,7 +413,6 @@ function createImageInstance(
       src,
       children: undefined,
     },
-    style: props.style || {},
     children: [],
   };
 }
@@ -632,7 +432,6 @@ function createButtonInstance(
       ...props,
       children: undefined,
     },
-    style: props.style || {},
     children: [],
   };
 }
@@ -650,7 +449,6 @@ function createLoadingInstance(
     kind: NodeKind.Loading,
     // @ts-ignore
     props,
-    style: props.style || {},
     children: [],
   };
 }
@@ -670,7 +468,6 @@ function createScrollBarInstance(
       ...props,
       children: undefined,
     },
-    style: {},
     children: [],
   };
 }
@@ -690,7 +487,6 @@ function createSvgInstance(
       ...props,
       children: undefined,
     },
-    style: props.style || {},
     children: [],
   };
 }
@@ -709,7 +505,6 @@ function createPathInstance(
     props: {
       ...props,
     },
-    style: props.style || {},
     children: [],
   };
 }
@@ -728,7 +523,6 @@ function createCircleInstance(
     props: {
       ...props,
     },
-    style: props.style || {},
     children: [],
   };
 }
@@ -747,7 +541,6 @@ function createIframeInstance(
     props: {
       ...props,
     },
-    style: props.style || {},
     children: [],
   };
 }
@@ -767,7 +560,6 @@ function createCustomInstance(
       ...props,
       children: undefined,
     },
-    style: props.style || {},
     children: [],
     component: kind,
   };
@@ -788,7 +580,6 @@ function createNavAnimationInstance(
       ...props,
       children: undefined,
     },
-    style: {},
     children: [],
   };
 }
@@ -807,7 +598,6 @@ function createBalancesTableInstance(
       ...props,
       children: undefined,
     },
-    style: props.style || {},
     children: [],
   };
 }
@@ -827,7 +617,6 @@ function createBalancesTableHeadInstance(
       ...props,
       children: undefined,
     },
-    style: props.style || {},
     children: [],
   };
 }
@@ -846,7 +635,6 @@ function createBalancesTableContentInstance(
       ...props,
       children: undefined,
     },
-    style: props.style || {},
     children: [],
   };
 }
@@ -866,7 +654,6 @@ function createBalancesTableRowInstance(
       ...props,
       children: undefined,
     },
-    style: props.style || {},
     children: [],
   };
 }
@@ -885,7 +672,6 @@ function createBalancesTableCellInstance(
       ...props,
       children: undefined,
     },
-    style: props.style || {},
     children: [],
   };
 }
@@ -904,7 +690,6 @@ function createBalancesTableFooterInstance(
       ...props,
       children: undefined,
     },
-    style: props.style || {},
     children: [],
   };
 }
@@ -924,21 +709,6 @@ export const HOST: Host = {
     return () => id++;
   })(),
 };
-
-type _HostConfig = HostConfig<
-  NodeKind,
-  NodeProps,
-  RootContainer,
-  NodeSerialized,
-  TextSerialized,
-  HydratableInstance,
-  Element,
-  Host,
-  UpdateDiff,
-  ChildSet,
-  TimeoutHandle,
-  NoTimeout
->;
 
 type Style = any;
 
@@ -1053,6 +823,7 @@ type TextNodeSerialized = DefNodeSerialized<NodeKind.Text, TextProps>;
 type TextProps = {
   style: Style;
   children: undefined;
+  tw: string;
 };
 
 //
@@ -1070,6 +841,7 @@ type TextFieldProps = {
   placeholder?: string;
   style: Style;
   children: undefined;
+  tw: string;
 };
 
 //
@@ -1081,6 +853,7 @@ type ImageProps = {
   onClick?: (() => Promise<void>) | boolean;
   children: undefined;
   src: string;
+  tw: string;
 };
 
 //
@@ -1088,9 +861,10 @@ type ImageProps = {
 //
 type ViewNodeSerialized = DefNodeSerialized<NodeKind.View, ViewProps>;
 type ViewProps = {
-  onClick?: (() => Promise<void>) | boolean;
+  onClick?: () => Promise<void>;
   style: Style;
   children: undefined;
+  tw: string;
 };
 
 //
@@ -1101,6 +875,7 @@ type ButtonProps = {
   onClick?: (() => Promise<void>) | boolean;
   style: Style;
   children: undefined;
+  tw: string;
 };
 
 //
@@ -1135,6 +910,7 @@ type SvgProps = {
   fill: string;
   children: undefined;
   style: Style;
+  tw: string;
 };
 
 //
@@ -1148,6 +924,7 @@ type PathProps = {
   fillRule?: string;
   clipRule?: string;
   stroke?: string;
+  tw: string;
 };
 
 type CircleNodeSerialized = DefNodeSerialized<NodeKind.Circle, CircleProps>;
@@ -1161,6 +938,7 @@ type CircleProps = {
   pathLength: string;
   strokeDasharray: string;
   strokeDashoffset: string;
+  tw: string;
 };
 
 //
@@ -1173,6 +951,7 @@ type IframeProps = {
   width: string;
   height: string;
   xnft: boolean;
+  tw: string;
 };
 
 //
@@ -1279,7 +1058,6 @@ type DefNodeSerialized<K, P> = {
   id: number;
   kind: K;
   props: P;
-  style: Style;
   children: Array<Element>;
 };
 
@@ -1287,7 +1065,6 @@ type CustomNodeSerialized = {
   id: number;
   kind: NodeKind.Custom;
   props: CustomProps;
-  style: Style;
   children: Array<Element>;
   component: string;
 };


### PR DESCRIPTION
The PR cleans up the reconciler. 
We now pass down all props that the user gives us to the renderer. This isn't a problem anymore since all this code runs inside an IFRAME. The renderer can chose to use/throw the props it doesn't need.

This also ensures that we propagate updates for all props to the reconciler. Until now we were cherrypicking the props whose updates we want to propagate based on the NodeKind (onClick, style ...)