### PR TITLE
Added handler on port so fly healthcheck succeeds

### DIFF
--- a/backend/native/notifications-worker/package.json
+++ b/backend/native/notifications-worker/package.json
@@ -8,9 +8,11 @@
     "@coral-xyz/zeus": "*",
     "@project-serum/anchor": "^0.25.0",
     "@solana/wallet-adapter-react": "^0.15.25",
+    "@types/express": "^4.17.15",
     "@types/redis": "^4.0.11",
     "@types/web-push": "^3.3.2",
     "esbuild": "^0.15.13",
+    "express": "^4.18.2",
     "redis": "^4.5.1",
     "uuid": "^9.0.0",
     "web-push": "^3.5.0"

--- a/backend/native/notifications-worker/src/index.ts
+++ b/backend/native/notifications-worker/src/index.ts
@@ -1,7 +1,9 @@
 import cluster from "cluster";
+import express from "express";
 import os from "os";
 
 import { processQueue } from "./worker";
+
 const workers: { [workerPid: string]: any } = {},
   count = os.cpus().length;
 
@@ -20,6 +22,8 @@ if (cluster.isMaster) {
     delete workers[worker.pid];
     spawn();
   });
+  const app = express();
+  app.listen(process.env.PORT || 8083);
 } else {
   (async () => {
     const x = 0;

--- a/docker/notifications-worker/Dockerfile
+++ b/docker/notifications-worker/Dockerfile
@@ -33,6 +33,6 @@ RUN cd /base/backend/native/notifications-worker && yarn run build
 ENV VAPID_PUBLIC_KEY=BDW-VH2Acel5JQXyL80lna43up_0HfXSg_7A5TwhJ9WX_MZPzr9DhNvR7tzH16LT1XPXWMfemZdYHl_wPUGT1DQ
 ENV VAPID_PRIVATE_KEY=LZ2o02-xNzos7djkyyQaWmfpDH0xXa646uGWqg7PPwE
 
-EXPOSE 8080
+EXPOSE 8083
 
 CMD ["node", "/base/backend/native/notifications-worker/dist/index.js"]

--- a/docker/notifications-worker/fly.toml
+++ b/docker/notifications-worker/fly.toml
@@ -16,7 +16,7 @@ dockerfile = "./docker/notifications-worker/Dockerfile"
 
 [[services]]
   http_checks = []
-  internal_port = 8080
+  internal_port = 8083
   processes = ["app"]
   protocol = "tcp"
   script_checks = []


### PR DESCRIPTION
`notifications-workers` are not deploying, I think because fly is checking the internal port and isn't getting a response from it. 
The PR exposes an HTTP server on the internal port just to make fly happy.