### PR TITLE
eslint + prettier caching & speed improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,4 @@ test-ledger/
 *-e
 
 .yarnrc
+.eslintcache

--- a/examples/xnft/network-monitor/package.json
+++ b/examples/xnft/network-monitor/package.json
@@ -13,7 +13,7 @@
   "devDependencies": {
     "@coral-xyz/xnft-cli": "^0.0.1",
     "@parcel/config-default": "^2.7.0",
-    "prettier": "2.7.1"
+    "prettier": "^2.7.1"
   },
   "dependencies": {
     "react": "^17.0.2",

--- a/package.json
+++ b/package.json
@@ -34,13 +34,13 @@
     "eslint-plugin-react": "^7.30.1",
     "husky": "^8.0.1",
     "lint-staged": "^12.4.1",
-    "prettier": "^2.6.2",
+    "prettier": "^2.7.1",
     "rimraf": "^3.0.2",
     "turbo": "^1.6.2",
     "yarn-deduplicate": "^6.0.0"
   },
   "lint-staged": {
-    "*.{ts,tsx,js,jsx,css,md,json}": "prettier --write"
+    "*.{ts,tsx,js,jsx,css,md,json}": "prettier --write --cache"
   },
   "resolutions": {
     "@solana/web3.js": "1.63.1",

--- a/packages/app-extension/package.json
+++ b/packages/app-extension/package.json
@@ -42,7 +42,7 @@
     "build": "cross-env NODE_ENV=production webpack",
     "build:release": "cross-env NODE_ENV=production webpack",
     "e2e": "jest --maxWorkers 1 --detectOpenHandles --forceExit --verbose",
-    "lint": "eslint ./src --ext .js,.jsx,.ts,.tsx",
+    "lint": "eslint ./src --ext .js,.jsx,.ts,.tsx --cache",
     "lint:fix": "yarn run lint --fix"
   },
   "eslintConfig": {

--- a/packages/app-mobile/package.json
+++ b/packages/app-mobile/package.json
@@ -9,7 +9,7 @@
     "web": "expo start --web",
     "add": "expo add",
     "eject": "expo eject",
-    "lint": "eslint ./src --ext .js,.jsx,.ts,.tsx",
+    "lint": "eslint ./src --ext .js,.jsx,.ts,.tsx --cache",
     "lint:fix": "yarn run lint --fix",
     "postinstall": "npx patch-package; cd ../../ && patch-package"
   },

--- a/packages/background/package.json
+++ b/packages/background/package.json
@@ -10,7 +10,7 @@
     "build:html": "parcel build src/service-worker-loader.html --dist-dir build --no-source-maps",
     "dev": "tsc --watch",
     "lint": "eslint ./src --ext .js,.jsx,.ts,.tsx --cache",
