### PR TITLE
add missing dependencies to api

### DIFF
--- a/backend/native/backpack-api/package.json
+++ b/backend/native/backpack-api/package.json
@@ -4,6 +4,7 @@
   "main": "index.js",
   "license": "MIT",
   "dependencies": {
+    "@coral-xyz/chat-zeus": "*",
     "@coral-xyz/common": "*",
     "@coral-xyz/zeus": "*",
     "@metaplex-foundation/js": "^0.17.12",
@@ -12,6 +13,7 @@
     "@types/request": "^2.48.8",
     "@types/web-push": "^3.3.2",
     "asn1.js": "^5.4.1",
+    "body-parser": "^1.20.1",
     "cookie-parser": "^1.4.6",
     "esbuild": "^0.15.16",
     "ethers": "^5.7.2",
@@ -25,6 +27,7 @@
     "request": "^2.88.2",
     "tweetnacl": "^1.0.3",
     "urlsafe-base64": "^1.0.0",
+    "uuid": "^9.0.0",
     "web-push": "^3.5.0",
     "zod": "^3.19.1"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -8504,7 +8504,7 @@ body-parser@1.19.0:
     raw-body "2.4.0"
     type-is "~1.6.17"
 
-body-parser@1.20.1:
+body-parser@1.20.1, body-parser@^1.20.1:
   version "1.20.1"
   resolved "https://registry.yarnpkg.com/body-parser/-/body-parser-1.20.1.tgz#b1812a8912c195cd371a3ee5e66faa2338a5c668"
   integrity sha512-jWi7abTbYwajOytWCQc37VulmWiRae5RyTpaCyDcS5/lMdtwSz5lOpDE67srw/HYe35f1z3fDQw+3txg7gNtWw==


### PR DESCRIPTION
fixes missing chat-zeus error when running `npx turbo run start --filter=backpack-api` from root