### PR TITLE
Add missing node script to provider-injection package

### DIFF
--- a/packages/provider-injection/package.json
+++ b/packages/provider-injection/package.json
@@ -3,6 +3,7 @@
   "version": "0.1.0",
   "source": "src/index.ts",
   "scripts": {
+    "start": "yarn build",
     "build": "node build.js"
   },
   "browserslist": "> 0.5%, last 2 versions, not dead",


### PR DESCRIPTION
When setting up my environment & running `start:fresh` or `start`, I kept getting these errors:
<img width="1520" alt="CleanShot 2023-01-21 at 17 28 07@2x" src="https://user-images.githubusercontent.com/11226395/213896743-ff493411-e5db-4d5e-af05-df0f886733c7.png">
<img width="630" alt="CleanShot 2023-01-21 at 17 49 54@2x" src="https://user-images.githubusercontent.com/11226395/213897096-2e3c90b6-a6d1-4b83-b96f-b87af05ab6a0.png">

Did a bit of investigating and I believe the problem stems from the lack of a `start` command in the `provider-injection` package for turborepo to run.

After adding the command, the error no longer shows up: 
<img width="1215" alt="CleanShot 2023-01-21 at 17 41 31@2x" src="https://user-images.githubusercontent.com/11226395/213896916-e316e10a-9a69-48ec-a4f0-48336ac5c34c.png">
Can also verify that the command is being invoked properly by turborepo:
<img width="946" alt="CleanShot 2023-01-21 at 17 53 35@2x" src="https://user-images.githubusercontent.com/11226395/213897171-5c326151-f278-432b-932c-ffa9a8964716.png">
