### PR TITLE
check derived pubkeys when signing JWT

### DIFF
--- a/packages/background/src/backend/core.ts
+++ b/packages/background/src/backend/core.ts
@@ -51,7 +51,7 @@ import {
   BACKPACK_FEATURE_USERNAMES,
   BACKPACK_FEATURE_JWT,
 } from "@coral-xyz/common";
-import type {
+import {
   KeyringInit,
   DerivationPath,
   EventEmitter,

--- a/packages/background/src/frontend/server-ui.ts
+++ b/packages/background/src/frontend/server-ui.ts
@@ -9,8 +9,6 @@ import {
   EventEmitter,
   Blockchain,
   XnftPreference,
-  BACKPACK_FEATURE_USERNAMES,
-  BACKPACK_FEATURE_JWT,
 } from "@coral-xyz/common";
 import type { Commitment } from "@solana/web3.js";
 import {
@@ -345,7 +343,7 @@ async function handle<T = any>(
     case UI_RPC_METHOD_ETHEREUM_SIGN_MESSAGE:
       return await handleEthereumSignMessage(ctx, params[0], params[1]);
     case UI_RPC_METHOD_TRY_TO_SIGN_MESSAGE:
-      return await tryToSignMessage(ctx, params[0], params[1]);
+      return await tryToSignMessage(ctx, params[0], params[1], params[2]);
     case UI_RPC_METHOD_SIGN_MESSAGE_FOR_WALLET:
       return await handleSignMessageForWallet(
         ctx,


### PR DESCRIPTION
problem:

a user might have removed the pubkey we store/associate with their username when they created their account

solution:

when locally signing a message to acquire a JWT, this checks against 20 derived pubkeys under each derivation path

the code could be improved a bit, including only checking the derived pubkeys if there is no match in the active wallet addresses, but given that the function is only called once and that #1599 is in the works, I figured it might be good enough for now