### PR TITLE
xnft api server more routes

### DIFF
--- a/backend/native/xnft-api-server/src/auth/middleware.ts
+++ b/backend/native/xnft-api-server/src/auth/middleware.ts
@@ -9,3 +9,7 @@ export const xnftMiddleware = (req, res, next) => {
   req.xnftAddress = xnftAddress;
   next();
 };
+
+export const authMiddleware = (req, res, next) => {
+  next();
+};

--- a/backend/native/xnft-api-server/src/db/users.ts
+++ b/backend/native/xnft-api-server/src/db/users.ts
@@ -1,0 +1,73 @@
+import { HASURA_URL, JWT } from "../config";
+
+import { Chain } from "@coral-xyz/zeus";
+
+const chain = Chain(HASURA_URL, {
+  headers: {
+    Authorization: `Bearer ${JWT}`,
+  },
+});
+
+/**
+ * Get a user by their id.
+ */
+export const getUser = async (id: string) => {
+  const response = await chain("query")({
+    auth_users_by_pk: [
+      {
+        id,
+      },
+      {
+        id: true,
+        username: true,
+        public_keys: [{}, { blockchain: true, public_key: true }],
+      },
+    ],
+  });
+  if (!response.auth_users_by_pk) {
+    throw new Error("user not found");
+  }
+  return transformUser(response.auth_users_by_pk);
+};
+
+/**
+ * Utility method to format a user for responses from a raw user object.
+ */
+const transformUser = (user: {
+  id: unknown;
+  username: unknown;
+  public_keys: Array<{ blockchain: string; public_key: string }>;
+}) => {
+  return {
+    id: user.id,
+    username: user.username,
+    // Camelcase public keys for response
+    publicKeys: user.public_keys.map((k) => ({
+      blockchain: k.blockchain,
+      publicKey: k.public_key,
+    })),
+    image: `https://avatars.xnfts.dev/v1/${user.username}`,
+  };
+};
+
+export const getUserIdFromPubkey = async ({ blockchain, publicKey }) => {
+  const response = await chain("query")({
+    auth_users: [
+      {
+        where: {
+          public_keys: {
+            public_key: { _eq: publicKey },
+            blockchain: { _eq: blockchain },
+          },
+        },
+      },
+      {
+        id: true,
+        username: true,
+        public_keys: [{}, { blockchain: true, public_key: true }],
+      },
+    ],
+  });
+
+  return response.auth_users[0] ?? null;
+};

--- a/backend/native/xnft-api-server/src/v1/index.ts
+++ b/backend/native/xnft-api-server/src/v1/index.ts
@@ -1,7 +1,9 @@
 import express from "express";
 const router = express.Router();
 import notificationRouter from "./notifications";
+import userRoutes from "./users";
 
 router.use("/notifications", notificationRouter);
+router.use("/users", userRoutes);
 
 export default router;

--- a/backend/native/xnft-api-server/src/v1/users.ts
+++ b/backend/native/xnft-api-server/src/v1/users.ts
@@ -1,0 +1,26 @@
+import express from "express";
+import { authMiddleware } from "../auth/middleware";
+import { getUserIdFromPubkey } from "../db/users";
+
+const router = express.Router();
+
+router.get("/fromPubkey", authMiddleware, async (req, res) => {
+  // @ts-ignore
+  const publicKey: string = req.query.publicKey;
+  // @ts-ignore
+  const blockchain: string = req.query.blockchain;
+
+  await getUserIdFromPubkey({ blockchain, publicKey })
+    .then((user) => {
+      if (user) {
+        res.status(200).json({ user });
+      } else {
+        res.status(411).json({ msg: "User not found" });
+      }
+    })
+    .catch((e) => {
+      res.status(411).json({ msg: "Failed to fetch user details" });
+    });
+});
+
+export default router;


### PR DESCRIPTION
Adds a new route to the `xnft-api-server` (API server that'll be used to expose things like notifications, fetching user data to xnft developers) for fetching a users details given their pubkey