### PR TITLE
use a single source of truth for active user uuid

### DIFF
--- a/packages/background/src/backend/core.ts
+++ b/packages/background/src/backend/core.ts
@@ -636,7 +636,7 @@ export class Backend {
       throw new Error("invariant violation: username not found");
     }
 
-    await this.keyringStore.tryUnlock(password);
+    await this.keyringStore.tryUnlock(password, uuid);
 
     const blockchainActiveWallets = await this.blockchainActiveWallets();
 

--- a/packages/background/src/backend/store/keyring.ts
+++ b/packages/background/src/backend/store/keyring.ts
@@ -12,7 +12,6 @@ const KEY_KEYRING_STORE = "keyring-store";
  * before reading to/from local storage.
  */
 export type KeyringStoreJson = {
-  activeUserUuid: string;
   users: {
     [uuid: string]: UserKeyringJson;
   };


### PR DESCRIPTION
Any issue with passing the uuid in instead of grabbing it from the stored keyring JSON @armaniferrante? That way there is only a single source of truth for the active uuid.

I ran into a problem with the store and the json active user uuids getting out of sync (admittedly it was some dev foolery with the service worker dying so probably not a real bug but it seems like we could avoid this class of bugs altogether).