### PR TITLE
Add nohoist to examples/**

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
       "packages/blockchains/*",
       "web"
     ],
-    "nohoist": ["examples/**"]
+    "nohoist": ["examples/**", "packages/app-mobile"]
   },
   "scripts": {
     "lint": "turbo run lint --filter=!@coral-xyz/app-mobile",

--- a/package.json
+++ b/package.json
@@ -1,16 +1,19 @@
 {
   "name": "backpack",
   "private": true,
-  "workspaces": [
-    "backend/workers/*",
-    "backend/native/*",
-    "examples/clients/*",
-    "examples",
-    "examples/xnft/*",
-    "packages/*",
-    "packages/blockchains/*",
-    "web"
-  ],
+  "workspaces": {
+    "packages": [
+      "backend/workers/*",
+      "backend/native/*",
+      "examples/clients/*",
+      "examples",
+      "examples/xnft/*",
+      "packages/*",
+      "packages/blockchains/*",
+      "web"
+    ],
+    "nohoist": ["examples/**]
+  },
   "scripts": {
     "lint": "turbo run lint --filter=!@coral-xyz/app-mobile",
     "lint:fix": "turbo run lint:fix --filter=!@coral-xyz/app-mobile",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
       "packages/blockchains/*",
       "web"
     ],
-    "nohoist": ["examples/**", "packages/app-mobile"]
+    "nohoist": ["examples/**", "packages/app-mobile/**"]
   },
   "scripts": {
     "lint": "turbo run lint --filter=!@coral-xyz/app-mobile",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
       "packages/blockchains/*",
       "web"
     ],
-    "nohoist": ["examples/**]
+    "nohoist": ["examples/**"]
   },
   "scripts": {
     "lint": "turbo run lint --filter=!@coral-xyz/app-mobile",


### PR DESCRIPTION
This PR adds `nohoist` to all `example/` packages:

The goal is to continue to make use of yarns package linking (installing local packages as dependencies) while managing dependencies independently.

- Keeping examples standalone / closer to real life.
- Enabling examples to have iE outdated dependencies without affecting the rest of the workspaces.

Also adding `nohoist` to `app-mobile` since `react-native` dependencies are sensitive and the dependency trees between mobile and the rest of the app have larger differences so hoisting becomes less valuable. 