### PR TITLE
Adds esbuild to xnft-cli

### DIFF
--- a/examples/xnft/recoil/package.json
+++ b/examples/xnft/recoil/package.json
@@ -2,7 +2,8 @@
   "name": "@coral-xyz/example-plugin-recoil",
   "version": "0.1.0",
   "scripts": {
-    "build": "xnft build",
+    "build": "xnft build -e true",
+    "dev": "xnft dev -e true",
     "start": "xnft watch"
   },
   "devDependencies": {

--- a/examples/xnft/recoil/package.json
+++ b/examples/xnft/recoil/package.json
@@ -2,8 +2,8 @@
   "name": "@coral-xyz/example-plugin-recoil",
   "version": "0.1.0",
   "scripts": {
-    "build": "xnft build -e true",
-    "dev": "xnft dev -e true",
+    "build": "xnft build",
+    "dev": "xnft dev",
     "start": "xnft watch"
   },
   "devDependencies": {

--- a/packages/xnft-cli/index.js
+++ b/packages/xnft-cli/index.js
@@ -2,7 +2,7 @@
 
 // using JS for now because there are race-condition issues
 // with compiling typescript before running in the monorepo
-
+const GlobalsPolyfills = require("@esbuild-plugins/node-globals-polyfill");
 const { Parcel } = require("@parcel/core");
 const { program } = require("commander");
 const { join, resolve } = require("path");
@@ -30,22 +30,54 @@ const options = {
   ],
 };
 
-program.command("build").action(async () => {
-  // https://parceljs.org/features/parcel-api/#building
-  const bundler = new Parcel({
-    ...options,
-    mode: "production",
-    sourceMap: false,
-    optimize: true,
-  });
+const esBuildOptions = {
+  entryPoints: ["./src/index.tsx"],
+  outfile: "dist/index.js",
+  bundle: true,
+  target: "es2022",
+  define: {
+    global: "window",
+  },
+  plugins: [
+    GlobalsPolyfills.default({
+      process: true,
+      buffer: true,
+    }),
+  ],
+};
 
-  try {
-    const { buildTime } = await bundler.run();
-    console.debug(`✨ built in ${buildTime}ms!`);
-  } catch (err) {
-    console.error(err.diagnostics);
-  }
-});
+program
+  .command("build")
+  .option(
+    "-e, --esbuild <boolean>",
+    "Use esbuild to compile your project, useful when you want to polyfill constructs like process"
+  )
+  .action(async ({ esbuild }) => {
+    if (esbuild) {
+      const startTime = new Date();
+      require("esbuild")
+        .build({
+          ...esBuildOptions,
+        })
+        .then((result) => {
+          console.debug(`✨ esbuild built in ${new Date() - startTime}ms!`);
+        });
+    } else {
+      // https://parceljs.org/features/parcel-api/#building
+      const bundler = new Parcel({
+        ...options,
+        mode: "production",
+        sourceMap: false,
+        optimize: true,
+      });
+      try {
+        const { buildTime } = await bundler.run();
+        console.debug(`✨ parcel built in ${buildTime}ms!`);
+      } catch (err) {
+        console.error(err.diagnostics);
+      }
+    }
+  });
 
 program.command("watch").action(async () => {
   console.debug(`👀 watching ${resolve()}`);
@@ -66,7 +98,11 @@ program
     "a URL to load inside an iframe xNFT in the simulator",
     (url) => new URL(url)?.href
   )
-  .action(async ({ iframe }) => {
+  .option(
+    "-e, --esbuild <boolean>",
+    "Use esbuild to compile your project, useful when you want to polyfill constructs like process"
+  )
+  .action(async ({ iframe, esbuild }) => {
     console.debug(`👀 watching ${resolve()}`);
 
     const express = require("express");
@@ -103,32 +139,50 @@ program
           iframe
         );
     } else {
-      // https://parceljs.org/features/parcel-api/#watching
-      const bundler = new Parcel({
-        ...options,
-        mode: "development",
-        sourceMap: true,
-        optimize: false,
-      });
+      if (!esbuild) {
+        const bundler = new Parcel({
+          ...options,
+          mode: "development",
+          sourceMap: true,
+          optimize: false,
+        });
 
-      if (!fs.existsSync("dist/index.js")) {
-        if (!fs.existsSync("dist")) {
-          fs.mkdirSync("dist");
+        if (!fs.existsSync("dist/index.js")) {
+          if (!fs.existsSync("dist")) {
+            fs.mkdirSync("dist");
+          }
+          fs.writeFileSync("dist/index.js", "");
         }
-        fs.writeFileSync("dist/index.js", "");
-      }
 
-      js = fs.readFileSync("dist/index.js", { encoding: "utf-8" });
-      await bundler.watch((err, buildEvent) => {
-        console.log("build changed");
-        if (err) {
-          console.error("build error", JSON.stringify(err));
-        }
-        if (buildEvent.type === "buildFailure") {
-          console.error("build error", JSON.stringify(buildEvent));
-        }
         js = fs.readFileSync("dist/index.js", { encoding: "utf-8" });
-      });
+        await bundler.watch((err, buildEvent) => {
+          console.log("build changed");
+          if (err) {
+            console.error("build error", JSON.stringify(err));
+          }
+          if (buildEvent.type === "buildFailure") {
+            console.error("build error", JSON.stringify(buildEvent));
+          }
+          js = fs.readFileSync("dist/index.js", { encoding: "utf-8" });
+        });
+      } else {
+        // https://parceljs.org/features/parcel-api/#watching
+        require("esbuild")
+          .build({
+            ...esBuildOptions,
+            watch: {
+              onRebuild(error, result) {
+                console.log("build changed");
+                if (error) console.error("build error", JSON.stringify(err));
+                js = fs.readFileSync("dist/index.js", { encoding: "utf-8" });
+              },
+            },
+          })
+          .then((result) => {
+            console.log("watching...");
+            js = fs.readFileSync("dist/index.js", { encoding: "utf-8" });
+          });
+      }
     }
 
     app.get("/", (req, res) => {

--- a/packages/xnft-cli/package.json
+++ b/packages/xnft-cli/package.json
@@ -9,12 +9,14 @@
     "build": "shx cp ../../examples/xnft/iframe/dist/index.js iframe.js && shx cp ../react-xnft-dom-renderer/dist/index.js renderer.js"
   },
   "dependencies": {
+    "@esbuild-plugins/node-globals-polyfill": "^0.1.1",
     "@parcel/config-default": "^2.7.0",
     "@parcel/core": "^2.7.0",
     "@parcel/reporter-cli": "^2.7.0",
     "commander": "^9.3.0",
-    "express": "^4.18.1",
-    "download-git-repo": "latest"
+    "download-git-repo": "latest",
+    "esbuild": "^0.15.13",
+    "express": "^4.18.1"
   },
   "devDependencies": {
     "react-xnft": "*",


### PR DESCRIPTION
Useful for users that want to polyfill node constructs.
Should make this the default in ~1 week after letting it sit for a while.

The PR also makes the build use esbuild for the `recoil` example which is breaking currently.

EDIT: Workflow is failing on the `recoil` example so will add that as a follow up when this gets merged in and deployed
