### PR TITLE
filter `yarn start` to only start `./packages/*`

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ yarn install
 yarn build
 ```
 
-### Start packages for development
+### Start everything inside `./packages` for development
 
 ```bash
 yarn start

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   "scripts": {
     "lint:fix": "prettier {examples/xnft,examples/xnft-program-library/packages,packages}/**/*.{ts,tsx,json} --write",
     "prepare": "husky install",
-    "start": "env-cmd --silent turbo run start --concurrency=100%",
+    "start": "env-cmd --silent turbo run start --concurrency=100% --filter=./packages/*",
     "start:fresh": "yarn install && yarn clean && yarn install && yarn start",
     "test": "env-cmd --silent turbo run test -- --passWithNoTests --watchAll=false",
     "build": "env-cmd --silent turbo run build",


### PR DESCRIPTION
no longer tries to start code inside `./examples` dir

`yarn start` from root will now only start what's inside `./packages`

if you want to start other packages inside the workspace, go into the package directory (where there is a package.json) and run `yarn start` or `yarn dev` depending on what's available