### PR TITLE
add websocket support to rpc proxy

### DIFF
--- a/backend/workers/rpc-proxy/src/index.ts
+++ b/backend/workers/rpc-proxy/src/index.ts
@@ -5,36 +5,43 @@ export interface Env {
 
 export default {
   async fetch(request: Request, env: Env): Promise<Response> {
-    switch (request.method) {
-      case "OPTIONS":
-        return new Response("ok", {
-          headers: {
-            "Access-Control-Allow-Headers": "*",
-            "Access-Control-Allow-Methods": "POST, OPTIONS",
-            "Access-Control-Allow-Origin": "*",
-          },
-        });
-      case "POST":
-        const { href, hostname } = new URL(
-          env.RPC_URL || "https://api.mainnet-beta.solana.com"
-        );
-        const rpcResponse = await fetch(
-          href,
-          (() => {
-            const _request = new Request(href, request);
-            // Only forward necessary headers from the client request
-            sanitizeHeaders(_request.headers);
-            return _request;
-          })()
-        );
-        const response = new Response(rpcResponse.body, rpcResponse);
-        // Add the RPC domain to the response headers for debugging purposes
-        response.headers.append("x-backpack-rpc", hostname);
-        return response;
-      default:
-        return new Response("Only POST or OPTIONS requests are allowed", {
+    if (request.method === "OPTIONS") {
+      return new Response("ok", {
+        headers: {
+          "Access-Control-Allow-Headers": "*",
+          "Access-Control-Allow-Methods": "POST, OPTIONS",
+          "Access-Control-Allow-Origin": "*",
+        },
+      });
+    } else if (
+      // POST for https
+      request.method === "POST" ||
+      // GET for websockets
+      (request.method === "GET" && request.headers.get("Upgrade"))
+    ) {
+      const { href, hostname } = new URL(
+        env.RPC_URL || "https://api.mainnet-beta.solana.com"
+      );
+      const rpcResponse = await fetch(
+        href,
+        (() => {
+          const _request = new Request(href, request);
+          // Only forward necessary headers from the client request
+          sanitizeHeaders(_request.headers);
+          return _request;
+        })()
+      );
+      const response = new Response(rpcResponse.body, rpcResponse);
+      // Add the RPC domain to the response headers for debugging purposes
+      response.headers.append("x-backpack-rpc", hostname);
+      return response;
+    } else {
+      return new Response(
+        "Only POST, OPTIONS or WebSocket Upgrade GET requests are allowed",
+        {
           status: 405,
-        });
+        }
+      );
     }
   },
 };
@@ -48,6 +55,7 @@ const sanitizeHeaders = (headers: Headers) => {
     "content-length",
     "content-type",
     "solana-client",
+    "upgrade",
   ];
   headers.forEach((_value, key) => {
     if (!allowedHeaders.includes(key.toLowerCase())) {


### PR DESCRIPTION
adds support for HTTP Upgrade requests so that websocket connections can be opened

I don't think this works with the swr-proxy URL right now, but merging so that the code can go live and be tested