### PR TITLE
chore: Update to jupiter api v4 for bugfixes and more dexes

### DIFF
--- a/packages/recoil/src/atoms/solana/jupiter.tsx
+++ b/packages/recoil/src/atoms/solana/jupiter.tsx
@@ -6,7 +6,7 @@ import { blockchainBalancesSorted } from "../balance";
 
 import { SOL_LOGO_URI, splTokenRegistry } from "./token-registry";
 
-export const JUPITER_BASE_URL = "https://quote-api.jup.ag/v1/";
+export const JUPITER_BASE_URL = "https://quote-api.jup.ag/v4/";
 
 export const jupiterRouteMap = selector({
   key: "jupiterRouteMap",


### PR DESCRIPTION
v4 has many bugfixes and new DEX integrations for best pricing. It also handle u64 as string at the interface to prevent any js `number` explosions.

Remove `onlyDirectRoutes` as v4 guarantees a single transaction.

`asLegacyTransaction` guarantees routing that fit in a legacy transaction, then request a legacy transaction calling `/swap`

https://docs.jup.ag/integrating-jupiter/backend-bot-integration/using-the-api

I don't fully understand  the comment 

```
  // The Jupiter API returns between 1 and 3 transations to perform a swap
  // (setupTransaction, swapTransaction, cleanupTransaction). Additionally
  // the wrapping of SOL (if required) is handled here by the wrapTransaction
  // step at the beginning.
  ```
  as `wrapUnwrapSOL` is true, but i think it is simply a stale comment as `onlyDirectRoutes` was used