### PR TITLE
hide ONE entrypoint when solana blockchain disabled.

### DIFF
--- a/packages/app-extension/src/hooks/useIsONELive.ts
+++ b/packages/app-extension/src/hooks/useIsONELive.ts
@@ -24,5 +24,5 @@ export function useIsONELive() {
     });
   }, []);
 
-  return isLive || whitelist.includes(wallet.publicKey);
+  return wallet && (isLive || whitelist.includes(wallet?.publicKey));
 }


### PR DESCRIPTION
Entrypoint should not show up at all when solana is disabled.