### PR TITLE
add public key to server on enable blockchain

### DIFF
--- a/packages/app-extension/src/components/Unlocked/Settings/Preferences/Blockchains.tsx
+++ b/packages/app-extension/src/components/Unlocked/Settings/Preferences/Blockchains.tsx
@@ -66,10 +66,12 @@ export function PreferencesBlockchains({
         } else {
           // Mnemonic based keyring. This is the simple case because we don't
           // need to prompt for the user to open their Ledger app to get the
-          // required public key.
+          // required public key. We also don't need a signature to prove
+          // ownership of the public key because that can't be done
+          // transparently by the backend.
           await background.request({
             method: UI_RPC_METHOD_BLOCKCHAIN_KEYRINGS_ADD,
-            params: [blockchain, DerivationPath.Default, 0, undefined],
+            params: [blockchain, DerivationPath.Default, 0],
           });
         }
       } else {
@@ -92,6 +94,7 @@ export function PreferencesBlockchains({
         result.derivationPath,
         result.accountIndex,
         result.publicKey,
+        result.signature,
       ],
     });
     setOpenDrawer(false);

--- a/packages/app-extension/src/components/Unlocked/Settings/Preferences/Blockchains.tsx
+++ b/packages/app-extension/src/components/Unlocked/Settings/Preferences/Blockchains.tsx
@@ -14,6 +14,7 @@ import {
   useEnabledBlockchains,
   useKeyringType,
 } from "@coral-xyz/recoil";
+import { Typography } from "@mui/material";
 
 import { WithDrawer } from "../../../common/Layout/Drawer";
 import { SettingsList } from "../../../common/Settings/List";
