### PR TITLE
Fixed sendAndConfirm

### DIFF
--- a/packages/app-extension/src/components/Unlocked/ApproveTransactionRequest.tsx
+++ b/packages/app-extension/src/components/Unlocked/ApproveTransactionRequest.tsx
@@ -365,6 +365,7 @@ function SendTransactionRequest({
             options?.commitment
           );
           if (resp?.value.err) {
+            onReject();
             setTxState("failed");
           } else {
             onResolve(signature);

--- a/packages/provider-core/src/common/solana.ts
+++ b/packages/provider-core/src/common/solana.ts
@@ -34,24 +34,15 @@ export async function sendAndConfirm<
   signers?: Signer[],
   options?: ConfirmOptions
 ): Promise<TransactionSignature> {
-  const [signature, { blockhash, lastValidBlockHeight }] = await Promise.all([
-    send(publicKey, requestManager, connection, tx, signers, options, true),
-    connection.getLatestBlockhash(options?.preflightCommitment),
-  ]);
-
-  const resp = await connection.confirmTransaction(
-    {
-      signature,
-      blockhash,
-      lastValidBlockHeight,
-    },
-    options?.commitment
+  const signature = await send(
+    publicKey,
+    requestManager,
+    connection,
+    tx,
+    signers,
+    options,
+    true
   );
-  if (resp?.value.err) {
-    throw new Error(
-      `error confirming transaction: ${resp.value.err.toString()}`
-    );
-  }
   return signature;
 }
 


### PR DESCRIPTION
Closes https://github.com/coral-xyz/backpack/issues/1773
We are now doing the transaction confirmation inside `ApproveTransactionRequest`. 
Dont need to do it twice. The second confirmation is what is causing a delayed resolve on the UI compared to the green checkmark appearing on the drawer