### PR TITLE
use a public key lookup to disable imports for wallets used on other accounts

### DIFF
--- a/packages/app-extension/src/components/common/Account/ImportAccounts.tsx
+++ b/packages/app-extension/src/components/common/Account/ImportAccounts.tsx
@@ -25,6 +25,7 @@ import * as anchor from "@project-serum/anchor";
 import { Connection as SolanaConnection, PublicKey } from "@solana/web3.js";
 import { BigNumber, ethers } from "ethers";
 
+import { useConflictQuery } from "../../../hooks/useConflictQuery";
 import {
   Checkbox,
   Header,
@@ -72,16 +73,22 @@ export function ImportAccounts({
   allowMultiple?: boolean;
 }) {
   const background = useBackgroundClient();
+  const checkPublicKeyConflicts = useConflictQuery();
   const theme = useCustomTheme();
   const [accounts, setAccounts] = useState<Array<Account>>([]);
   const [selectedAccounts, setSelectedAccounts] = useState<SelectedAccount[]>(
     []
   );
   const [ledgerLocked, setLedgerLocked] = useState(false);
+  // Public keys that have already been imported on this account
   const [importedPubkeys, setImportedPubkeys] = useState<string[]>([]);
+  // Public keys that are in use on other Backpack accounts
+  const [conflictingPubkeys, setConflictingPubkeys] = useState<string[]>([]);
   const [derivationPath, setDerivationPath] = useState<DerivationPath>(
     DerivationPath.Default
   );
+
+  const disabledPubkeys = [...importedPubkeys, ...conflictingPubkeys];
 
   useEffect(() => {
     (async () => {
@@ -101,6 +108,26 @@ export function ImportAccounts({
       }
     })();
   }, [background, blockchain]);
+
+  //
+  // Query the server for a list of public keys that are already in use
+  //
+  useEffect(() => {
+    (async () => {
+      if (accounts.length === 0) return;
+      try {
+        const response = await checkPublicKeyConflicts(
+          accounts.map((a) => ({
+            blockchain,
+            publicKey: a.publicKey,
+          }))
+        );
+        setConflictingPubkeys(response.map((r: any) => r.public_key));
+      } catch {
+        // If the query failed assume all are valid
+      }
+    })();
+  }, [accounts, blockchain]);
 
   //
   // Load a list of accounts and their associated balances
@@ -382,7 +409,7 @@ export function ImportAccounts({
                       paddingBottom: "5px",
                     }}
                     disableRipple
-                    disabled={importedPubkeys.includes(publicKey.toString())}
+                    disabled={disabledPubkeys.includes(publicKey.toString())}
                   >
                     <Box style={{ display: "flex", width: "100%" }}>
                       <div
@@ -399,7 +426,7 @@ export function ImportAccounts({
                             importedPubkeys.includes(publicKey.toString())
                           }
                           tabIndex={-1}
-                          disabled={importedPubkeys.includes(
+                          disabled={disabledPubkeys.includes(
                             publicKey.toString()
                           )}
                           disableRipple

--- a/packages/app-extension/src/hooks/useConflictQuery.tsx
+++ b/packages/app-extension/src/hooks/useConflictQuery.tsx
@@ -1,0 +1,19 @@
+import type { Blockchain } from "@coral-xyz/common";
+import { BACKEND_API_URL } from "@coral-xyz/common";
+
+export const useConflictQuery = () => {
+  const checkConflicts = async (
+    blockchainPublicKeys: Array<{ blockchain: Blockchain; publicKey: string }>
+  ) => {
+    const response = await fetch(`${BACKEND_API_URL}/publicKeys`, {
+      method: "POST",
+      body: JSON.stringify(blockchainPublicKeys),
+      headers: {
+        "Content-Type": "application/json",
+      },
+    });
+    return await response.json();
+  };
+
+  return checkConflicts;
+};


### PR DESCRIPTION
Adds a lookup query to the import accounts component to disable imports for wallets that are already used on other accounts.

Closes https://github.com/coral-xyz/backpack/issues/1824

Closes https://github.com/coral-xyz/backpack/issues/1823