### PR TITLE
Setup swr-data cache proxy for cf workers

### DIFF
--- a/backend/workers/data/src/index.ts
+++ b/backend/workers/data/src/index.ts
@@ -25,16 +25,16 @@ app.get("/metaplex-nft/:mintAddress/image", async (c) => {
       new Request("https://solana-rpc.xnfts.dev/rpc-proxy", {
         method: "POST",
         body: `{
-				"jsonrpc": "2.0",
-				"id": 1,
-				"method": "getAccountInfo",
-				"params": [
-					"${metadataAccountAddress}",
-					{
-						"encoding": "base64"
-					}
-				]
-			}`,
+          "jsonrpc": "2.0",
+          "id": 1,
+          "method": "getAccountInfo",
+          "params": [
+            "${metadataAccountAddress}",
+            {
+              "encoding": "base64"
+            }
+          ]
+        }`,
       })
     );
     const metadataAccount = await metadataAccountResponse.json();
@@ -69,7 +69,7 @@ app.get("/metaplex-nft/:mintAddress/image", async (c) => {
     );
     return response;
   } catch (e) {
-    console.log("Error", e);
+    console.error(e);
     return c.status(500);
   }
 });

--- a/backend/workers/data/wrangler.toml
+++ b/backend/workers/data/wrangler.toml
@@ -4,5 +4,5 @@ compatibility_date = "2022-12-05"
 node_compat = true
 
 services = [
-  { binding = "rpc", service = "rpc-proxy" }
+  { binding = "rpc", service = "swr-data-cache" }
 ]

--- a/backend/workers/swr-data-cache/src/index.ts
+++ b/backend/workers/swr-data-cache/src/index.ts
@@ -1,21 +1,114 @@
+import type { ExecuteRequest, ShouldCache, ToCacheKey } from "./swr";
 import swr from "./swr";
 
 // eslint-disable-next-line @typescript-eslint/no-empty-interface
-interface Env {}
+interface Env {
+  data: { fetch: (req: Request) => Promise<Response> };
+  rpc: { fetch: (req: Request) => Promise<Response> };
+}
 
-// Proxy function to rewrite hostname
-const proxy = (req: Request): Request => {
-  const url = new URL(req.url);
-  url.host = "data.backpack.workers.dev";
-  return new Request(url.toString(), req);
+const toCacheKey: (
+  c: ExecutionContext,
+  env: Env,
+  body: Promise<any>
+) => ToCacheKey = (c, env, body) => async (req) => {
+  if (req.method === "GET" || req.method === "HEAD") {
+    return new Request(req.url, {
+      method: req.method,
+    });
+  }
+  // Can't cache POST requests, so we're creating a GET cache key.
+  return new Request(
+    req.url + "?" + encodeURIComponent(JSON.stringify(await body)),
+    {
+      method: "GET",
+    }
+  );
 };
+
+const excludeFromCache: string[] = [
+  // "getHealth",
+  // "getBalance",
+  // "getProgramAccounts",
+];
+const shouldCache: (
+  c: ExecutionContext,
+  env: Env,
+  body: Promise<any>
+) => ShouldCache = (c, env, body) => async (req, res) => {
+  // dont cache failed requests
+  if (!res.ok) {
+    return false;
+  }
+  // cache all get requests
+  if (req.method === "GET") {
+    return true;
+  }
+  const [service] = extractService(new URL(req.url));
+  // cache posts to specific rpc methods
+  if (service === "rpc-proxy") {
+    const method = (await body)?.method ?? "";
+
+    if (
+      method &&
+      method.startsWith("get") &&
+      !excludeFromCache.includes(method)
+    ) {
+      return true;
+    }
+    // return cacheRPCmethods.includes((await body)?.method);
+  }
+
+  return false;
+};
+
+const executeRequest: (c: ExecutionContext, env: Env) => ExecuteRequest =
+  (_c, env) => async (req) => {
+    const [service, url] = extractService(new URL(req.url));
+
+    if (service === "data") {
+      return env.data.fetch(new Request(url, req));
+    }
+
+    if (service === "rpc-proxy") {
+      const fetched = await env.rpc.fetch(new Request(url, req));
+      return new Response(fetched.body, {
+        headers: new Headers([
+          [
+            "Cache-Control",
+            `max-age=${1}, s-maxage=${1}, stale-while-revalidate=${5}`,
+          ],
+        ]),
+      });
+    }
+
+    url.host = `${service}.backpack.workers.dev`;
+    return fetch(new Request(url, req));
+  };
 
 export default {
   async fetch(
     request: Request,
-    _env: Env,
+    env: Env,
     ctx: ExecutionContext
   ): Promise<Response> {
-    return swr(proxy(request), ctx);
+    const body =
+      request.method === "POST"
+        ? request.clone().json()
+        : Promise.resolve(null);
+    return swr(
+      request,
+      ctx,
+      executeRequest(ctx, env),
+      shouldCache(ctx, env, body),
+      toCacheKey(ctx, env, body)
+    );
   },
+};
+
+const extractService = (url: URL): [string | undefined, URL] => {
+  const path = url.pathname.slice(1).split("/");
+  const service = path.shift();
+  url.pathname = `/${path.join("/")}`;
+  return [service, url];
 };

--- a/backend/workers/swr-data-cache/src/index.ts
+++ b/backend/workers/swr-data-cache/src/index.ts
@@ -1,7 +1,6 @@
 import type { ExecuteRequest, ShouldCache, ToCacheKey } from "./swr";
 import swr from "./swr";
 
-// eslint-disable-next-line @typescript-eslint/no-empty-interface
 interface Env {
   data: { fetch: (req: Request) => Promise<Response> };
   rpc: { fetch: (req: Request) => Promise<Response> };
@@ -48,7 +47,6 @@ const shouldCache: (
   // cache posts to specific rpc methods
   if (service === "rpc-proxy") {
     const method = (await body)?.method ?? "";
-
     if (
       method &&
       method.startsWith("get") &&
@@ -56,7 +54,6 @@ const shouldCache: (
     ) {
       return true;
     }
-    // return cacheRPCmethods.includes((await body)?.method);
   }
 
   return false;

--- a/backend/workers/swr-data-cache/wrangler.toml
+++ b/backend/workers/swr-data-cache/wrangler.toml
@@ -1,3 +1,9 @@
 name = "swr-data-cache"
 main = "src/index.ts"
 compatibility_date = "2022-12-05"
+
+
+services = [
+  { binding = "rpc", service = "rpc-proxy" },
+  { binding = "data", service = "data" }
+]


### PR DESCRIPTION
swr-data is a proxy cache service:
`https://swr-data.xnfts.dev/[worker]/[path]` will cache `https://[worker].backpack.workers.dev/[path]`

iE: 
-   image service: https://data.xnfts.dev/metaplex-nft/3ewQC8f3o3k7B14eWyFKTWS67axLdm9pY3XkrCBvve9E/image
- cached: https://swr-data.xnfts.dev/data/metaplex-nft/3ewQC8f3o3k7B14eWyFKTWS67axLdm9pY3XkrCBvve9E/image

The proxy looks at the Cache-Control headers of the worker response and cache the results accordingly including adhering to the stale-while-revalidate directive.

With some tweaks (POST requests are usually not cached) this works for our rpc-proxy: https://swr-data.xnfts.dev/rpc-proxy/

The cache is kept really short for the rpc : `max-age=1, s-maxage=1, stale-while-revalidate=5` so this might just work out of the box, but we might also have to add the `?no-cache=true` flag in some time sensitive places to make sure all data updates when it should.

Needs some testing before making it the default rpc 