### PR TITLE
removes recoil require cycle

### DIFF
--- a/packages/recoil/src/atoms/friendship.tsx
+++ b/packages/recoil/src/atoms/friendship.tsx
@@ -9,7 +9,7 @@ import type { EnrichedInboxDb } from "@coral-xyz/common/dist/esm/messages/db";
 import { getFriendshipByUserId } from "@coral-xyz/db";
 import { atomFamily, selectorFamily } from "recoil";
 
-import * as atoms from "./index";
+import * as atoms from "./preferences/index";
 
 export const friendship = atomFamily<Friendship | null, { userId: string }>({
   key: "friendship",


### PR DESCRIPTION
require cycles are allowed in JS, but they can mess up react native bc of the metro bundler