### PR TITLE
Fixed preview

### DIFF
--- a/packages/app-extension/src/components/Unlocked/Apps/Plugin.tsx
+++ b/packages/app-extension/src/components/Unlocked/Apps/Plugin.tsx
@@ -60,7 +60,7 @@ export function _PluginDisplay({
 }) {
   const theme = useCustomTheme();
   const xnftPreference = useXnftPreference({
-    xnftId: plugin.xnftInstallAddress.toString(),
+    xnftId: plugin.xnftInstallAddress?.toString(),
   });
 
   // TODO: splash loading page.


### PR DESCRIPTION
Previews on xnft.gg broke in https://github.com/coral-xyz/backpack/pull/1451
The PR fixes them. 
Need to figure out a better way to define preferences for xnfts that aren't yet installed (so no way of giving camera permissions currently since they wont appear in your `xnfts` section)