### PR TITLE
Added xnft level camera/mic permissions

### DIFF
--- a/packages/app-extension/src/components/Unlocked/Apps/Plugin.tsx
+++ b/packages/app-extension/src/components/Unlocked/Apps/Plugin.tsx
@@ -2,7 +2,7 @@ import { Button, Divider } from "@mui/material";
 import { PublicKey } from "@solana/web3.js";
 import { Plugin } from "@coral-xyz/common";
 import { PluginRenderer } from "../../../plugin/Renderer";
-import { useDarkMode, usePlugins } from "@coral-xyz/recoil";
+import { useDarkMode, usePlugins, useXnftPreference } from "@coral-xyz/recoil";
 import { useCustomTheme } from "@coral-xyz/themes";
 import { PowerIcon, MoreIcon } from "../../common/Icon";
 import { Simulator } from "./Simulator";
@@ -54,6 +54,9 @@ export function _PluginDisplay({
   closePlugin: () => void;
 }) {
   const theme = useCustomTheme();
+  const xnftPreference = useXnftPreference({
+    xnftId: plugin.xnftAddress.toString(),
+  });
 
   // TODO: splash loading page.
   return (
@@ -64,7 +67,11 @@ export function _PluginDisplay({
       }}
     >
       <PluginControl closePlugin={closePlugin} />
-      <PluginRenderer key={plugin.iframeRootUrl} plugin={plugin} />
+      <PluginRenderer
+        key={plugin.iframeRootUrl}
+        plugin={plugin}
+        xnftPreference={xnftPreference}
+      />
     </div>
   );
 }

