### PR TITLE
update rpc proxy headers

### DIFF
--- a/backend/workers/rpc-proxy/src/index.ts
+++ b/backend/workers/rpc-proxy/src/index.ts
@@ -5,25 +5,53 @@ export interface Env {
 
 export default {
   async fetch(request: Request, env: Env): Promise<Response> {
-    const corsHeaders = {
-      "Access-Control-Allow-Origin": "*",
-      "Access-Control-Allow-Methods": "GET, OPTIONS",
-      "Access-Control-Allow-Headers": "*",
-    };
-    if (request.method === "OPTIONS") {
-      return new Response("ok", {
-        headers: corsHeaders,
-      });
-    }
-    if (request.method === "POST") {
-      return await fetch(
-        env.RPC_URL || "https://api.mainnet-beta.solana.com",
-        request
-      );
-    } else {
-      return new Response("Only POST requests are allowed", {
-        status: 405,
-      });
+    switch (request.method) {
+      case "OPTIONS":
+        return new Response("ok", {
+          headers: {
+            "Access-Control-Allow-Headers": "*",
+            "Access-Control-Allow-Methods": "POST, OPTIONS",
+            "Access-Control-Allow-Origin": "*",
+          },
+        });
+      case "POST":
+        const { href, hostname } = new URL(
+          env.RPC_URL || "https://api.mainnet-beta.solana.com"
+        );
+        const rpcResponse = await fetch(
+          href,
+          (() => {
+            const _request = new Request(href, request);
+            // Only forward necessary headers from the client request
+            sanitizeHeaders(_request.headers);
+            return _request;
+          })()
+        );
+        const response = new Response(rpcResponse.body, rpcResponse);
+        // Add the RPC domain to the response headers for debugging purposes
+        response.headers.append("x-backpack-rpc", hostname);
+        return response;
+      default:
+        return new Response("Only POST or OPTIONS requests are allowed", {
+          status: 405,
+        });
     }
   },
+};
+
+const sanitizeHeaders = (headers: Headers) => {
+  const allowedHeaders = [
+    "accept-encoding",
+    "accept",
+    "cache-control",
+    "connection",
+    "content-length",
+    "content-type",
+    "solana-client",
+  ];
+  headers.forEach((_value, key) => {
+    if (!allowedHeaders.includes(key.toLowerCase())) {
+      headers.delete(key);
+    }
+  });
 };


### PR DESCRIPTION
sanitizes rpc request headers and includes the rpc hostname in the response headers

# todo

- [x] find what caused `500` errors in prod