### PR TITLE
fix nan bugs

### DIFF
--- a/packages/app-extension/src/components/Unlocked/Balances/Balances.tsx
+++ b/packages/app-extension/src/components/Unlocked/Balances/Balances.tsx
@@ -154,8 +154,8 @@ export function BalancesTableCell({ props }: any) {
   let trim;
   try {
     trim = `${subtitle.split(".")[0]}.${subtitle.split(".")[1].slice(0, 5)}`;
-  } catch (e) {
-    console.error("can't trim the balance");
+  } catch {
+    // pass
   }
 
   return (

--- a/packages/common-public/src/utils.ts
+++ b/packages/common-public/src/utils.ts
@@ -11,11 +11,16 @@ export function toTitleCase(str: string) {
  * formatUSD(-1234567.89) // "-$1,234,567.89"
  */
 export function formatUSD(amount: number | string) {
-  const amountNumber = typeof amount === "string" ? Number(amount) : amount;
+  let amountNumber: number;
+  if (typeof amount === "string") {
+    amountNumber = Number(amount.replace(",", ""));
+  } else {
+    amountNumber = amount;
+  }
   return new Intl.NumberFormat("en-US", {
     style: "currency",
     currency: "USD",
-  }).format(Number(String(amountNumber)));
+  }).format(amountNumber);
 }
 
 /**


### PR DESCRIPTION
Bug stemmed from commas in string values, i.e. Number("1,234.231") is NaN. Also removed error in trim failure because it's a common case and not really an error.

Closes #1015 