### PR TITLE
restart autolock countdown after receiving UI_RPC_* messages

### DIFF
--- a/packages/background/src/backend/core.ts
+++ b/packages/background/src/backend/core.ts
@@ -733,6 +733,10 @@ export class Backend {
     return SUCCESS_RESPONSE;
   }
 
+  keyringStoreAutoLockCountdownRestart() {
+    this.keyringStore.autoLockCountdownRestart();
+  }
+
   keyringStoreLock() {
     this.keyringStore.lock();
     this.events.emit(BACKEND_EVENT, {

--- a/packages/background/src/frontend/server-ui.ts
+++ b/packages/background/src/frontend/server-ui.ts
@@ -134,6 +134,9 @@ async function handle<T = any>(
 ): Promise<RpcResponse<T>> {
   logger.debug(`handle rpc ${msg.method}`, msg);
 
+  // The user did something so keep the keyring store unlocked
+  ctx.backend.keyringStoreAutoLockCountdownRestart();
+
   const { method, params } = msg;
   switch (method) {
     //


### PR DESCRIPTION
fixes #1393 based on @tomlinton (& @armaniferrante's) [suggestion](https://github.com/coral-xyz/backpack/pull/1478#discussion_r1021011451)

# todo

- [ ] disable autolock if an xnft is open
- [ ] grok `lastUsedTs` to check if it can be removed or ignored
- [ ] verify that only UI_RPC methods are included and polling updates are excluded
- [ ] verify this works ok with multiple user profiles, will each username have its own timeout setting?
- [ ] more testing

