### PR TITLE
add jwt storage for users

### DIFF
--- a/backend/native/backpack-api/src/auth/middleware.ts
+++ b/backend/native/backpack-api/src/auth/middleware.ts
@@ -80,10 +80,9 @@ export const optionallyExtractUserId = (allowQueryString: boolean) => {
       } catch {
         // Pass
       }
-    }
-
-    // Couldn't get JWT from cookie, try query string
-    if (!jwt && req.query.jwt && allowQueryString) {
+    } else if (req.headers["Backpack-JWT"]) {
+      jwt = req.headers["Backpack-JWT"] as string;
+    } else if (req.query.jwt && allowQueryString) {
       jwt = req.query.jwt as string;
     }
 
@@ -91,7 +90,7 @@ export const optionallyExtractUserId = (allowQueryString: boolean) => {
       try {
         const payloadRes = await validateJwt(jwt);
         if (payloadRes.payload.sub) {
-          // Extend cookie
+          // Extend cookie or set it if not set
           setCookie(req, res, payloadRes.payload.sub);
           // Set id on request
           req.id = payloadRes.payload.sub;

--- a/backend/native/backpack-api/src/auth/middleware.ts
+++ b/backend/native/backpack-api/src/auth/middleware.ts
@@ -68,8 +68,12 @@ export const optionallyExtractUserId = (allowQueryString: boolean) => {
 
     let jwt = "";
 
+    // Header takes precedence
+    if (req.headers["backpack-jwt"]) {
+      jwt = req.headers["backpack-jwt"] as string;
+    }
     // Extract JWT from cookie
-    if (cookie) {
+    else if (cookie) {
       try {
         cookie.split(";").forEach((item) => {
           const cookie = item.trim().split("=");
@@ -80,8 +84,6 @@ export const optionallyExtractUserId = (allowQueryString: boolean) => {
       } catch {
         // Pass
       }
-    } else if (req.headers["Backpack-JWT"]) {
-      jwt = req.headers["Backpack-JWT"] as string;
     } else if (req.query.jwt && allowQueryString) {
       jwt = req.query.jwt as string;
     }

--- a/backend/native/backpack-api/src/auth/util.ts
+++ b/backend/native/backpack-api/src/auth/util.ts
@@ -43,4 +43,6 @@ export const setCookie = async (
     path: "/",
     maxAge: 60 * 60 * 24 * 365, // approx 1 year
   });
+
+  return jwt;
 };

--- a/backend/native/backpack-api/src/routes/v1/authenticate.ts
+++ b/backend/native/backpack-api/src/routes/v1/authenticate.ts
@@ -58,9 +58,9 @@ router.post("/", async (req, res) => {
     return res.status(403).json({ msg: "invalid user id" });
   }
 
-  await setCookie(req, res, user.id as string);
+  const jwt = await setCookie(req, res, user.id as string);
 
-  return res.json(user);
+  return res.json({ ...user, jwt });
 });
 
 export default router;

--- a/backend/native/backpack-api/src/routes/v1/users.ts
+++ b/backend/native/backpack-api/src/routes/v1/users.ts
@@ -108,8 +108,9 @@ router.post("/", async (req, res) => {
     }
   }
 
+  let jwt: string;
   if (user) {
-    await setCookie(req, res, user.id as string);
+    jwt = await setCookie(req, res, user.id as string);
   } else {
     return res.status(500).json({ msg: "Error creating user account" });
   }
@@ -134,7 +135,7 @@ router.post("/", async (req, res) => {
     }
   }
 
-  return res.json({ id: user.id, msg: "ok" });
+  return res.json({ id: user.id, msg: "ok", jwt });
 });
 
 /**

--- a/packages/app-extension/src/hooks/useAuthentication.tsx
+++ b/packages/app-extension/src/hooks/useAuthentication.tsx
@@ -3,6 +3,7 @@ import {
   BACKEND_API_URL,
   UI_RPC_METHOD_KEYRING_STORE_LOCK,
   UI_RPC_METHOD_KEYRING_STORE_READ_ALL_PUBKEYS,
+  UI_RPC_METHOD_USER_JWT_UPDATE,
 } from "@coral-xyz/common";
 import { useBackgroundClient, useUser } from "@coral-xyz/recoil";
 import { ethers } from "ethers";
@@ -11,7 +12,6 @@ const { base58 } = ethers.utils;
 
 export const useAuthentication = () => {
   const background = useBackgroundClient();
-  const user = useUser();
 
   /**
    * Login the user.
@@ -55,7 +55,10 @@ export const useAuthentication = () => {
   /**
    * Query the server and see if the user has a valid JWT..
    */
-  const checkAuthentication = async (): Promise<
+  const checkAuthentication = async (
+    username: string,
+    jwt: string
+  ): Promise<
     | {
         id: string;
         publicKeys: Array<{ blockchain: Blockchain; publicKey: string }>;
@@ -64,15 +67,13 @@ export const useAuthentication = () => {
     | undefined
   > => {
     try {
-      const response = await fetch(
-        `${BACKEND_API_URL}/users/${user.username}`,
-        {
-          method: "GET",
-          headers: {
-            "Content-Type": "application/json",
-          },
-        }
-      );
+      const response = await fetch(`${BACKEND_API_URL}/users/${username}`, {
+        method: "GET",
+        headers: {
+          "Content-Type": "application/json",
+          ...(jwt ? { "Backpack-JWT": jwt } : {}),
+        },
+      });
       if (response.status === 404) {
         // User does not exist on server, how to handle?
         throw new Error("user does not exist");

--- a/packages/app-extension/src/hooks/useAuthentication.tsx
+++ b/packages/app-extension/src/hooks/useAuthentication.tsx
@@ -67,12 +67,13 @@ export const useAuthentication = () => {
     | undefined
   > => {
     try {
+      const headers = {
+        "Content-Type": "application/json",
+        ...(jwt ? { "Backpack-JWT": jwt } : {}),
+      };
       const response = await fetch(`${BACKEND_API_URL}/users/${username}`, {
         method: "GET",
-        headers: {
-          "Content-Type": "application/json",
-          ...(jwt ? { "Backpack-JWT": jwt } : {}),
-        },
+        headers,
       });
       if (response.status === 404) {
         // User does not exist on server, how to handle?

--- a/packages/background/src/backend/core.ts
+++ b/packages/background/src/backend/core.ts
@@ -605,7 +605,7 @@ export class Backend {
 
   async activeUserUpdate(uuid: string): Promise<string> {
     // Change active user account.
-    const { username } = await this.keyringStore.activeUserUpdate(uuid);
+    const { username, jwt } = await this.keyringStore.activeUserUpdate(uuid);
 
     // Get data to push back to the UI.
     const walletData = await this.keyringStoreReadAllPubkeyData();
@@ -621,6 +621,7 @@ export class Backend {
         user: {
           uuid,
           username,
+          jwt,
         },
         walletData,
         preferences,

--- a/packages/background/src/backend/core.ts
+++ b/packages/background/src/backend/core.ts
@@ -71,6 +71,7 @@ import * as store from "./store";
 import {
   DEFAULT_DARK_MODE,
   getWalletDataForUser,
+  setUser,
   setWalletDataForUser,
 } from "./store";
 
@@ -549,9 +550,10 @@ export class Backend {
     username: string,
     password: string,
     keyringInit: KeyringInit,
-    uuid: string
+    uuid: string,
+    jwt: string
   ): Promise<string> {
-    await this.keyringStore.init(username, password, keyringInit, uuid);
+    await this.keyringStore.init(username, password, keyringInit, uuid, jwt);
 
     // Notify all listeners.
     this.events.emit(BACKEND_EVENT, {
@@ -571,9 +573,15 @@ export class Backend {
   async usernameAccountCreate(
     username: string,
     keyringInit: KeyringInit,
-    uuid: string
+    uuid: string,
+    jwt: string
   ): Promise<string> {
-    await this.keyringStore.usernameKeyringCreate(username, keyringInit, uuid);
+    await this.keyringStore.usernameKeyringCreate(
+      username,
+      keyringInit,
+      uuid,
+      jwt
+    );
     const walletData = await this.keyringStoreReadAllPubkeyData();
     const preferences = await this.preferencesRead(uuid);
     const xnftPreferences = await this.getXnftPreferences();
@@ -584,6 +592,7 @@ export class Backend {
         user: {
           username,
           uuid,
+          jwt,
         },
         walletData,
         preferences,
@@ -841,8 +850,13 @@ export class Backend {
       const user = await store.getActiveUser();
       return user;
     } catch (err) {
-      return { username: "", uuid: "" };
+      return { username: "", uuid: "", jwt: "" };
     }
+  }
+
+  async userJwtUpdate(uuid: string, jwt: string) {
+    await setUser(uuid, { jwt });
+    return SUCCESS_RESPONSE;
   }
 
   async allUsersRead(): Promise<Array<User>> {

--- a/packages/background/src/backend/keyring/index.ts
+++ b/packages/background/src/backend/keyring/index.ts
@@ -72,12 +72,13 @@ export class KeyringStore {
     username: string,
     password: string,
     keyringInit: KeyringInit,
-    uuid: string
+    uuid: string,
+    jwt: string
   ) {
     this.password = password;
 
     // Setup the user.
-    await this._usernameKeyringCreate(username, keyringInit, uuid);
+    await this._usernameKeyringCreate(username, keyringInit, uuid, jwt);
 
     // Persist the encrypted data to then store.
     await this.persist(true);
@@ -89,17 +90,24 @@ export class KeyringStore {
   public async usernameKeyringCreate(
     username: string,
     keyringInit: KeyringInit,
-    uuid: string
+    uuid: string,
+    jwt: string
   ) {
     return await this.withUnlockAndPersist(async () => {
-      return await this._usernameKeyringCreate(username, keyringInit, uuid);
+      return await this._usernameKeyringCreate(
+        username,
+        keyringInit,
+        uuid,
+        jwt
+      );
     });
   }
 
   public async _usernameKeyringCreate(
     username: string,
     keyringInit: KeyringInit,
-    uuid: string
+    uuid: string,
+    jwt: string
   ) {
     this.users.set(uuid, await UserKeyring.init(username, keyringInit, uuid));
     this.activeUserUuid = uuid;
@@ -113,6 +121,7 @@ export class KeyringStore {
     await store.setActiveUser({
       username,
       uuid,
+      jwt,
     });
   }
 
@@ -239,10 +248,7 @@ export class KeyringStore {
     const userData = await store.getUserData();
     const user = userData.users.filter((u) => u.uuid === uuid)[0];
     this.activeUserUuid = uuid;
-    await store.setActiveUser({
-      username: user.username,
-      uuid,
-    });
+    await store.setActiveUser(user);
     return user;
   }
 

--- a/packages/background/src/backend/store/usernames.ts
+++ b/packages/background/src/backend/store/usernames.ts
@@ -10,6 +10,7 @@ type UserData = {
 export type User = {
   username: string;
   uuid: string;
+  jwt: string;
 };
 
 export async function getActiveUser(): Promise<User> {
@@ -40,4 +41,28 @@ export async function getUserData(): Promise<UserData> {
     throw new Error("user data not found");
   }
   return data;
+}
+
+/**
+ * Used to update users in storage. This is primarily used for updating the
+ * cached JWT value, but may be used if usernames are made immutable in the
+ * future.
+ */
+export async function setUser(
+  uuid: string,
+  updateData: Partial<User>
+): Promise<User> {
+  const data = await LocalStorageDb.get(STORE_KEY_USER_DATA);
+  const user = data.users.find((u: User) => u.uuid === uuid);
+  const updatedUser = {
+    ...user,
+    ...updateData,
+  };
+  await LocalStorageDb.set(STORE_KEY_USER_DATA, {
+    activeUser: data.activeUser.uuid === uuid ? updatedUser : data.activeUser,
+    users: data.users
+      .filter((u: User) => u.uuid !== uuid)
+      .concat([updatedUser]),
+  });
+  return updatedUser;
 }

--- a/packages/background/src/frontend/server-ui.ts
+++ b/packages/background/src/frontend/server-ui.ts
@@ -91,6 +91,7 @@ import {
   UI_RPC_METHOD_SOLANA_SIGN_MESSAGE,
   UI_RPC_METHOD_SOLANA_SIGN_TRANSACTION,
   UI_RPC_METHOD_SOLANA_SIMULATE,
+  UI_RPC_METHOD_USER_JWT_UPDATE,
   UI_RPC_METHOD_USER_READ,
   UI_RPC_METHOD_USERNAME_ACCOUNT_CREATE,
   withContextPort,
@@ -281,6 +282,9 @@ async function handle<T = any>(
     //
     case UI_RPC_METHOD_USER_READ:
       return await handleUserRead(ctx);
+    case UI_RPC_METHOD_USER_JWT_UPDATE:
+      // @ts-ignore
+      return await handleUserJwtUpdate(ctx, ...params);
     case UI_RPC_METHOD_ALL_USERS_READ:
       return await handleAllUsersRead(ctx);
     case UI_RPC_METHOD_USERNAME_ACCOUNT_CREATE:
@@ -492,6 +496,14 @@ async function handleUserRead(
   ctx: Context<Backend>
 ): Promise<RpcResponse<number>> {
   const resp = await ctx.backend.userRead();
+  return [resp];
+}
+
+async function handleUserJwtUpdate(
+  ctx: Context<Backend>,
+  ...args: Parameters<Backend["userJwtUpdate"]>
+): Promise<RpcResponse<string>> {
+  const resp = ctx.backend.userJwtUpdate(...args);
   return [resp];
 }
 

--- a/packages/common/src/constants.ts
+++ b/packages/common/src/constants.ts
@@ -193,6 +193,7 @@ export const UI_RPC_METHOD_USERNAME_ACCOUNT_CREATE =
   "ui-rpc-method-username-account-create";
 export const UI_RPC_METHOD_ACTIVE_USER_UPDATE =
   "ui-rpc-method-active-user-update";
+export const UI_RPC_METHOD_USER_JWT_UPDATE = "ui-rpc-method-user-jwt-update";
 export const UI_RPC_METHOD_PREFERENCES_READ = "ui-rpc-method-references-read";
 // Solana
 export const UI_RPC_METHOD_SOLANA_COMMITMENT_READ =

--- a/packages/recoil/src/atoms/preferences/index.tsx
+++ b/packages/recoil/src/atoms/preferences/index.tsx
@@ -70,7 +70,7 @@ export const approvedOrigins = selector<Array<string>>({
 });
 
 // This is the *active* username.
-export const user = atom<{ username: string; uuid: string }>({
+export const user = atom<{ username: string; uuid: string; jwt: string }>({
   key: "user",
   default: selector({
     key: "userDefault",


### PR DESCRIPTION
- Save the JWT in the store for each user.
- In the call to check if a user is authenticated in the `WithAuth` wrapper the backend will check the JWT in the header for authentication first, and if it's valid the cookie will be set (overwriting a possibly incorrect cookie if the cookie that exists has a JWT that is different from the JWT in the header).

Closes https://github.com/coral-xyz/backpack/issues/1735