--- a/packages/app-extension/src/components/Unlocked/Settings/Xnfts/Detail.tsx
+++ b/packages/app-extension/src/components/Unlocked/Settings/Xnfts/Detail.tsx
@@ -7,6 +7,9 @@ import {
   explorerUrl,
   Blockchain,
   Solana,
+  UI_RPC_METHOD_KEYRING_STORE_UNLOCK,
+  UI_RPC_METHOD_GET_XNFT_PREFERENCES,
+  UI_RPC_METHOD_SET_XNFT_PREFERENCES,
 } from "@coral-xyz/common";
 import { useCustomTheme } from "@coral-xyz/themes";
 import {
@@ -14,6 +17,8 @@ import {
   useSolanaExplorer,
   useSolanaConnectionUrl,
   useNavigation,
+  useXnftPreference,
+  useBackgroundClient,
 } from "@coral-xyz/recoil";
 import { SwitchToggle } from "../Preferences";
 import { SettingsList } from "../../../common/Settings/List";
@@ -36,7 +41,9 @@ const logger = getLogger("xnft-detail");
 export const XnftDetail: React.FC<{ xnft: any }> = ({ xnft }) => {
   const theme = useCustomTheme();
   const [openConfirm, setOpenConfirm] = useState(false);
+  const xnftPreference = useXnftPreference({ xnftId: xnft.install.publicKey });
   const nav = useNavStack();
+  const background = useBackgroundClient();
 
   const isDisabled = xnft.install.publicKey === PublicKey.default.toString();
 
@@ -46,7 +53,34 @@ export const XnftDetail: React.FC<{ xnft: any }> = ({ xnft }) => {
 
   const menuItems = {
     Display: {
-      detail: <SwitchToggle enabled={true} onChange={() => {}} />,
+      detail: (
+        <SwitchToggle enabled={!xnftPreference.disabled} onChange={() => {}} />
+      ),
+      onClick: () => {},
+      style: {
+        opacity: 0.5,
+      },
+    },
+    MediaAccess: {
+      label: "Cam/Mic/Display access",
+      detail: (
+        <SwitchToggle
+          enabled={xnftPreference.mediaPermissions}
+          onChange={async () => {
+            const updatedMediaPermissions = !xnftPreference.mediaPermissions;
+
+            await background.request({
+              method: UI_RPC_METHOD_SET_XNFT_PREFERENCES,
+              params: [
+                xnft.install.publicKey,
+                {
+                  mediaPermissions: updatedMediaPermissions,
+                },
+              ],
+            });
+          }}
+        />
+      ),
       onClick: () => {},
       style: {
         opacity: 0.5,

--- a/packages/app-extension/src/plugin/Renderer.tsx
+++ b/packages/app-extension/src/plugin/Renderer.tsx
@@ -1,8 +1,20 @@
 import { useEffect, useRef, useState } from "react";
 import { Loading } from "../components/common";
-import { useAvatarUrl, useDarkMode, useUsername } from "@coral-xyz/recoil";
+import {
+  useAvatarUrl,
+  useDarkMode,
+  useUsername,
+  useXnftPreference,
+} from "@coral-xyz/recoil";
+import { XnftPreference } from "@coral-xyz/common";
 
-export function PluginRenderer({ plugin }: { plugin: any }) {
+export function PluginRenderer({
+  plugin,
+  xnftPreference,
+}: {
+  plugin: any;
+  xnftPreference: XnftPreference;
+}) {
   const ref = useRef<any>();
   const [loaded, setLoaded] = useState(false);
   const username = useUsername();
@@ -11,7 +23,7 @@ export function PluginRenderer({ plugin }: { plugin: any }) {
 
   useEffect(() => {
     if (plugin && ref && ref.current) {
-      plugin.mount();
+      plugin.mount(xnftPreference);
       plugin.didFinishSetup!.then(() => {
         plugin.pushAppUiMetadata({ isDarkMode, username, avatarUrl });
         plugin.iframeRoot.style.display = "";

--- a/packages/background/src/backend/core.ts
+++ b/packages/background/src/backend/core.ts
@@ -975,8 +975,6 @@ export class Backend {
         ...preference,
       },
     };
-    console.log("updated preferences are");
-    console.log(updatedPreferences);
     await store.setXnftPreferences(updatedPreferences);
     this.events.emit(BACKEND_EVENT, {
       name: NOTIFICATION_XNFT_PREFERENCE_UPDATED,

--- a/packages/background/src/backend/core.ts
+++ b/packages/background/src/backend/core.ts
@@ -40,10 +40,13 @@ import {
   NOTIFICATION_SOLANA_COMMITMENT_UPDATED,
   NOTIFICATION_SOLANA_CONNECTION_URL_UPDATED,
   NOTIFICATION_SOLANA_EXPLORER_UPDATED,
+  NOTIFICATION_XNFT_PREFERENCE_UPDATED,
   SolanaCluster,
   SolanaExplorer,
   deserializeTransaction,
   FEATURE_GATES_MAP,
+  XnftPreferenceStore,
+  XnftPreference,
 } from "@coral-xyz/common";
 import type {
   KeyringInit,
@@ -961,6 +964,28 @@ export class Backend {
 
   async getFeatureGates() {
     return await store.getFeatureGates();
+  }
+
+  async setXnftPreferences(xnftId: string, preference: XnftPreference) {
+    const currentPreferences = (await store.getXnftPreferences()) || {};
+    const updatedPreferences = {
+      ...currentPreferences,
+      [xnftId]: {
+        ...(currentPreferences[xnftId] || {}),
+        ...preference,
+      },
+    };
+    console.log("updated preferences are");
+    console.log(updatedPreferences);
+    await store.setXnftPreferences(updatedPreferences);
+    this.events.emit(BACKEND_EVENT, {
+      name: NOTIFICATION_XNFT_PREFERENCE_UPDATED,
+      data: { updatedPreferences },
+    });
+  }
+
+  async getXnftPreferences() {
+    return await store.getXnftPreferences();
   }
 
   ///////////////////////////////////////////////////////////////////////////////

--- a/packages/background/src/backend/store/index.ts
+++ b/packages/background/src/backend/store/index.ts
@@ -9,6 +9,7 @@ export * from "./db";
 export * from "./keyring";
 export * from "./keyname";
 export * from "./feature-gates";
+export * from "./xnft-preferences";
 
 export function reset() {
   return LocalStorageDb.reset();

--- a/packages/background/src/backend/store/xnft-preferences.ts
+++ b/packages/background/src/backend/store/xnft-preferences.ts
@@ -1,0 +1,12 @@
+import { LocalStorageDb } from "./db";
+import { XnftPreferenceStore } from "@coral-xyz/common";
+
+const KEY_XNFT_PREFERENCES_STORE = "xnft-preferences-store";
+
+export async function getXnftPreferences(): Promise<XnftPreferenceStore> {
+  return await LocalStorageDb.get(KEY_XNFT_PREFERENCES_STORE);
+}
+
+export async function setXnftPreferences(preferences: XnftPreferenceStore) {
+  await LocalStorageDb.set(KEY_XNFT_PREFERENCES_STORE, preferences);
+}

--- a/packages/background/src/frontend/server-ui.ts
+++ b/packages/background/src/frontend/server-ui.ts
@@ -8,6 +8,7 @@ import type {
   Context,
   EventEmitter,
   Blockchain,
+  XnftPreference,
 } from "@coral-xyz/common";
 import type { Commitment } from "@solana/web3.js";
 import {
@@ -87,6 +88,8 @@ import {
   UI_RPC_METHOD_SET_FEATURE_GATES,
   FEATURE_GATES_MAP,
   UI_RPC_METHOD_GET_FEATURE_GATES,
+  UI_RPC_METHOD_GET_XNFT_PREFERENCES,
+  UI_RPC_METHOD_SET_XNFT_PREFERENCES,
 } from "@coral-xyz/common";
 import type { KeyringStoreState } from "@coral-xyz/recoil";
 import type { Backend } from "../backend/core";
@@ -235,6 +238,10 @@ async function handle<T = any>(
       return await handleSetFeatureGates(ctx, params[0]);
     case UI_RPC_METHOD_GET_FEATURE_GATES:
       return await handleGetFeatureGates(ctx);
+    case UI_RPC_METHOD_GET_XNFT_PREFERENCES:
+      return await handleGetXnftPreferences(ctx);
+    case UI_RPC_METHOD_SET_XNFT_PREFERENCES:
+      return await handleSetXnftPreferences(ctx, params[0], params[1]);
     case UI_RPC_METHOD_BLOCKCHAIN_KEYRINGS_ADD:
       return await handleBlockchainKeyringsAdd(
         ctx,
@@ -871,6 +878,20 @@ async function handleSetFeatureGates(
 
 async function handleGetFeatureGates(ctx: Context<Backend>) {
   const resp = await ctx.backend.getFeatureGates();
+  return [resp];
+}
+
+async function handleGetXnftPreferences(ctx: Context<Backend>) {
+  const resp = await ctx.backend.getXnftPreferences();
+  return [resp];
+}
+
+async function handleSetXnftPreferences(
+  ctx: Context<Backend>,
+  xnftId: string,
+  preference: XnftPreference
+) {
+  const resp = await ctx.backend.setXnftPreferences(xnftId, preference);
   return [resp];
 }
 

--- a/packages/common/src/constants.ts
+++ b/packages/common/src/constants.ts
@@ -166,6 +166,11 @@ export const UI_RPC_METHOD_SET_FEATURE_GATES =
   "ui-rpc-method-set-feature-gates";
 export const UI_RPC_METHOD_GET_FEATURE_GATES =
   "ui-rpc-method-get-feature-gates";
+export const UI_RPC_METHOD_GET_XNFT_PREFERENCES =
+  "ui-rpc-method-get-xnft-preference";
+export const UI_RPC_METHOD_SET_XNFT_PREFERENCES =
+  "ui-rpc-method-set-xnft-preference";
+
 export const UI_RPC_METHOD_PREVIEW_PUBKEYS =
   "ui-rpc-method-keyring-preview-pubkeys";
 export const UI_RPC_METHOD_SETTINGS_DARK_MODE_READ =
@@ -231,6 +236,8 @@ export const NOTIFICATION_AUTO_LOCK_SECS_UPDATED =
   "notification-auto-lock-secs-updated";
 export const NOTIFICATION_BLOCKCHAIN_DISABLED =
   "notification-blockchain-disabled";
+export const NOTIFICATION_XNFT_PREFERENCE_UPDATED =
+  "notification-xnft-preference-updated";
 export const NOTIFICATION_BLOCKCHAIN_ENABLED =
   "notification-blockchain-enabled";
 export const NOTIFICATION_DARK_MODE_UPDATED = "notification-dark-mode-updated";

--- a/packages/common/src/plugin.ts
+++ b/packages/common/src/plugin.ts
@@ -37,7 +37,7 @@ import { getLogger, Event, XnftMetadata } from "@coral-xyz/common-public";
 import { BackgroundClient } from "./channel/app-ui";
 import { PluginServer } from "./channel/plugin";
 
-import { Blockchain, RpcResponse } from "./types";
+import { Blockchain, RpcResponse, XnftPreference } from "./types";
 
 const logger = getLogger("common/plugin");
 
@@ -123,7 +123,7 @@ export class Plugin {
   //
   // Loads the plugin javascript code inside the iframe.
   //
-  public createIframe() {
+  public createIframe(preference: XnftPreference) {
     logger.debug("creating iframe element");
 
     this._nextRenderId = 0;
@@ -132,6 +132,12 @@ export class Plugin {
     this.iframeRoot.style.height = "100vh";
     this.iframeRoot.style.border = "none";
 
+    if (preference.mediaPermissions) {
+      this.iframeRoot.setAttribute(
+        "allow",
+        "camera;microphone;display-capture"
+      );
+    }
     this.iframeRoot.setAttribute("fetchpriority", "low");
     this.iframeRoot.src = this.iframeRootUrl;
     this.iframeRoot.sandbox.add("allow-same-origin");
@@ -211,8 +217,8 @@ export class Plugin {
   // Rendering.
   //////////////////////////////////////////////////////////////////////////////
 
-  public mount() {
-    this.createIframe();
+  public mount(preference: XnftPreference) {
+    this.createIframe(preference);
     this.didFinishSetup!.then(() => {
       this.pushMountNotification();
     });

--- a/packages/common/src/types.ts
+++ b/packages/common/src/types.ts
@@ -80,3 +80,10 @@ export type BlockchainKeyringInit = {
   publicKey: string;
   signature: string | null;
 };
+
+export interface XnftPreference {
+  disabled: boolean;
+  mediaPermissions: boolean;
+}
+
+export type XnftPreferenceStore = { [key: string]: XnftPreference };

--- a/packages/recoil/src/atoms/preferences/index.tsx
+++ b/packages/recoil/src/atoms/preferences/index.tsx
@@ -93,3 +93,5 @@ export const username = atom<string | null>({
     },
   }),
 });
+
+export * from "./xnft-preferences";

--- a/packages/recoil/src/atoms/preferences/xnft-preferences.tsx
+++ b/packages/recoil/src/atoms/preferences/xnft-preferences.tsx
@@ -1,0 +1,40 @@
+import { atom, atomFamily, selector, selectorFamily } from "recoil";
+import {
+  UI_RPC_METHOD_GET_XNFT_PREFERENCES,
+  XnftPreferenceStore,
+  XnftPreference,
+} from "@coral-xyz/common";
+import { backgroundClient } from "../client";
+
+export const xnftPreferences = atom<XnftPreferenceStore>({
+  key: "xnftPreferences",
+  default: selector({
+    key: "xnftPreferencesDefault",
+    get: async ({ get }) => {
+      const background = get(backgroundClient);
+      const response = await background.request({
+        method: UI_RPC_METHOD_GET_XNFT_PREFERENCES,
+        params: [],
+      });
+      return response || {};
+    },
+  }),
+});
+
+export const xnftPreference = atomFamily<
+  XnftPreference,
+  {
+    xnftId: string;
+  }
+>({
+  key: "xnftPreference",
+  default: selectorFamily({
+    key: "xnftPreferenceDefault",
+    get:
+      ({ xnftId }: { xnftId: string }) =>
+      async ({ get }) => {
+        const preferences = get(xnftPreferences);
+        return preferences[xnftId] || {};
+      },
+  }),
+});

--- a/packages/recoil/src/context/Notifications.tsx
+++ b/packages/recoil/src/context/Notifications.tsx
@@ -32,6 +32,7 @@ import {
   NOTIFICATION_ETHEREUM_CHAIN_ID_UPDATED,
   NOTIFICATION_ETHEREUM_TOKENS_DID_UPDATE,
   NOTIFICATION_ETHEREUM_FEE_DATA_DID_UPDATE,
+  NOTIFICATION_XNFT_PREFERENCE_UPDATED,
 } from "@coral-xyz/common";
 import {
   KeyringStoreStateEnum,
@@ -55,6 +56,7 @@ export function NotificationsProvider(props: any) {
   const setActiveWallets = useSetRecoilState(atoms.activeWallets);
   const setApprovedOrigins = useSetRecoilState(atoms.approvedOrigins);
   const setAutoLockSecs = useSetRecoilState(atoms.autoLockSecs);
+  const setXnftPreferences = useSetRecoilState(atoms.xnftPreferences);
   const setIsDarkMode = useSetRecoilState(atoms.isDarkMode);
   const setIsDeveloperMode = useSetRecoilState(atoms.isDeveloperMode);
   const setEnabledBlockchains = useSetRecoilState(atoms.enabledBlockchains);
@@ -116,6 +118,9 @@ export function NotificationsProvider(props: any) {
           break;
         case NOTIFICATION_AUTO_LOCK_SECS_UPDATED:
           handleAutoLockSecsUpdated(notif);
+          break;
+        case NOTIFICATION_XNFT_PREFERENCE_UPDATED:
+          handleXnftPreferenceUpdated(notif);
           break;
         case NOTIFICATION_DARK_MODE_UPDATED:
           handleIsDarkModeUpdated(notif);
@@ -310,6 +315,10 @@ export function NotificationsProvider(props: any) {
 
     const handleAutoLockSecsUpdated = (notif: Notification) => {
       setAutoLockSecs(notif.data.autoLockSecs);
+    };
+
+    const handleXnftPreferenceUpdated = (notif: Notification) => {
+      setXnftPreferences(notif.data.updatedPreferences);
     };
 
     const handleIsDarkModeUpdated = (notif: Notification) => {

--- a/packages/recoil/src/hooks/index.tsx
+++ b/packages/recoil/src/hooks/index.tsx
@@ -15,3 +15,4 @@ export * from "./useTotalBalance";
 export * from "./useTransactionData";
 export * from "./avatar";
 export * from "./useFeatureGates";
+export * from "./useXnftPreferences";

--- a/packages/recoil/src/hooks/useXnftPreferences.tsx
+++ b/packages/recoil/src/hooks/useXnftPreferences.tsx
@@ -1,0 +1,10 @@
+import { useRecoilValue } from "recoil";
+import * as atoms from "../atoms";
+
+export const useXnftPreferences = () => {
+  return useRecoilValue(atoms.xnftPreferences);
+};
+
+export function useXnftPreference({ xnftId }: { xnftId: string }) {
+  return useRecoilValue(atoms.xnftPreference({ xnftId }));
+}


### PR DESCRIPTION
The PR adds a new `toggle` to `xnft settings`. 
A user who wants to use an xnft that wants camera/mic/display access will need to enable it in these settings. 
Since the `camera/mic` permission in chrome is given on a `URL` level, once a user approves camera for the `extension`, all xnfts inside it would have camera access unless we limit it. 

![Screenshot 2022-11-07 at 8 21 34 AM](https://user-images.githubusercontent.com/8079861/200216477-a7b81386-36ed-4c2f-86ee-c5b04381c555.png)
