### PR TITLE
Removed backward compatibility from existing renderer xnfts

### DIFF
--- a/backend/workers/xnft-wrapper/src/index.ts
+++ b/backend/workers/xnft-wrapper/src/index.ts
@@ -4,38 +4,12 @@ const RPC = "https://api.devnet.solana.com";
 const PROD_RENDERER_URL =
   "https://unpkg.com/@coral-xyz/react-xnft-dom-renderer@0.2.0-latest.427/dist/index.js";
 
-const V1_BUNDLES: string[] = [
-  "https://ipfs.io/ipfs/bafybeibhd37z7osxbp2fvxcenid6uufsvrpumawxw4ked7h2br4duz3sme",
-  "https://xnfts.s3.us-west-2.amazonaws.com/4AwaNy62XXNhgEbe3Szk9Tb7eEgDcHG3YbpEzdX8DPj5/bundle/index.js",
-  "https://xnfts.s3.us-west-2.amazonaws.com/9Tqzi3gb4jE3D8Ez79HUTjFfS9f9ES31NjXez6yaffd7/bundle/index.js",
-  "https://xnfts.s3.us-west-2.amazonaws.com/3i8Av28osHPoWZzWRoU29JBmfSJEcFtJhDzBTLhFG1u6/bundle/index.js",
-  "https://xnfts.s3.us-west-2.amazonaws.com/4QaPNGJFsdqT5cbURcLcVGPQD8GgCpNM6Bmf2p88ex2f/bundle/index.js",
-  "https://xnfts.s3.us-west-2.amazonaws.com/HGVjbFZdHuEK1e8MAXte5hG9NquPSig5RobdLvyXvSXG/bundle/index.js",
-  "https://ipfs.io/ipfs/bafybeiekyqolvv7xwtg5mp65wnpsumzf7kns4fiticgdmgbrh5wdmbm5ve",
-  "https://ipfs.io/ipfs/bafybeig4hrp7prl5afffpv2wzd4dmmxlrg7f4oj3vnytwpnjzxy7gh22ve",
-  "https://ipfs.io/ipfs/bafybeignivvx6ilmx3hrcekwk53riant44knedielglpa3pirh76ld7tse",
-  "https://ipfs.io/ipfs/bafybeifwqc6zlfh4in56y2cptfa64rivqlqunu5kfxy43rxlacm7kqbjz4",
-];
-
 export default {
   async fetch(request: Request): Promise<Response> {
     const { searchParams, pathname } = new URL(request.url);
 
     // @ts-ignore
     let bundle: string = searchParams.get("bundle");
-    let v2 = searchParams.get("v2");
-
-    // TODO Remove this logic few days after the new renderer releases
-    if (v2 && V1_BUNDLES.includes(bundle)) {
-      // Upgrade Warning example xnft bundle
-      bundle =
-        "https://xnfts-dev.s3.us-west-2.amazonaws.com/warning-xnft/index-new-wallet-warning.js";
-    }
-
-    if (!v2 && !V1_BUNDLES.includes(bundle)) {
-      bundle =
-        "https://xnfts-dev.s3.us-west-2.amazonaws.com/warning-xnft/index-old-wallet-warning.js";
-    }
 
     if (!bundle) {
       const xnftMint = pathname.match(/^\/(\w{30,50})/)?.[1];
@@ -82,9 +56,7 @@ export default {
         <script>${js}</script>`;
       }
 
-      if (v2) {
-        innerHTML += `<script src="${PROD_RENDERER_URL}"></script>`;
-      }
+      innerHTML += `<script src="${PROD_RENDERER_URL}"></script>`;
 
       return html(`
         <!DOCTYPE html>


### PR DESCRIPTION
Xnfts that haven't deployed have been hidden from xnft.gg for a while. Removing this logic that would conditionally render a warning when they were opened.