### PR TITLE
prevent the react native runtime from crashing when chrome.runtime.id is invoked

### DIFF
--- a/packages/common/src/channel/app-ui.ts
+++ b/packages/common/src/channel/app-ui.ts
@@ -31,6 +31,15 @@ export class ChannelAppUi {
   }
 }
 
+// This check is necessary otherwise chrome.runtime.id will explode in React Native
+function isReactNative() {
+  if (typeof window !== "undefined" && typeof window.document !== "undefined") {
+    return false;
+  }
+
+  return true;
+}
+
 export class ChannelAppUiServer {
   constructor(private name: string) {}
 
@@ -41,10 +50,11 @@ export class ChannelAppUiServer {
           return;
         }
 
-        // TODO(peter/armani): chrome.runtime.id doesn't work in react-native since it uses Hermes/JavascriptCore under the hood. We'll need to figure out the equivalent (eventually?)
-        if (chrome && chrome?.runtime?.id) {
-          if (sender.id !== chrome.runtime.id) {
-            return;
+        if (!isReactNative()) {
+          if (chrome && chrome?.runtime?.id) {
+            if (sender.id !== chrome.runtime.id) {
+              return;
+            }
           }
         }
 
@@ -73,10 +83,11 @@ export class ChannelAppUiNotifications {
           return;
         }
 
-        // TODO(peter/armani): chrome.runtime.id doesn't work in react-native since it uses Hermes/JavascriptCore under the hood. We'll need to figure out the equivalent (eventually?)
-        if (chrome && chrome?.runtime?.id) {
-          if (sender.id !== chrome.runtime.id) {
-            return;
+        if (!isReactNative()) {
+          if (chrome && chrome?.runtime?.id) {
+            if (sender.id !== chrome.runtime.id) {
+              return;
+            }
           }
         }
 


### PR DESCRIPTION
just mentioning `chrome` in the react native runtime breaks everything