### PR TITLE
fixes eslint parserOptions.project error

### DIFF
--- a/packages/app-extension/.eslintrc.js
+++ b/packages/app-extension/.eslintrc.js
@@ -1,4 +1,5 @@
 module.exports = {
   root: true,
   extends: ["custom"],
+  parserOptions: { project: ["./tsconfig.json"] },
 };

--- a/packages/app-mobile/.eslintrc.js
+++ b/packages/app-mobile/.eslintrc.js
@@ -1,5 +1,5 @@
 module.exports = {
   root: true,
   extends: ["custom"],
-  parserOptions: { project: null },
+  parserOptions: { project: ["./tsconfig.json"] },
 };


### PR DESCRIPTION
by including parserOptions.project and pointing it to the tsconfig.json, we're able to remove the weird `rootDir` error