### PR TITLE
Children to undefined if no children are present

### DIFF
--- a/packages/react-xnft-dom-renderer/src/Component.tsx
+++ b/packages/react-xnft-dom-renderer/src/Component.tsx
@@ -283,7 +283,9 @@ function Custom({ children, component, props }) {
   const el = React.createElement(
     component,
     { ...props, className: props?.tw + " " + props.className },
-    children.map((c) => <ViewRenderer key={c.id} element={c} />)
+    children && children.length
+      ? children.map((c) => <ViewRenderer key={c.id} element={c} />)
+      : undefined
   );
   return el;
 }


### PR DESCRIPTION
More details here - https://discord.com/channels/985994296337498182/1011846320677462137/1041780817191514223
tl;dr is this error was thrown https://reactjs.org/docs/error-decoder.html/?invariant=137&args[]=input when we would pass in children to `input`.