### PR TITLE
Fixed replies for user sending out message

### DIFF
--- a/packages/chat-sdk/src/components/ChatContext.tsx
+++ b/packages/chat-sdk/src/components/ChatContext.tsx
@@ -9,6 +9,7 @@ type ChatContext = {
     parent_client_generated_uuid: string | null;
     text: string;
     parent_username: string;
+    parent_message_author_uuid: string;
   };
   chatManager: ChatManager | null;
   roomId: string;
@@ -36,6 +37,7 @@ export function ChatProvider(props: {
     parent_client_generated_uuid: string | null;
     text: string;
     parent_username: string;
+    parent_message_author_uuid: string;
   };
   chatManager: ChatManager | null;
   roomId: string;

--- a/packages/chat-sdk/src/components/ChatRoom.tsx
+++ b/packages/chat-sdk/src/components/ChatRoom.tsx
@@ -45,6 +45,7 @@ export const ChatRoom = ({
   const [activeReply, setActiveReply] = useState({
     parent_username: "",
     parent_client_generated_uuid: null,
+    parent_message_author_uuid: "",
     text: "",
   });
 

--- a/packages/chat-sdk/src/components/Message.tsx
+++ b/packages/chat-sdk/src/components/Message.tsx
@@ -207,6 +207,7 @@ export function ChatMessages() {
                 messageKind={chat.message_kind}
                 image={chat.image}
                 username={chat.username}
+                userId={chat.uuid}
                 client_generated_uuid={chat.client_generated_uuid}
                 parent_message_text={chat.parent_message_text}
                 parent_message_author_username={
@@ -223,6 +224,7 @@ export function ChatMessages() {
             key={chat.id}
             message={chat.message}
             received={chat.received}
+            userId={chat.uuid}
             messageKind={chat.message_kind}
             image={chat.image}
             username={chat.username}
@@ -282,6 +284,7 @@ function MessageLeft(props) {
                 parent_client_generated_uuid: props.client_generated_uuid,
                 text: message,
                 parent_username: `@${props.username}`,
+                parent_message_author_uuid: props.userId,
               });
             }}
           >
@@ -329,6 +332,7 @@ function MessageRight(props) {
                 setActiveReply({
                   parent_client_generated_uuid: props.client_generated_uuid,
                   text: message,
+                  parent_message_author_uuid: props.userId,
                   parent_username: "Yourself",
                 });
               }}

--- a/packages/chat-sdk/src/components/SendMessage.tsx
+++ b/packages/chat-sdk/src/components/SendMessage.tsx
@@ -124,6 +124,11 @@ export const SendMessage = ({ messageRef }: any) => {
           message_kind: messageKind,
           username,
           image: `https://avatars.xnfts.dev/v1/${username}`,
+          parent_client_generated_uuid:
+            activeReply.parent_client_generated_uuid,
+          parent_message_author_uuid: activeReply.parent_message_author_uuid,
+          parent_message_text: activeReply.text,
+          parent_message_author_username: activeReply.parent_username,
         },
       ]);
       setMessageContent("");


### PR DESCRIPTION
When a user sends a message with `reply` attached, it doesn't show up for them unless they refresh. 
PR fixes that