-    "lint:fix": "yarn run lint --fix --cache",
+    "lint:fix": "yarn run lint --fix",
     "start": "parcel src/service-worker-loader.html -p 9333"
   },
   "dependencies": {

--- a/packages/background/package.json
+++ b/packages/background/package.json
@@ -9,8 +9,8 @@
     "build": "tsc",
     "build:html": "parcel build src/service-worker-loader.html --dist-dir build --no-source-maps",
     "dev": "tsc --watch",
-    "lint": "eslint ./src --ext .js,.jsx,.ts,.tsx",
-    "lint:fix": "yarn run lint --fix",
+    "lint": "eslint ./src --ext .js,.jsx,.ts,.tsx --cache",
+    "lint:fix": "yarn run lint --fix --cache",
     "start": "parcel src/service-worker-loader.html -p 9333"
   },
   "dependencies": {

--- a/packages/blockchains/common/package.json
+++ b/packages/blockchains/common/package.json
@@ -13,7 +13,7 @@
   "scripts": {
     "build": "tsc",
     "dev": "tsc --watch",
-    "lint": "eslint ./src --ext .js,.jsx,.ts,.tsx",
+    "lint": "eslint ./src --ext .js,.jsx,.ts,.tsx --cache",
     "lint:fix": "yarn run lint --fix"
   },
   "dependencies": {

--- a/packages/blockchains/evm/package.json
+++ b/packages/blockchains/evm/package.json
@@ -13,7 +13,7 @@
   "scripts": {
     "build": "tsc",
     "dev": "tsc --watch",
-    "lint": "eslint ./src --ext .js,.jsx,.ts,.tsx",
+    "lint": "eslint ./src --ext .js,.jsx,.ts,.tsx --cache",
     "lint:fix": "yarn run lint --fix"
   },
   "dependencies": {

--- a/packages/blockchains/keyring/package.json
+++ b/packages/blockchains/keyring/package.json
@@ -13,7 +13,7 @@
   "scripts": {
     "build": "tsc",
     "dev": "tsc --watch",
-    "lint": "eslint ./src --ext .js,.jsx,.ts,.tsx",
+    "lint": "eslint ./src --ext .js,.jsx,.ts,.tsx --cache",
     "lint:fix": "yarn run lint --fix"
   },
   "dependencies": {

--- a/packages/blockchains/solana/package.json
+++ b/packages/blockchains/solana/package.json
@@ -13,7 +13,7 @@
   "scripts": {
     "build": "tsc",
     "dev": "tsc --watch",
-    "lint": "eslint ./src --ext .js,.jsx,.ts,.tsx",
+    "lint": "eslint ./src --ext .js,.jsx,.ts,.tsx --cache",
     "lint:fix": "yarn run lint --fix"
   },
   "dependencies": {

--- a/packages/common-public/.eslintrc.js
+++ b/packages/common-public/.eslintrc.js
@@ -1,4 +1,7 @@
 module.exports = {
   root: true,
   extends: ["custom"],
+  parserOptions: {
+    ecmaVersion: 6,
+  },
 };

--- a/packages/common-public/package.json
+++ b/packages/common-public/package.json
@@ -13,7 +13,7 @@
     "build": "./scripts/config.sh && tsc && tsc-alias && tsc -p tsconfig.rn.json",
     "dev": "tsc --watch",
     "lint": "eslint ./src --ext .js,.jsx,.ts,.tsx --cache",
-    "lint:fix": "yarn run lint --fix --cache",
+    "lint:fix": "yarn run lint --fix",
     "start": "yarn build"
   },
   "dependencies": {

--- a/packages/common-public/package.json
+++ b/packages/common-public/package.json
@@ -12,8 +12,8 @@
   "scripts": {
     "build": "./scripts/config.sh && tsc && tsc-alias && tsc -p tsconfig.rn.json",
     "dev": "tsc --watch",
-    "lint": "eslint ./src --ext .js,.jsx,.ts,.tsx",
-    "lint:fix": "yarn run lint --fix",
+    "lint": "eslint ./src --ext .js,.jsx,.ts,.tsx --cache",
+    "lint:fix": "yarn run lint --fix --cache",
     "start": "yarn build"
   },
   "dependencies": {

--- a/packages/common-public/src/index.ts
+++ b/packages/common-public/src/index.ts
@@ -2,8 +2,8 @@
 // publicly. We should remove this eventually.
 
 export * from "./constants";
-export * from "./types";
 export * from "./logging";
+export * from "./types";
 export * from "./utils";
 export * from "./zustand-store";
 

--- a/packages/common-public/src/logging.ts
+++ b/packages/common-public/src/logging.ts
@@ -1,7 +1,7 @@
-import { vanillaStore } from "./zustand-store";
-import { isServiceWorker, IS_MOBILE } from "./utils";
 import { MOBILE_CHANNEL_LOGS } from "./constants";
 import * as cfg from "./generated-config";
+import { IS_MOBILE, isServiceWorker } from "./utils";
+import { vanillaStore } from "./zustand-store";
 
 export function getLogger(mod: string) {
   if (_LOG_LEVEL === undefined) {

--- a/packages/common-public/src/utils.ts
+++ b/packages/common-public/src/utils.ts
@@ -1,4 +1,5 @@
 import { v1 } from "uuid";
+
 import { IMAGE_PROXY_URL } from "./constants";
 
 export function toTitleCase(str: string) {

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -9,7 +9,7 @@
   "scripts": {
     "build": "./scripts/config.sh && tsc && tsc-alias && tsc -p tsconfig.rn.json",
     "dev": "tsc --watch",
-    "lint": "eslint ./src --ext .js,.jsx,.ts,.tsx",
+    "lint": "eslint ./src --ext .js,.jsx,.ts,.tsx --cache",
     "lint:fix": "yarn run lint --fix",
     "start": "yarn build"
   },

--- a/packages/eslint-config-custom/index.js
+++ b/packages/eslint-config-custom/index.js
@@ -70,7 +70,8 @@ module.exports = {
     "simple-import-sort/exports": "warn",
   },
 
-  ignorePatterns: ["dist/*"],
+  // https://eslint.org/docs/latest/user-guide/configuring/ignoring-code#the-eslintignore-file
+  ignorePatterns: ["dist/*", "build/*", "dev/*", "node_modules/**"],
   parserOptions: {
     ecmaVersion: 2020,
     // "sourceType": "module",

--- a/packages/provider-core/package.json
+++ b/packages/provider-core/package.json
@@ -6,7 +6,7 @@
   "types": "dist/esm/index.d.ts",
   "scripts": {
     "build": "tsc",
-    "lint": "eslint ./src --ext .js,.jsx,.ts,.tsx",
+    "lint": "eslint ./src --ext .js,.jsx,.ts,.tsx --cache",
     "lint:fix": "yarn run lint --fix"
   },
   "dependencies": {

--- a/packages/react-xnft-dom-renderer/package.json
+++ b/packages/react-xnft-dom-renderer/package.json
@@ -11,7 +11,7 @@
   ],
   "scripts": {
     "build": "parcel build src/index.tsx --dist-dir dist",
-    "lint": "eslint ./src --ext .js,.jsx,.ts,.tsx",
+    "lint": "eslint ./src --ext .js,.jsx,.ts,.tsx --cache",
     "lint:fix": "yarn run lint --fix"
   },
   "dependencies": {

--- a/packages/react-xnft/package.json
+++ b/packages/react-xnft/package.json
@@ -14,7 +14,7 @@
   "scripts": {
     "build": "tsc",
     "dev": "tsc --watch",
-    "lint": "eslint ./src --ext .js,.jsx,.ts,.tsx",
+    "lint": "eslint ./src --ext .js,.jsx,.ts,.tsx --cache",
     "lint:fix": "yarn run lint --fix"
   },
   "dependencies": {

--- a/packages/recoil/package.json
+++ b/packages/recoil/package.json
@@ -11,7 +11,7 @@
   "scripts": {
     "build": "tsc",
     "dev": "tsc --watch",
-    "lint": "eslint ./src --ext .js,.jsx,.ts,.tsx",
+    "lint": "eslint ./src --ext .js,.jsx,.ts,.tsx --cache",
     "lint:fix": "yarn run lint --fix"
   },
   "dependencies": {

--- a/packages/themes/package.json
+++ b/packages/themes/package.json
@@ -10,7 +10,7 @@
   ],
   "scripts": {
     "build": "tsc",
-    "lint": "eslint ./src --ext .js,.jsx,.ts,.tsx",
+    "lint": "eslint ./src --ext .js,.jsx,.ts,.tsx --cache",
     "lint:fix": "yarn run lint --fix"
   },
   "dependencies": {

--- a/packages/wallet-standard/.eslintignore
+++ b/packages/wallet-standard/.eslintignore
@@ -1,1 +1,2 @@
 lib
+node_modules

--- a/packages/wallet-standard/.eslintrc
+++ b/packages/wallet-standard/.eslintrc
@@ -1,16 +1,8 @@
 {
     "root": true,
-    "extends": [
-        "eslint:recommended",
-        "plugin:@typescript-eslint/recommended",
-        "plugin:prettier/recommended"
-    ],
+    "extends": ["eslint:recommended", "plugin:@typescript-eslint/recommended", "prettier"],
     "parser": "@typescript-eslint/parser",
-    "plugins": [
-        "@typescript-eslint",
-        "prettier",
-        "require-extensions"
-    ],
+    "plugins": ["@typescript-eslint", "require-extensions"],
     "rules": {
         "@typescript-eslint/consistent-type-imports": "error"
     }

--- a/packages/wallet-standard/package.json
+++ b/packages/wallet-standard/package.json
@@ -35,7 +35,6 @@
         "@wallet-standard/features": "^1.0.0",
         "eslint": "8.22.0",
         "eslint-config-prettier": "^8.5.0",
-        "eslint-plugin-prettier": "^4.2.1",
         "eslint-plugin-require-extensions": "^0.1.1",
         "prettier": "^2.7.1",
         "shx": "^0.3.4",

--- a/packages/wallet-standard/package.json
+++ b/packages/wallet-standard/package.json
@@ -16,7 +16,7 @@
         "clean": "shx mkdir -p lib && shx rm -rf lib",
         "tsc": "tsc --build --verbose tsconfig.root.json",
         "package": "shx echo '{ \"type\": \"commonjs\" }' > lib/cjs/package.json",
-        "fmt": "prettier --write '{*,**/*}.{ts,tsx,js,jsx,json}'",
+        "fmt": "prettier --write '{*,**/*}.{ts,tsx,js,jsx,json}' --cache",
         "lint": "prettier --check '{*,**/*}.{ts,tsx,js,jsx,json}' && eslint . --cache",
         "lint:fix": "yarn run fmt && eslint --fix . --cache"
     },

--- a/packages/wallet-standard/package.json
+++ b/packages/wallet-standard/package.json
@@ -17,8 +17,8 @@
         "tsc": "tsc --build --verbose tsconfig.root.json",
         "package": "shx echo '{ \"type\": \"commonjs\" }' > lib/cjs/package.json",
         "fmt": "prettier --write '{*,**/*}.{ts,tsx,js,jsx,json}'",
-        "lint": "prettier --check '{*,**/*}.{ts,tsx,js,jsx,json}' && eslint .",
-        "lint:fix": "yarn run fmt && eslint --fix ."
+        "lint": "prettier --check '{*,**/*}.{ts,tsx,js,jsx,json}' && eslint . --cache",
+        "lint:fix": "yarn run fmt && eslint --fix . --cache"
     },
     "dependencies": {
         "@coral-xyz/provider-core": "*",

--- a/yarn.lock
+++ b/yarn.lock
@@ -11457,13 +11457,6 @@ eslint-plugin-only-warn@^1.0.3:
   resolved "https://registry.yarnpkg.com/eslint-plugin-only-warn/-/eslint-plugin-only-warn-1.0.3.tgz#a75f3a9ded7f03e9808e75ec27f22b644084506e"
   integrity sha512-XQOX/TfLoLw6h8ky51d29uUjXRTQHqBGXPylDEmy5fe/w7LIOnp8MA24b1OSMEn9BQoKow1q3g1kLe5/9uBTvw==
 
-eslint-plugin-prettier@^4.2.1:
-  version "4.2.1"
-  resolved "https://registry.yarnpkg.com/eslint-plugin-prettier/-/eslint-plugin-prettier-4.2.1.tgz#651cbb88b1dab98bfd42f017a12fa6b2d993f94b"
-  integrity sha512-f/0rXLXUt0oFYs8ra4w49wYZBG5GKZpAYsJSm6rnYL5uVDjd+zowwMwVZHnAjf4edNrKpCDYfXDgmRE/Ak7QyQ==
-  dependencies:
-    prettier-linter-helpers "^1.0.0"
-
 eslint-plugin-react-hooks@^4.5.0:
   version "4.6.0"
   resolved "https://registry.yarnpkg.com/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-4.6.0.tgz#4c3e697ad95b77e93f8646aaa1630c1ba607edd3"
@@ -12627,11 +12620,6 @@ fast-deep-equal@^3.1.1, fast-deep-equal@^3.1.3:
   version "3.1.3"
   resolved "https://registry.yarnpkg.com/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz#3a7d56b559d6cbc3eb512325244e619a65c6c525"
   integrity sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==
-
-fast-diff@^1.1.2:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/fast-diff/-/fast-diff-1.2.0.tgz#73ee11982d86caaf7959828d519cfe927fac5f03"
-  integrity sha512-xJuoT5+L99XlZ8twedaRf6Ax2TgQVxvgZOYoPKqZufmJib0tL2tegPBOZb1pVNgIhlqDlA0eO0c3wBvQcmzx4w==
 
 fast-glob@^3.2.11, fast-glob@^3.2.5, fast-glob@^3.2.9:
   version "3.2.11"
@@ -19051,13 +19039,6 @@ prepend-http@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/prepend-http/-/prepend-http-2.0.0.tgz#e92434bfa5ea8c19f41cdfd401d741a3c819d897"
   integrity sha512-ravE6m9Atw9Z/jjttRUZ+clIXogdghyZAuWJ3qEzjT+jI/dL1ifAqhZeC5VHzQp1MSt1+jxKkFNemj/iO7tVUA==
-
-prettier-linter-helpers@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/prettier-linter-helpers/-/prettier-linter-helpers-1.0.0.tgz#d23d41fe1375646de2d0104d3454a3008802cf7b"
-  integrity sha512-GbK2cP9nraSSUF9N2XwUwqfzlAFlMNYYl+ShE/V+H8a9uNl/oUqB1w2EL54Jh0OlyRSd8RfWYJ3coVS4TROP2w==
-  dependencies:
-    fast-diff "^1.1.2"
 
 prettier-plugin-tailwindcss@^0.1.11:
   version "0.1.12"

--- a/yarn.lock
+++ b/yarn.lock
@@ -19064,7 +19064,7 @@ prettier-plugin-tailwindcss@^0.1.11:
   resolved "https://registry.yarnpkg.com/prettier-plugin-tailwindcss/-/prettier-plugin-tailwindcss-0.1.12.tgz#d002a0e25d76a06fdccb6f3c6c52dd9f85e3ccd8"
   integrity sha512-pEZ6tppwknCeq3ObR9g8t61AhWtVRRR3I0EQNeiRrrJ3D42FJGeUDxiFc/LJRYEeAx5JOxagsF0MICwuWOJa+w==
 
-prettier@2.7.1, prettier@^2.6.2, prettier@^2.7.1:
+prettier@2.7.1, prettier@^2.7.1:
   version "2.7.1"
   resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.7.1.tgz#e235806850d057f97bb08368a4f7d899f7760c64"
   integrity sha512-ujppO+MkdPqoVINuDFDRLClm7D78qbDt0/NR+wp5FqEZOoTNAjPHWj17QRhu7geIHJfcNhRk1XVQmF8Bp3ye+g==


### PR DESCRIPTION
eslint was very slow on save. for vscode folks, slow is the norm. for vim/emacs folks, slow is not the norm. this isn't a silver bullet, but it's an improvement

## the process 
running `TIMING=1 yarn lint` resulted in discovering that `prettier/prettier` takes up a whopping second on every save (or every time eslint runs, so all the time).

`eslint-plugin-prettier` will run prettier on the underlying code first, causing the slow-down. By moving towards `eslint-config-prettier` we're able to prevent that from happening and only check prettier styles.

## the result

BEFORE:

```
@coral-xyz/wallet-standard:lint: Rule                                            | Time (ms) | Relative
@coral-xyz/wallet-standard:lint: :-----------------------------------------------|----------:|--------:
@coral-xyz/wallet-standard:lint: prettier/prettier                               |  1098.920 |    97.9%
@coral-xyz/wallet-standard:lint: prefer-spread                                   |     4.016 |     0.4%
@coral-xyz/wallet-standard:lint: @typescript-eslint/no-unused-vars               |     3.514 |     0.3%
@coral-xyz/wallet-standard:lint: @typescript-eslint/no-empty-function            |     1.616 |     0.1%
@coral-xyz/wallet-standard:lint: no-misleading-character-class                   |     1.085 |     0.1%
@coral-xyz/wallet-standard:lint: no-control-regex                                |     0.908 |     0.1%
@coral-xyz/wallet-standard:lint: @typescript-eslint/consistent-type-imports      |     0.875 |     0.1%
@coral-xyz/wallet-standard:lint: no-debugger                                     |     0.868 |     0.1%
@coral-xyz/wallet-standard:lint: @typescript-eslint/no-non-null-assertion        |     0.602 |     0.1%
@coral-xyz/wallet-standard:lint: @typescript-eslint/adjacent-overload-signatures |     0.588 |     0.1%
```

AFTER:

```
All matched files use Prettier code style!
Rule                                       | Time (ms) | Relative
:------------------------------------------|----------:|--------:
@typescript-eslint/no-inferrable-types     |     4.857 |    24.8%
@typescript-eslint/no-unused-vars          |     3.092 |    15.8%
@typescript-eslint/no-empty-function       |     1.213 |     6.2%
no-misleading-character-class              |     0.989 |     5.0%
no-control-regex                           |     0.771 |     3.9%
@typescript-eslint/consistent-type-imports |     0.619 |     3.2%
no-useless-backreference                   |     0.546 |     2.8%
@typescript-eslint/no-non-null-assertion   |     0.526 |     2.7%
@typescript-eslint/no-loss-of-precision    |     0.453 |     2.3%
@typescript-eslint/triple-slash-reference  |     0.416 |     2.1%
```

## summary 
- adds `--cache` to `eslint`
- adds `--cache` to `prettier` (introduced in 2.7)
- replaces `eslint-plugin-prettier` with `eslint-config-prettier` to speed up eslint
- fixes `common-public` eslint parsing error (noticed this while running the command) by adding `parserOptions`
- adds `.eslintcache` to `.gitignore`

## possible next steps
- run `eslint --fix` on everything and reduce the amount of warnings that show up. duplicate imports/import-order is the next time-consuming process and that seems like an easy win
- adds paths / references to tsconfig.json and fix the next elephant in the room :eyes: