### PR TITLE
change default rpc url for mainnet in simple client

### DIFF
--- a/examples/clients/simple/src/SolanaWallet.tsx
+++ b/examples/clients/simple/src/SolanaWallet.tsx
@@ -1,4 +1,4 @@
-import React, { FC, useMemo } from "react";
+import { FC, useMemo } from "react";
 import {
   ConnectionProvider,
   WalletProvider,
@@ -21,7 +21,13 @@ export const SolanaWallet: FC = (props) => {
   const network = WalletAdapterNetwork.Mainnet;
 
   // You can also provide a custom RPC endpoint.
-  const endpoint = useMemo(() => clusterApiUrl(network), [network]);
+  const endpoint = useMemo(() => {
+    if (network === "mainnet-beta") {
+      return "https://solana-rpc.xnfts.dev/";
+    } else {
+      return clusterApiUrl(network);
+    }
+  }, [network]);
 
   // @solana/wallet-adapter-wallets includes all the adapters but supports tree shaking and lazy loading --
   // Only the wallets you configure here will be compiled into your application, and only the dependencies


### PR DESCRIPTION
`http://api.mainnet-beta.solana.com/` is returning 403 so the simple client isn't working for testing.