### PR TITLE
Proxy metadata requests to get rid of `Deceptive site warning`

### DIFF
--- a/backend/native/backpack-api/package.json
+++ b/backend/native/backpack-api/package.json
@@ -4,7 +4,9 @@
   "main": "index.js",
   "license": "MIT",
   "dependencies": {
+    "@coral-xyz/zeus": "*",
     "@types/express": "^4.17.14",
+    "@types/request": "^2.48.8",
     "@types/web-push": "^3.3.2",
     "asn1.js": "^5.4.1",
     "cookie-parser": "^1.4.6",
@@ -13,9 +15,9 @@
     "http_ece": "^1.1.0",
     "jws": "^4.0.0",
     "reequest": "^0.0.1-security",
+    "request": "^2.88.2",
     "urlsafe-base64": "^1.0.0",
-    "web-push": "^3.5.0",
-    "@coral-xyz/zeus": "*"
+    "web-push": "^3.5.0"
   },
   "scripts": {
     "build": "esbuild ./src/index.js --bundle --platform=node --outfile=dist/index.js",

--- a/backend/native/backpack-api/src/index.ts
+++ b/backend/native/backpack-api/src/index.ts
@@ -1,10 +1,7 @@
 import express from "express";
-import {
-  getPreferences,
-  insertSubscription,
-  updatePreference,
-} from "./db/preference";
-import { getNotifications } from "./db/notifications";
+import notificationRoutes from "./routes/v1/notifications";
+import preferenceRoutes from "./routes/v1/preferences";
+import proxyRouter from "./routes/v1/proxy";
 
 const app = express();
 const bodyParser = require("body-parser");
@@ -13,53 +10,10 @@ const cookieParser = require("cookie-parser");
 app.use(cookieParser());
 app.use(bodyParser.json());
 app.use(bodyParser.json({ type: "application/json" }));
-
-app.post("/notifications/register", async (req, res) => {
-  //TODO: Secure this
-  const username = req.body.username || "";
-  const publicKey = req.body.publicKey || "";
-  const subscription = req.body.subscription;
-
-  await insertSubscription(publicKey, username, subscription);
-
-  res.json({});
-});
+app.use("/notifications/", notificationRoutes);
+app.use("/preferences", preferenceRoutes);
+app.use("/proxy", proxyRouter);
 
 // TODO: Add validation using zod
-app.post("/preference", async (req, res) => {
-  //TODO: Secure this
-  const username = req.body.username || "";
-  const xnftId = req.body.xnftId;
-  const preferences = req.body.preferences;
-
-  await updatePreference(xnftId, username, preferences);
-
-  res.json({});
-});
-
-app.get("/preferences", async (req, res) => {
-  //TODO: Secure this
-  const username = req.body.username || "";
-
-  const xnftPreferences = await getPreferences(username);
-
-  res.json({ xnftPreferences });
-});
-
-app.get("/notifications", async (req, res) => {
-  // @TODO: secure this
-  //@ts-ignore
-  const username: string = req.query.username;
-  //@ts-ignore
-  const limit: string = req.query.limit || 10;
-  //@ts-ignore
-  const offset: string = req.query.offset || 0;
-  const notifications = await getNotifications(
-    username,
-    parseInt(offset),
-    parseInt(limit)
-  );
-  res.json({ notifications });
-});
 
 app.listen(process.env.PORT || 8080);

--- a/backend/native/backpack-api/src/routes/v1/notifications.ts
+++ b/backend/native/backpack-api/src/routes/v1/notifications.ts
@@ -1,0 +1,33 @@
+import express from "express";
+import { insertSubscription } from "../../db/preference";
+import { getNotifications } from "../../db/notifications";
+const router = express.Router();
+
+router.post("/register", async (req, res) => {
+  //TODO: Secure this
+  const username = req.body.username || "";
+  const publicKey = req.body.publicKey || "";
+  const subscription = req.body.subscription;
+
+  await insertSubscription(publicKey, username, subscription);
+
+  res.json({});
+});
+
+router.get("/", async (req, res) => {
+  // @TODO: secure this
+  //@ts-ignore
+  const username: string = req.query.username;
+  //@ts-ignore
+  const limit: string = req.query.limit || 10;
+  //@ts-ignore
+  const offset: string = req.query.offset || 0;
+  const notifications = await getNotifications(
+    username,
+    parseInt(offset),
+    parseInt(limit)
+  );
+  res.json({ notifications });
+});
+
+export default router;

--- a/backend/native/backpack-api/src/routes/v1/preferences.ts
+++ b/backend/native/backpack-api/src/routes/v1/preferences.ts
@@ -1,0 +1,26 @@
+import { getPreferences, updatePreference } from "../../db/preference";
+
+import express from "express";
+const router = express.Router();
+
+router.post("/", async (req, res) => {
+  //TODO: Secure this
+  const username = req.body.username || "";
+  const xnftId = req.body.xnftId;
+  const preferences = req.body.preferences;
+
+  await updatePreference(xnftId, username, preferences);
+
+  res.json({});
+});
+
+router.get("/", async (req, res) => {
+  //TODO: Secure this
+  const username = req.body.username || "";
+
+  const xnftPreferences = await getPreferences(username);
+
+  res.json({ xnftPreferences });
+});
+
+export default router;

--- a/backend/native/backpack-api/src/routes/v1/proxy.ts
+++ b/backend/native/backpack-api/src/routes/v1/proxy.ts
@@ -2,9 +2,14 @@ import router from "./preferences";
 import request from "request";
 
 router.get("/*", async (req, res) => {
-  const url = req.path.slice(1);
+  const url = (req.path || "")?.slice(1);
   try {
-    request(url).pipe(res);
+    const req = request(url);
+    req.on("error", function (err) {
+      console.log(err);
+      res.status(404).json({});
+    });
+    req.pipe(res);
   } catch (e) {
     res.status(500).json({ msg: "Error while proxying request" });
   }

--- a/backend/native/backpack-api/src/routes/v1/proxy.ts
+++ b/backend/native/backpack-api/src/routes/v1/proxy.ts
@@ -1,0 +1,13 @@
+import router from "./preferences";
+import request from "request";
+
+router.get("/*", async (req, res) => {
+  const url = req.path.slice(1);
+  try {
+    request(url).pipe(res);
+  } catch (e) {
+    res.status(500).json({ msg: "Error while proxying request" });
+  }
+});
+
+export default router;

--- a/packages/app-extension/src/api/preferences.ts
+++ b/packages/app-extension/src/api/preferences.ts
@@ -35,7 +35,7 @@ export const updateRemotePreference = (
   username: string,
   preferences: { notifications: boolean }
 ) => {
-  return fetch(`${BACKEND_API_URL}/preference`, {
+  return fetch(`${BACKEND_API_URL}/preferences`, {
     method: "POST",
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify({

--- a/packages/common/src/solana/programs/token.ts
+++ b/packages/common/src/solana/programs/token.ts
@@ -5,6 +5,7 @@ import { AnchorProvider, BN, Spl } from "@project-serum/anchor";
 import type { Provider, Program, SplToken } from "@project-serum/anchor";
 import { metadata } from "@project-serum/token";
 import { getLogger, externalResourceUri } from "@coral-xyz/common-public";
+import { BACKEND_API_URL } from "../../constants";
 import type {
   SolanaTokenAccount,
   SolanaTokenAccountWithKey,
@@ -162,12 +163,21 @@ export async function fetchSplMetadataUri(
         const resp = await new Promise<any>(async (resolve, reject) => {
           setTimeout(() => {
             reject(new Error("timeout"));
-          }, 5000);
+          }, 6000);
           try {
-            const resp = await fetch(externalResourceUri(t.account.data.uri));
+            const resp = await fetch(
+              `${BACKEND_API_URL}/proxy/${externalResourceUri(
+                t.account.data.uri
+              )}`
+            );
             resolve(resp);
           } catch (err) {
-            reject(err);
+            try {
+              const resp = await fetch(externalResourceUri(t.account.data.uri));
+              resolve(resp);
+            } catch (e) {
+              reject(err);
+            }
           }
         });
         return await resp.json();


### PR DESCRIPTION
Gets rid of the big red warning by proxying metadata requests from our backend servers.
Closes https://github.com/coral-xyz/backpack/issues/1227