### PR TITLE
remove semicolons from postinstall commands

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "clean": "npx rimraf {.,backend,examples,packages,node_modules}/**/{.parcel-cache,.turbo,build,dist,node_modules,yarn-error.log} packages/app-extension/dev",
     "start:mobile": "env-cmd --silent turbo run start --filter=@coral-xyz/common... --filter=@coral-xyz/recoil... --filter=@coral-xyz/background... --filter=!examples",
     "build:mobile": "env-cmd --silent turbo run build --filter=@coral-xyz/common... --filter=@coral-xyz/recoil... --filter=@coral-xyz/background... --filter=!examples",
-    "postinstall": "yarn-deduplicate --scopes @babel @mui @typescript-eslint @types; patch-package && cd packages/app-mobile && patch-package"
+    "postinstall": "yarn-deduplicate --scopes @babel @mui @typescript-eslint @types && patch-package && cd packages/app-mobile && patch-package"
   },
   "devDependencies": {
     "@typescript-eslint/eslint-plugin": "^5.31.0",

--- a/packages/app-mobile/package.json
+++ b/packages/app-mobile/package.json
@@ -11,7 +11,7 @@
     "eject": "expo eject",
     "lint": "eslint ./src --ext .js,.jsx,.ts,.tsx --cache",
     "lint:fix": "yarn run lint --fix",
-    "postinstall": "npx patch-package; cd ../../ && patch-package"
+    "postinstall": "npx patch-package && cd ../../ && patch-package"
   },
   "dependencies": {
     "@cardinal/payment-manager": "^1.7.9",


### PR DESCRIPTION
Removes the semicolons for windows compatability. `&&` has different semantics on windows but it should be fine.

Closes https://github.com/coral-xyz/backpack/issues/1539