### PR TITLE
ensure jwt cookie remains after ending session

### DIFF
--- a/backend/workers/auth/src/jwt.ts
+++ b/backend/workers/auth/src/jwt.ts
@@ -20,12 +20,12 @@ export const clearCookie = (c: Context<any>, cookieName: string) => {
 };
 
 export const jwt = async (
-  c: Context,
+  c: Context<any>,
   user: { id: unknown; username: unknown }
 ) => {
   const secret = await importPKCS8(c.env.AUTH_JWT_PRIVATE_KEY, alg);
 
-  const jwt = await new SignJWT({
+  const _jwt = await new SignJWT({
     sub: String(user.id),
     username: user.username,
   })
@@ -35,12 +35,14 @@ export const jwt = async (
     .setIssuedAt()
     .sign(secret);
 
-  c.cookie("jwt", jwt, {
+  c.cookie("jwt", _jwt, {
     secure: true,
     httpOnly: true,
     sameSite: "Strict",
     domain: cookieDomain(c.req.url),
+    path: "/",
+    maxAge: 60 * 60 * 24 * 365, // approx 1 year
   });
 
-  return c.json({ jwt });
+  return c.json({ msg: "ok" });
 };


### PR DESCRIPTION
if you're already testing the jwt cookie you probably want to quit and reopen your browser before testing these changes, as that will clear old cookies

- makes `jwt` cookie persist if browser is closed and reopened (it only lasted for the session before)
- fixes hono complaint about `DELETE /authenticate` not completing the response correctly
- specifies `path="/"` on the jwt cookie
- just returns an "ok" message and not the jwt in the response body

cc: @tomlinton 