### PR TITLE
Add support for links in messages

### DIFF
--- a/packages/app-extension/package.json
+++ b/packages/app-extension/package.json
@@ -35,6 +35,8 @@
     "bs58": "^5.0.0",
     "ethers": "^5.7.0",
     "figma-squircle": "^0.2.1",
+    "linkify-react": "^4.1.0",
+    "linkifyjs": "^4.1.0",
     "react": "^17.0.2",
     "react-custom-scrollbars": "^4.2.1",
     "react-dom": "^17.0.2",

--- a/packages/chat-sdk/src/components/Message.tsx
+++ b/packages/chat-sdk/src/components/Message.tsx
@@ -21,9 +21,9 @@ import { Gif as GifComponent } from "@giphy/react-components";
 import AccessTimeIcon from "@mui/icons-material/AccessTime";
 import CallMadeIcon from "@mui/icons-material/CallMade";
 import { Skeleton } from "@mui/material";
-import Button from "@mui/material/Button";
 import { createStyles, makeStyles } from "@mui/styles";
 import { LAMPORTS_PER_SOL, PublicKey } from "@solana/web3.js";
+import Linkify from "linkify-react";
 
 import {
   cancel,
@@ -304,7 +304,11 @@ export const MessageLine = (props) => {
                         <div>{message}</div>
                       </div>
                     ) : (
-                      message
+                      <span style={{ wordBreak: "break-word" }}>
+                        <Linkify options={{ target: "_blank" }}>
+                          {message}
+                        </Linkify>
+                      </span>
                     )}
                   </p>
                 </div>

--- a/yarn.lock
+++ b/yarn.lock
@@ -17937,6 +17937,16 @@ lines-and-columns@^1.1.6:
   resolved "https://registry.yarnpkg.com/lines-and-columns/-/lines-and-columns-1.2.4.tgz#eca284f75d2965079309dc0ad9255abb2ebc1632"
   integrity sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==
 
+linkify-react@^4.1.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/linkify-react/-/linkify-react-4.1.0.tgz#8b2796a8bc7a847ae1486b86392c0ad833d0f314"
+  integrity sha512-PG+ulIQkrHHDluuH/YgvRZDX1GFi0sarb7jNL4BdFOBH+muoiIVvBVwHkP9K7lSn7OmC6k8JEXKe+QvwBUsuOg==
+
+linkifyjs@^4.1.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/linkifyjs/-/linkifyjs-4.1.0.tgz#0460bfcc37d3348fa80e078d92e7bbc82588db15"
+  integrity sha512-Ffv8VoY3+ixI1b3aZ3O+jM6x17cOsgwfB1Wq7pkytbo1WlyRp6ZO0YDMqiWT/gQPY/CmtiGuKfzDIVqxh1aCTA==
+
 lint-staged@^12.4.1:
   version "12.4.1"
   resolved "https://registry.yarnpkg.com/lint-staged/-/lint-staged-12.4.1.tgz#63fa27bfc8a33515f6902f63f6670864f1fb233c"


### PR DESCRIPTION
Makes links in messages clickable, using [`linkifyjs`](https://github.com/Hypercontext/linkifyjs) and its React wrapper (licensed under MIT).
A simple stopgap solution until link unfurling (#2148) is properly supported.

<img width="530" alt="CleanShot 2023-01-21 at 16 24 25@2x" src="https://user-images.githubusercontent.com/11226395/213895171-53e74ad5-21c7-4061-bef7-91b108d74618.png">
<img width="522" alt="CleanShot 2023-01-21 at 17 25 43@2x" src="https://user-images.githubusercontent.com/11226395/213896504-7de7b46a-b788-46c2-9ef4-2499d4bc37fc.png">
