### PR TITLE
exclude app-mobile from linting

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,8 +12,8 @@
     "web"
   ],
   "scripts": {
-    "lint": "turbo run lint",
-    "lint:fix": "turbo run lint:fix",
+    "lint": "turbo run lint --filter=!@coral-xyz/app-mobile",
+    "lint:fix": "turbo run lint:fix --filter=!@coral-xyz/app-mobile",
     "prepare": "husky install",
     "start": "env-cmd --silent turbo run start --concurrency=100% --filter=./packages/*",
     "start:fresh": "yarn install && yarn clean && yarn install && yarn start",


### PR DESCRIPTION
Runs out of memory while running for some reason, will exclude for now and make an issue.