### PR TITLE
add rpc proxy worker

### DIFF
--- a/backend/workers/rpc-proxy/package.json
+++ b/backend/workers/rpc-proxy/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "rpc-proxy",
+  "version": "0.0.0",
+  "devDependencies": {
+    "wrangler": "^2.1.9"
+  },
+  "private": true,
+  "scripts": {
+    "dev": "wrangler dev",
+    "deploy": "wrangler publish"
+  }
+}

--- a/backend/workers/rpc-proxy/src/index.ts
+++ b/backend/workers/rpc-proxy/src/index.ts
@@ -1,0 +1,13 @@
+export interface Env {
+  // in secrets, see `npx wrangler secret --help`
+  RPC_URL: string;
+}
+
+export default {
+  async fetch(request: Request, env: Env): Promise<Response> {
+    return await fetch(
+      env.RPC_URL || "https://api.mainnet-beta.solana.com",
+      request
+    );
+  },
+};

--- a/backend/workers/rpc-proxy/tsconfig.json
+++ b/backend/workers/rpc-proxy/tsconfig.json
@@ -1,0 +1,3 @@
+{
+  "extends": "../tsconfig.json"
+}

--- a/backend/workers/rpc-proxy/wrangler.toml
+++ b/backend/workers/rpc-proxy/wrangler.toml
@@ -1,0 +1,3 @@
+name = "rpc-proxy"
+main = "src/index.ts"
+compatibility_date = "2022-11-10"


### PR DESCRIPTION
a simple proxy for switching RPC providers remotely

only uses https://api.mainnet-beta.solana.com when RPC_URL secret is missing, i.e. local testing