### PR TITLE
adds turbo filtering logic to extension

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,8 @@
     "build": "env-cmd --silent turbo run build",
     "e2e": "env-cmd --silent turbo run e2e",
     "clean": "npx rimraf {.,backend,examples,packages,node_modules}/**/{.parcel-cache,.turbo,build,dist,node_modules,yarn-error.log} packages/app-extension/dev",
+    "start:ext": "env-cmd --silent turbo run start --filter=@coral-xyz/app-extension...",
+    "build:ext": "env-cmd --silent turbo run build --filter=@coral-xyz/app-extension...",
     "start:mobile": "env-cmd --silent turbo run start --filter=@coral-xyz/app-mobile... --filter=@coral-xyz/background...",
     "build:mobile": "env-cmd --silent turbo run build --filter=@coral-xyz/app-mobile... --filter=@coral-xyz/background...",
     "postinstall": "yarn-deduplicate --scopes @babel @mui @typescript-eslint @types @react-native-community @react-navigation && if [ -d \"packages/app-mobile\" ]; then patch-package && cd packages/app-mobile && patch-package ; fi"

--- a/package.json
+++ b/package.json
@@ -21,8 +21,8 @@
     "build": "env-cmd --silent turbo run build",
     "e2e": "env-cmd --silent turbo run e2e",
     "clean": "npx rimraf {.,backend,examples,packages,node_modules}/**/{.parcel-cache,.turbo,build,dist,node_modules,yarn-error.log} packages/app-extension/dev",
-    "start:ext": "env-cmd --silent turbo run start --filter=@coral-xyz/app-extension...",
-    "build:ext": "env-cmd --silent turbo run build --filter=@coral-xyz/app-extension...",
+    "start:ext": "env-cmd turbo run start --filter=@coral-xyz/app-extension...",
+    "build:ext": "env-cmd turbo run build --filter=@coral-xyz/app-extension...",
     "start:mobile": "env-cmd --silent turbo run start --filter=@coral-xyz/app-mobile... --filter=@coral-xyz/background...",
     "build:mobile": "env-cmd --silent turbo run build --filter=@coral-xyz/app-mobile... --filter=@coral-xyz/background...",
     "postinstall": "yarn-deduplicate --scopes @babel @mui @typescript-eslint @types @react-native-community @react-navigation && if [ -d \"packages/app-mobile\" ]; then patch-package && cd packages/app-mobile && patch-package ; fi"


### PR DESCRIPTION
adds 2 scripts:

```
- start:ext
- build:ext
```

turbo repo allows you to watch/build based on your required dependencies. by including `...` at the end of the extension we're saying "build the extension and the dependencies the extension relies on"

i could update the main start/build scripts, but i'm not sure what repercussions that would have

i've used this technique for mobile and it has been a substantial improvement in speed

https://turbo.build/repo/docs/core-concepts/monorepos/filtering#include-dependencies-of-matched-workspaces