@@ -29,6 +30,7 @@ export function PreferencesBlockchains({
 }) {
   const [tooltipOpen, setTooltipOpen] = useState(false);
   const [openDrawer, setOpenDrawer] = useState(false);
+  const [error, setError] = useState<string | null>(null);
   const background = useBackgroundClient();
   const enabledBlockchains = useEnabledBlockchains();
   const keyringType = useKeyringType();
@@ -69,10 +71,14 @@ export function PreferencesBlockchains({
           // required public key. We also don't need a signature to prove
           // ownership of the public key because that can't be done
           // transparently by the backend.
-          await background.request({
-            method: UI_RPC_METHOD_BLOCKCHAIN_KEYRINGS_ADD,
-            params: [blockchain, DerivationPath.Default, 0],
-          });
+          try {
+            await background.request({
+              method: UI_RPC_METHOD_BLOCKCHAIN_KEYRINGS_ADD,
+              params: [blockchain, DerivationPath.Default, 0],
+            });
+          } catch (error) {
+            setError("Wallet address is used by another Backpack account.");
+          }
         }
       } else {
         // Keyring exists for blockchain, just enable it
@@ -87,16 +93,20 @@ export function PreferencesBlockchains({
   const handleHardwareOnboardComplete = async (
     result: BlockchainKeyringInit
   ) => {
-    await background.request({
-      method: UI_RPC_METHOD_BLOCKCHAIN_KEYRINGS_ADD,
-      params: [
-        result.blockchain,
-        result.derivationPath,
-        result.accountIndex,
-        result.publicKey,
-        result.signature,
-      ],
-    });
+    try {
+      await background.request({
+        method: UI_RPC_METHOD_BLOCKCHAIN_KEYRINGS_ADD,
+        params: [
+          result.blockchain,
+          result.derivationPath,
+          result.accountIndex,
+          result.publicKey,
+          result.signature,
+        ],
+      });
+    } catch (error) {
+      setError("Wallet address is used by another Backpack account.");
+    }
     setOpenDrawer(false);
   };
 
@@ -121,6 +131,11 @@ export function PreferencesBlockchains({
       >
         <div>
           <SettingsList menuItems={menuItems} />
+          {error && (
+            <Typography style={{ color: "red", margin: "12px 24px" }}>
+              {error}
+            </Typography>
+          )}
         </div>
       </WithCopyTooltip>
       <WithDrawer

--- a/packages/app-extension/src/components/Unlocked/Settings/index.tsx
+++ b/packages/app-extension/src/components/Unlocked/Settings/index.tsx
@@ -386,7 +386,7 @@ function WalletList({
         method: UI_RPC_METHOD_KEYRING_ACTIVE_WALLET_UPDATE,
         params: [publicKey, blockchain],
       })
-      .then((_resp) => close())
+      .then(() => close())
       .catch(console.error);
   };
 

--- a/packages/background/src/backend/core.ts
+++ b/packages/background/src/backend/core.ts
@@ -852,12 +852,13 @@ export class Backend {
     if (jwtEnabled) {
       try {
         await this._addPublicKeyToAccount(blockchain, publicKey);
-      } catch {
+      } catch (error) {
         // Something went wrong persisting to server, roll back changes to the
         // keyring. This is not a complete rollback of state changes, because
         // the next account index gets incremented. This is the correct behaviour
         // because it should allow for sensible retries on conflicts.
         this.keyringKeyDelete(blockchain, publicKey);
+        throw error;
       }
     }
 
@@ -1016,10 +1017,11 @@ export class Backend {
     if (jwtEnabled) {
       try {
         await this._addPublicKeyToAccount(blockchain, publicKey);
-      } catch {
+      } catch (error) {
         // Something went wrong persisting to server, roll back changes to the
         // keyring.
         this.keyringKeyDelete(blockchain, publicKey);
+        throw error;
       }
     }
 
@@ -1086,10 +1088,11 @@ export class Backend {
     if (jwtEnabled) {
       try {
         await this._addPublicKeyToAccount(blockchain, publicKey, signature);
-      } catch {
+      } catch (error) {
         // Something went wrong persisting to server, roll back changes to the
         // keyring.
         this.keyringKeyDelete(blockchain, publicKey);
+        throw error;
       }
     }
     // Set the active wallet to the newly added public key
@@ -1301,9 +1304,10 @@ export class Backend {
     if (jwtEnabled) {
       try {
         await this._addPublicKeyToAccount(blockchain, newPublicKey, signature);
-      } catch {
+      } catch (error) {
         // Roll back the added blockchain keyring
         await this.keyringStore.blockchainKeyringRemove(blockchain);
+        throw error;
       }
     }
     // Automatically enable the newly added blockchain

--- a/packages/background/src/backend/core.ts
+++ b/packages/background/src/backend/core.ts
@@ -1138,6 +1138,7 @@ export class Backend {
   ) {
     // Persist the newly added public key to the Backpack API
     if (!signature) {
+      // Signature should only be undefined for non hardware wallets
       signature = await this.signMessageForPublicKey(
         blockchain,
         bs58.encode(Buffer.from(getAddMessage(publicKey), "utf-8")),

--- a/packages/background/src/backend/keyring/index.ts
+++ b/packages/background/src/backend/keyring/index.ts
@@ -327,14 +327,33 @@ export class KeyringStore {
     accountIndex: number,
     publicKey?: string,
     persist = true
-  ): Promise<void> {
-    this.activeUserKeyring.blockchainKeyringAdd(
+  ): Promise<string> {
+    // If this is a mnemonic based keyring the public key being returned is
+    // unknown, if it is a ledger it will just be the same as `publicKey`
+    const newPublicKey = this.activeUserKeyring.blockchainKeyringAdd(
       blockchain,
       derivationPath,
       accountIndex,
-      publicKey,
-      persist
+      publicKey
     );
+    if (persist) {
+      await this.persist();
+    }
+    return newPublicKey;
+  }
+
+  /**
+   * Remove a keyring. This shouldn't be exposed to the client as it can
+   * use the blockchain disable method to soft remove a keyring and still be
+   * able to enable it later without any reonboarding (signatures, etc). It
+   * is used by the backend to revert state changes for non atomic call
+   * sequences.
+   */
+  public async blockchainKeyringRemove(
+    blockchain: Blockchain,
+    persist = true
+  ): Promise<void> {
+    this.activeUserKeyring.blockchainKeyringRemove(blockchain);
     if (persist) {
       await this.persist();
     }
@@ -664,15 +683,19 @@ class UserKeyring {
     blockchain: Blockchain,
     derivationPath: DerivationPath,
     accountIndex: number,
-    publicKey?: string,
-    persist = true
-  ): Promise<void> {
+    publicKey?: string
+  ): Promise<string> {
     const keyring = keyringForBlockchain(blockchain);
+    let newPublicKey: string;
     if (this.mnemonic) {
       // Initialising using a mnemonic
-      await keyring.initFromMnemonic(this.mnemonic, derivationPath, [
-        accountIndex,
-      ]);
+      const wallets = await keyring.initFromMnemonic(
+        this.mnemonic,
+        derivationPath,
+        [accountIndex]
+      );
+      // Set the newly created public key for return
+      newPublicKey = wallets[0][0];
     } else {
       if (!publicKey)
         throw new Error(
@@ -686,8 +709,16 @@ class UserKeyring {
           publicKey,
         },
       ]);
+      // This is the same as the public key that was passed in, it is returned
+      // unchanged
+      newPublicKey = publicKey;
     }
     this.blockchains.set(blockchain, keyring);
+    return newPublicKey;
+  }
+
+  public async blockchainKeyringRemove(blockchain: Blockchain): Promise<void> {
+    this.blockchains.delete(blockchain);
   }
 
   public async importSecretKey(

--- a/packages/background/src/backend/keyring/index.ts
+++ b/packages/background/src/backend/keyring/index.ts
@@ -574,9 +574,7 @@ class UserKeyring {
         blockchainKeyring.blockchain,
         blockchainKeyring.derivationPath,
         blockchainKeyring.accountIndex,
-        blockchainKeyring.publicKey,
-        // Don't persist, as we persist manually later
-        false
+        blockchainKeyring.publicKey
       );
     }
     return kr;

--- a/packages/background/src/frontend/server-ui.ts
+++ b/packages/background/src/frontend/server-ui.ts
@@ -267,7 +267,8 @@ async function handle<T = any>(
         params[0],
         params[1],
         params[2],
-        params[3]
+        params[3],
+        params[4]
       );
     case UI_RPC_METHOD_BLOCKCHAIN_KEYRINGS_READ:
       return await handleBlockchainKeyringsRead(ctx);

--- a/packages/background/src/frontend/server-ui.ts
+++ b/packages/background/src/frontend/server-ui.ts
@@ -991,13 +991,15 @@ async function handleBlockchainKeyringsAdd(
   blockchain: Blockchain,
   derivationPath: DerivationPath,
   accountIndex: number,
-  publicKey: string | undefined
+  publicKey?: string,
+  signature?: string
 ): Promise<RpcResponse<Array<string>>> {
   const resp = await ctx.backend.blockchainKeyringsAdd(
     blockchain,
     derivationPath,
     accountIndex,
-    publicKey
+    publicKey,
+    signature
   );
   return [resp];
 }


### PR DESCRIPTION
- API call to server to add public key to backpack account when a new blockchain is enabled
- Moved the state reverts out of the main API call function in the backend to allow for different types of state reverts
- Updated the API to not error when attempting to add a public key to an account that already has it

Relevant https://github.com/coral-xyz/backpack/issues/1821
Closes https://github.com/coral-xyz/backpack/issues/1820