### PR TITLE
add users.dropzone_public_key helper to hasura

### DIFF
--- a/backend/native/zeus/src/zeus/const.ts
+++ b/backend/native/zeus/src/zeus/const.ts
@@ -515,6 +515,11 @@ export const AllTypesProps: Record<string, any> = {
   auth_user_nfts_stream_cursor_value_input: {},
   auth_user_nfts_update_column: "enum" as const,
   auth_users: {
+    dropzone_public_key: {
+      distinct_on: "auth_public_keys_select_column",
+      order_by: "auth_public_keys_order_by",
+      where: "auth_public_keys_bool_exp",
+    },
     public_keys: {
       distinct_on: "auth_public_keys_select_column",
       order_by: "auth_public_keys_order_by",
@@ -562,6 +567,7 @@ export const AllTypesProps: Record<string, any> = {
     _and: "auth_users_bool_exp",
     _not: "auth_users_bool_exp",
     _or: "auth_users_bool_exp",
+    dropzone_public_key: "auth_public_keys_bool_exp",
     id: "uuid_comparison_exp",
     public_keys: "auth_public_keys_bool_exp",
     public_keys_aggregate: "auth_public_keys_aggregate_bool_exp",
@@ -597,6 +603,7 @@ export const AllTypesProps: Record<string, any> = {
     where: "auth_users_bool_exp",
   },
   auth_users_order_by: {
+    dropzone_public_key_aggregate: "auth_public_keys_aggregate_order_by",
     id: "order_by",
     public_keys_aggregate: "auth_public_keys_aggregate_order_by",
     referred_users_aggregate: "auth_users_aggregate_order_by",
@@ -764,6 +771,9 @@ export const AllTypesProps: Record<string, any> = {
     data: "jsonb",
   },
   dropzone_distributors_update_column: "enum" as const,
+  dropzone_user_dropzone_public_key_args: {
+    user_row: "users_scalar",
+  },
   invitations_aggregate_fields: {
     count: {
       columns: "invitations_select_column",
@@ -1164,6 +1174,18 @@ export const AllTypesProps: Record<string, any> = {
       where: "dropzone_distributors_bool_exp",
     },
     dropzone_distributors_by_pk: {},
+    dropzone_user_dropzone_public_key: {
+      args: "dropzone_user_dropzone_public_key_args",
+      distinct_on: "auth_public_keys_select_column",
+      order_by: "auth_public_keys_order_by",
+      where: "auth_public_keys_bool_exp",
+    },
+    dropzone_user_dropzone_public_key_aggregate: {
+      args: "dropzone_user_dropzone_public_key_args",
+      distinct_on: "auth_public_keys_select_column",
+      order_by: "auth_public_keys_order_by",
+      where: "auth_public_keys_bool_exp",
+    },
     invitations: {
       distinct_on: "invitations_select_column",
       order_by: "invitations_order_by",
@@ -1333,6 +1355,18 @@ export const AllTypesProps: Record<string, any> = {
       cursor: "dropzone_distributors_stream_cursor_input",
       where: "dropzone_distributors_bool_exp",
     },
+    dropzone_user_dropzone_public_key: {
+      args: "dropzone_user_dropzone_public_key_args",
+      distinct_on: "auth_public_keys_select_column",
+      order_by: "auth_public_keys_order_by",
+      where: "auth_public_keys_bool_exp",
+    },
+    dropzone_user_dropzone_public_key_aggregate: {
+      args: "dropzone_user_dropzone_public_key_args",
+      distinct_on: "auth_public_keys_select_column",
+      order_by: "auth_public_keys_order_by",
+      where: "auth_public_keys_bool_exp",
+    },
     invitations: {
       distinct_on: "invitations_select_column",
       order_by: "invitations_order_by",
@@ -1359,6 +1393,7 @@ export const AllTypesProps: Record<string, any> = {
     _neq: "timestamptz",
     _nin: "timestamptz",
   },
+  users_scalar: `scalar.users_scalar` as const,
   uuid: `scalar.uuid` as const,
   uuid_comparison_exp: {
     _eq: "uuid",
@@ -1636,6 +1671,7 @@ export const ReturnTypes: Record<string, any> = {
     returning: "auth_user_nfts",
   },
   auth_users: {
+    dropzone_public_key: "auth_public_keys",
     id: "uuid",
     public_keys: "auth_public_keys",
     public_keys_aggregate: "auth_public_keys_aggregate",
@@ -1851,6 +1887,8 @@ export const ReturnTypes: Record<string, any> = {
     dropzone_distributors: "dropzone_distributors",
     dropzone_distributors_aggregate: "dropzone_distributors_aggregate",
     dropzone_distributors_by_pk: "dropzone_distributors",
+    dropzone_user_dropzone_public_key: "auth_public_keys",
+    dropzone_user_dropzone_public_key_aggregate: "auth_public_keys_aggregate",
     invitations: "invitations",
     invitations_aggregate: "invitations_aggregate",
   },
@@ -1899,11 +1937,14 @@ export const ReturnTypes: Record<string, any> = {
     dropzone_distributors_aggregate: "dropzone_distributors_aggregate",
     dropzone_distributors_by_pk: "dropzone_distributors",
     dropzone_distributors_stream: "dropzone_distributors",
+    dropzone_user_dropzone_public_key: "auth_public_keys",
+    dropzone_user_dropzone_public_key_aggregate: "auth_public_keys_aggregate",
     invitations: "invitations",
     invitations_aggregate: "invitations_aggregate",
     invitations_stream: "invitations",
   },
   timestamptz: `scalar.timestamptz` as const,
+  users_scalar: `scalar.users_scalar` as const,
   uuid: `scalar.uuid` as const,
 };
 

--- a/backend/native/zeus/src/zeus/index.ts
+++ b/backend/native/zeus/src/zeus/index.ts
@@ -1001,6 +1001,7 @@ export type ScalarCoders = {
   citext?: ScalarResolver;
   jsonb?: ScalarResolver;
   timestamptz?: ScalarResolver;
+  users_scalar?: ScalarResolver;
   uuid?: ScalarResolver;
 };
 type ZEUS_UNIONS = never;
@@ -3260,6 +3261,40 @@ export type ValueTypes = {
   ["auth_user_nfts_update_column"]: auth_user_nfts_update_column;
   /** columns and relationships of "auth.users" */
   ["auth_users"]: AliasType<{
+    dropzone_public_key?: [
+      {
+        /** distinct select on columns */
+        distinct_on?:
+          | Array<ValueTypes["auth_public_keys_select_column"]>
+          | undefined
+          | null
+          | Variable<any, string> /** limit the number of rows returned */;
+        limit?:
+          | number
+          | undefined
+          | null
+          | Variable<
+              any,
+              string
+            > /** skip the first n rows. Use only with order_by */;
+        offset?:
+          | number
+          | undefined
+          | null
+          | Variable<any, string> /** sort the rows by one or more columns */;
+        order_by?:
+          | Array<ValueTypes["auth_public_keys_order_by"]>
+          | undefined
+          | null
+          | Variable<any, string> /** filter the rows returned */;
+        where?:
+          | ValueTypes["auth_public_keys_bool_exp"]
+          | undefined
+          | null
+          | Variable<any, string>;
+      },
+      ValueTypes["auth_public_keys"]
+    ];
     id?: boolean | `@${string}`;
     public_keys?: [
       {
@@ -3487,6 +3522,11 @@ export type ValueTypes = {
       | undefined
       | null
       | Variable<any, string>;
+    dropzone_public_key?:
+      | ValueTypes["auth_public_keys_bool_exp"]
+      | undefined
+      | null
+      | Variable<any, string>;
     id?:
       | ValueTypes["uuid_comparison_exp"]
       | undefined
@@ -3613,6 +3653,11 @@ export type ValueTypes = {
   };
   /** Ordering options when selecting data from "auth.users". */
   ["auth_users_order_by"]: {
+    dropzone_public_key_aggregate?:
+      | ValueTypes["auth_public_keys_aggregate_order_by"]
+      | undefined
+      | null
+      | Variable<any, string>;
     id?: ValueTypes["order_by"] | undefined | null | Variable<any, string>;
     public_keys_aggregate?:
       | ValueTypes["auth_public_keys_aggregate_order_by"]
@@ -4181,6 +4226,13 @@ export type ValueTypes = {
   };
   /** placeholder for update columns of table "dropzone.distributors" (current role has no relevant permissions) */
   ["dropzone_distributors_update_column"]: dropzone_distributors_update_column;
+  ["dropzone_user_dropzone_public_key_args"]: {
+    user_row?:
+      | ValueTypes["users_scalar"]
+      | undefined
+      | null
+      | Variable<any, string>;
+  };
   /** columns and relationships of "invitations" */
   ["invitations"]: AliasType<{
     claimed_at?: boolean | `@${string}`;
@@ -5945,6 +5997,80 @@ export type ValueTypes = {
       { id: string | Variable<any, string> },
       ValueTypes["dropzone_distributors"]
     ];
+    dropzone_user_dropzone_public_key?: [
+      {
+        /** input parameters for function "dropzone_user_dropzone_public_key" */
+        args:
+          | ValueTypes["dropzone_user_dropzone_public_key_args"]
+          | Variable<any, string> /** distinct select on columns */;
+        distinct_on?:
+          | Array<ValueTypes["auth_public_keys_select_column"]>
+          | undefined
+          | null
+          | Variable<any, string> /** limit the number of rows returned */;
+        limit?:
+          | number
+          | undefined
+          | null
+          | Variable<
+              any,
+              string
+            > /** skip the first n rows. Use only with order_by */;
+        offset?:
+          | number
+          | undefined
+          | null
+          | Variable<any, string> /** sort the rows by one or more columns */;
+        order_by?:
+          | Array<ValueTypes["auth_public_keys_order_by"]>
+          | undefined
+          | null
+          | Variable<any, string> /** filter the rows returned */;
+        where?:
+          | ValueTypes["auth_public_keys_bool_exp"]
+          | undefined
+          | null
+          | Variable<any, string>;
+      },
+      ValueTypes["auth_public_keys"]
+    ];
+    dropzone_user_dropzone_public_key_aggregate?: [
+      {
+        /** input parameters for function "dropzone_user_dropzone_public_key_aggregate" */
+        args:
+          | ValueTypes["dropzone_user_dropzone_public_key_args"]
+          | Variable<any, string> /** distinct select on columns */;
+        distinct_on?:
+          | Array<ValueTypes["auth_public_keys_select_column"]>
+          | undefined
+          | null
+          | Variable<any, string> /** limit the number of rows returned */;
+        limit?:
+          | number
+          | undefined
+          | null
+          | Variable<
+              any,
+              string
+            > /** skip the first n rows. Use only with order_by */;
+        offset?:
+          | number
+          | undefined
+          | null
+          | Variable<any, string> /** sort the rows by one or more columns */;
+        order_by?:
+          | Array<ValueTypes["auth_public_keys_order_by"]>
+          | undefined
+          | null
+          | Variable<any, string> /** filter the rows returned */;
+        where?:
+          | ValueTypes["auth_public_keys_bool_exp"]
+          | undefined
+          | null
+          | Variable<any, string>;
+      },
+      ValueTypes["auth_public_keys_aggregate"]
+    ];
     invitations?: [
       {
         /** distinct select on columns */
@@ -7002,6 +7128,80 @@ export type ValueTypes = {
       },
       ValueTypes["dropzone_distributors"]
     ];
+    dropzone_user_dropzone_public_key?: [
+      {
+        /** input parameters for function "dropzone_user_dropzone_public_key" */
+        args:
+          | ValueTypes["dropzone_user_dropzone_public_key_args"]
+          | Variable<any, string> /** distinct select on columns */;
+        distinct_on?:
+          | Array<ValueTypes["auth_public_keys_select_column"]>
+          | undefined
+          | null
+          | Variable<any, string> /** limit the number of rows returned */;
+        limit?:
+          | number
+          | undefined
+          | null
+          | Variable<
+              any,
+              string
+            > /** skip the first n rows. Use only with order_by */;
+        offset?:
+          | number
+          | undefined
+          | null
+          | Variable<any, string> /** sort the rows by one or more columns */;
+        order_by?:
+          | Array<ValueTypes["auth_public_keys_order_by"]>
+          | undefined
+          | null
+          | Variable<any, string> /** filter the rows returned */;
+        where?:
+          | ValueTypes["auth_public_keys_bool_exp"]
+          | undefined
+          | null
+          | Variable<any, string>;
+      },
+      ValueTypes["auth_public_keys"]
+    ];
+    dropzone_user_dropzone_public_key_aggregate?: [
+      {
+        /** input parameters for function "dropzone_user_dropzone_public_key_aggregate" */
+        args:
+          | ValueTypes["dropzone_user_dropzone_public_key_args"]
+          | Variable<any, string> /** distinct select on columns */;
+        distinct_on?:
+          | Array<ValueTypes["auth_public_keys_select_column"]>
+          | undefined
+          | null
+          | Variable<any, string> /** limit the number of rows returned */;
+        limit?:
+          | number
+          | undefined
+          | null
+          | Variable<
+              any,
+              string
+            > /** skip the first n rows. Use only with order_by */;
+        offset?:
+          | number
+          | undefined
+          | null
+          | Variable<any, string> /** sort the rows by one or more columns */;
+        order_by?:
+          | Array<ValueTypes["auth_public_keys_order_by"]>
+          | undefined
+          | null
+          | Variable<any, string> /** filter the rows returned */;
+        where?:
+          | ValueTypes["auth_public_keys_bool_exp"]
+          | undefined
+          | null
+          | Variable<any, string>;
+      },
+      ValueTypes["auth_public_keys_aggregate"]
+    ];
     invitations?: [
       {
         /** distinct select on columns */
@@ -7115,6 +7315,7 @@ export type ValueTypes = {
       | null
       | Variable<any, string>;
   };
+  ["users_scalar"]: unknown;
   ["uuid"]: unknown;
   /** Boolean expression to compare columns of type "uuid". All fields are combined with logical 'AND'. */
   ["uuid_comparison_exp"]: {
@@ -8743,6 +8944,32 @@ export type ResolverInputTypes = {
   ["auth_user_nfts_update_column"]: auth_user_nfts_update_column;
   /** columns and relationships of "auth.users" */
   ["auth_users"]: AliasType<{
+    dropzone_public_key?: [
+      {
+        /** distinct select on columns */
+        distinct_on?:
+          | Array<ResolverInputTypes["auth_public_keys_select_column"]>
+          | undefined
+          | null /** limit the number of rows returned */;
+        limit?:
+          | number
+          | undefined
+          | null /** skip the first n rows. Use only with order_by */;
+        offset?:
+          | number
+          | undefined
+          | null /** sort the rows by one or more columns */;
+        order_by?:
+          | Array<ResolverInputTypes["auth_public_keys_order_by"]>
+          | undefined
+          | null /** filter the rows returned */;
+        where?:
+          | ResolverInputTypes["auth_public_keys_bool_exp"]
+          | undefined
+          | null;
+      },
+      ResolverInputTypes["auth_public_keys"]
+    ];
     id?: boolean | `@${string}`;
     public_keys?: [
       {
@@ -8904,6 +9131,10 @@ export type ResolverInputTypes = {
     _and?: Array<ResolverInputTypes["auth_users_bool_exp"]> | undefined | null;
     _not?: ResolverInputTypes["auth_users_bool_exp"] | undefined | null;
     _or?: Array<ResolverInputTypes["auth_users_bool_exp"]> | undefined | null;
+    dropzone_public_key?:
+      | ResolverInputTypes["auth_public_keys_bool_exp"]
+      | undefined
+      | null;
     id?: ResolverInputTypes["uuid_comparison_exp"] | undefined | null;
     public_keys?:
       | ResolverInputTypes["auth_public_keys_bool_exp"]
@@ -8992,6 +9223,10 @@ export type ResolverInputTypes = {
   };
   /** Ordering options when selecting data from "auth.users". */
   ["auth_users_order_by"]: {
+    dropzone_public_key_aggregate?:
+      | ResolverInputTypes["auth_public_keys_aggregate_order_by"]
+      | undefined
+      | null;
     id?: ResolverInputTypes["order_by"] | undefined | null;
     public_keys_aggregate?:
       | ResolverInputTypes["auth_public_keys_aggregate_order_by"]
@@ -9404,6 +9639,9 @@ export type ResolverInputTypes = {
   };
   /** placeholder for update columns of table "dropzone.distributors" (current role has no relevant permissions) */
   ["dropzone_distributors_update_column"]: dropzone_distributors_update_column;
+  ["dropzone_user_dropzone_public_key_args"]: {
+    user_row?: ResolverInputTypes["users_scalar"] | undefined | null;
+  };
   /** columns and relationships of "invitations" */
   ["invitations"]: AliasType<{
     claimed_at?: boolean | `@${string}`;
@@ -10742,6 +10980,60 @@ export type ResolverInputTypes = {
       { id: string },
       ResolverInputTypes["dropzone_distributors"]
     ];
+    dropzone_user_dropzone_public_key?: [
+      {
+        /** input parameters for function "dropzone_user_dropzone_public_key" */
+        args: ResolverInputTypes["dropzone_user_dropzone_public_key_args"] /** distinct select on columns */;
+        distinct_on?:
+          | Array<ResolverInputTypes["auth_public_keys_select_column"]>
+          | undefined
+          | null /** limit the number of rows returned */;
+        limit?:
+          | number
+          | undefined
+          | null /** skip the first n rows. Use only with order_by */;
+        offset?:
+          | number
+          | undefined
+          | null /** sort the rows by one or more columns */;
+        order_by?:
+          | Array<ResolverInputTypes["auth_public_keys_order_by"]>
+          | undefined
+          | null /** filter the rows returned */;
+        where?:
+          | ResolverInputTypes["auth_public_keys_bool_exp"]
+          | undefined
+          | null;
+      },
+      ResolverInputTypes["auth_public_keys"]
+    ];
+    dropzone_user_dropzone_public_key_aggregate?: [
+      {
+        /** input parameters for function "dropzone_user_dropzone_public_key_aggregate" */
+        args: ResolverInputTypes["dropzone_user_dropzone_public_key_args"] /** distinct select on columns */;
+        distinct_on?:
+          | Array<ResolverInputTypes["auth_public_keys_select_column"]>
+          | undefined
+          | null /** limit the number of rows returned */;
+        limit?:
+          | number
+          | undefined
+          | null /** skip the first n rows. Use only with order_by */;
+        offset?:
+          | number
+          | undefined
+          | null /** sort the rows by one or more columns */;
+        order_by?:
+          | Array<ResolverInputTypes["auth_public_keys_order_by"]>
+          | undefined
+          | null /** filter the rows returned */;
+        where?:
+          | ResolverInputTypes["auth_public_keys_bool_exp"]
+          | undefined
+          | null;
+      },
+      ResolverInputTypes["auth_public_keys_aggregate"]
+    ];
     invitations?: [
       {
         /** distinct select on columns */
@@ -11514,6 +11806,60 @@ export type ResolverInputTypes = {
       },
       ResolverInputTypes["dropzone_distributors"]
     ];
+    dropzone_user_dropzone_public_key?: [
+      {
+        /** input parameters for function "dropzone_user_dropzone_public_key" */
+        args: ResolverInputTypes["dropzone_user_dropzone_public_key_args"] /** distinct select on columns */;
+        distinct_on?:
+          | Array<ResolverInputTypes["auth_public_keys_select_column"]>
+          | undefined
+          | null /** limit the number of rows returned */;
+        limit?:
+          | number
+          | undefined
+          | null /** skip the first n rows. Use only with order_by */;
+        offset?:
+          | number
+          | undefined
+          | null /** sort the rows by one or more columns */;
+        order_by?:
+          | Array<ResolverInputTypes["auth_public_keys_order_by"]>
+          | undefined
+          | null /** filter the rows returned */;
+        where?:
+          | ResolverInputTypes["auth_public_keys_bool_exp"]
+          | undefined
+          | null;
+      },
+      ResolverInputTypes["auth_public_keys"]
+    ];
+    dropzone_user_dropzone_public_key_aggregate?: [
+      {
+        /** input parameters for function "dropzone_user_dropzone_public_key_aggregate" */
+        args: ResolverInputTypes["dropzone_user_dropzone_public_key_args"] /** distinct select on columns */;
+        distinct_on?:
+          | Array<ResolverInputTypes["auth_public_keys_select_column"]>
+          | undefined
+          | null /** limit the number of rows returned */;
+        limit?:
+          | number
+          | undefined
+          | null /** skip the first n rows. Use only with order_by */;
+        offset?:
+          | number
+          | undefined
+          | null /** sort the rows by one or more columns */;
+        order_by?:
+          | Array<ResolverInputTypes["auth_public_keys_order_by"]>
+          | undefined
+          | null /** filter the rows returned */;
+        where?:
+          | ResolverInputTypes["auth_public_keys_bool_exp"]
+          | undefined
+          | null;
+      },
+      ResolverInputTypes["auth_public_keys_aggregate"]
+    ];
     invitations?: [
       {
         /** distinct select on columns */
@@ -11588,6 +11934,7 @@ export type ResolverInputTypes = {
     _neq?: ResolverInputTypes["timestamptz"] | undefined | null;
     _nin?: Array<ResolverInputTypes["timestamptz"]> | undefined | null;
   };
+  ["users_scalar"]: unknown;
   ["uuid"]: unknown;
   /** Boolean expression to compare columns of type "uuid". All fields are combined with logical 'AND'. */
   ["uuid_comparison_exp"]: {
@@ -12805,6 +13152,8 @@ export type ModelTypes = {
   ["auth_user_nfts_update_column"]: auth_user_nfts_update_column;
   /** columns and relationships of "auth.users" */
   ["auth_users"]: {
+    /** the user's first solana public key inside an array due to hasura limitation */
+    dropzone_public_key?: Array<ModelTypes["auth_public_keys"]> | undefined;
     id: ModelTypes["uuid"];
     /** An array relationship */
     public_keys: Array<ModelTypes["auth_public_keys"]>;
@@ -12855,6 +13204,7 @@ export type ModelTypes = {
     _and?: Array<ModelTypes["auth_users_bool_exp"]> | undefined;
     _not?: ModelTypes["auth_users_bool_exp"] | undefined;
     _or?: Array<ModelTypes["auth_users_bool_exp"]> | undefined;
+    dropzone_public_key?: ModelTypes["auth_public_keys_bool_exp"] | undefined;
     id?: ModelTypes["uuid_comparison_exp"] | undefined;
     public_keys?: ModelTypes["auth_public_keys_bool_exp"] | undefined;
     public_keys_aggregate?:
@@ -12921,6 +13271,9 @@ export type ModelTypes = {
   };
   /** Ordering options when selecting data from "auth.users". */
   ["auth_users_order_by"]: {
+    dropzone_public_key_aggregate?:
+      | ModelTypes["auth_public_keys_aggregate_order_by"]
+      | undefined;
     id?: ModelTypes["order_by"] | undefined;
     public_keys_aggregate?:
       | ModelTypes["auth_public_keys_aggregate_order_by"]
@@ -13249,6 +13602,9 @@ export type ModelTypes = {
     id?: string | undefined;
   };
   ["dropzone_distributors_update_column"]: dropzone_distributors_update_column;
+  ["dropzone_user_dropzone_public_key_args"]: {
+    user_row?: ModelTypes["users_scalar"] | undefined;
+  };
   /** columns and relationships of "invitations" */
   ["invitations"]: {
     claimed_at?: ModelTypes["timestamptz"] | undefined;
@@ -13656,6 +14012,12 @@ export type ModelTypes = {
     dropzone_distributors_by_pk?:
       | ModelTypes["dropzone_distributors"]
       | undefined;
+    /** execute function "dropzone.user_dropzone_public_key" which returns "auth.public_keys" */
+    dropzone_user_dropzone_public_key?:
+      | ModelTypes["auth_public_keys"]
+      | undefined;
+    /** execute function "dropzone.user_dropzone_public_key" and query aggregates on result of table type "auth.public_keys" */
+    dropzone_user_dropzone_public_key_aggregate: ModelTypes["auth_public_keys_aggregate"];
     /** fetch data from the table: "invitations" */
     invitations: Array<ModelTypes["invitations"]>;
     /** fetch aggregated fields from the table: "invitations" */
@@ -13764,6 +14126,12 @@ export type ModelTypes = {
       | undefined;
     /** fetch data from the table in a streaming manner: "dropzone.distributors" */
     dropzone_distributors_stream: Array<ModelTypes["dropzone_distributors"]>;
+    /** execute function "dropzone.user_dropzone_public_key" which returns "auth.public_keys" */
+    dropzone_user_dropzone_public_key?:
+      | ModelTypes["auth_public_keys"]
+      | undefined;
+    /** execute function "dropzone.user_dropzone_public_key" and query aggregates on result of table type "auth.public_keys" */
+    dropzone_user_dropzone_public_key_aggregate: ModelTypes["auth_public_keys_aggregate"];
     /** fetch data from the table: "invitations" */
     invitations: Array<ModelTypes["invitations"]>;
     /** fetch aggregated fields from the table: "invitations" */
@@ -13784,6 +14152,7 @@ export type ModelTypes = {
     _neq?: ModelTypes["timestamptz"] | undefined;
     _nin?: Array<ModelTypes["timestamptz"]> | undefined;
   };
+  ["users_scalar"]: any;
   ["uuid"]: any;
   /** Boolean expression to compare columns of type "uuid". All fields are combined with logical 'AND'. */
   ["uuid_comparison_exp"]: {
@@ -15097,6 +15466,8 @@ export type GraphQLTypes = {
   /** columns and relationships of "auth.users" */
   ["auth_users"]: {
     __typename: "auth_users";
+    /** the user's first solana public key inside an array due to hasura limitation */
+    dropzone_public_key?: Array<GraphQLTypes["auth_public_keys"]> | undefined;
     id: GraphQLTypes["uuid"];
     /** An array relationship */
     public_keys: Array<GraphQLTypes["auth_public_keys"]>;
@@ -15149,6 +15520,7 @@ export type GraphQLTypes = {
     _and?: Array<GraphQLTypes["auth_users_bool_exp"]> | undefined;
     _not?: GraphQLTypes["auth_users_bool_exp"] | undefined;
     _or?: Array<GraphQLTypes["auth_users_bool_exp"]> | undefined;
+    dropzone_public_key?: GraphQLTypes["auth_public_keys_bool_exp"] | undefined;
     id?: GraphQLTypes["uuid_comparison_exp"] | undefined;
     public_keys?: GraphQLTypes["auth_public_keys_bool_exp"] | undefined;
     public_keys_aggregate?:
@@ -15221,6 +15593,9 @@ export type GraphQLTypes = {
   };
   /** Ordering options when selecting data from "auth.users". */
   ["auth_users_order_by"]: {
+    dropzone_public_key_aggregate?:
+      | GraphQLTypes["auth_public_keys_aggregate_order_by"]
+      | undefined;
     id?: GraphQLTypes["order_by"] | undefined;
     public_keys_aggregate?:
       | GraphQLTypes["auth_public_keys_aggregate_order_by"]
@@ -15571,6 +15946,9 @@ export type GraphQLTypes = {
   };
   /** placeholder for update columns of table "dropzone.distributors" (current role has no relevant permissions) */
   ["dropzone_distributors_update_column"]: dropzone_distributors_update_column;
+  ["dropzone_user_dropzone_public_key_args"]: {
+    user_row?: GraphQLTypes["users_scalar"] | undefined;
+  };
   /** columns and relationships of "invitations" */
   ["invitations"]: {
     __typename: "invitations";
@@ -16007,6 +16385,12 @@ export type GraphQLTypes = {
     dropzone_distributors_by_pk?:
       | GraphQLTypes["dropzone_distributors"]
       | undefined;
+    /** execute function "dropzone.user_dropzone_public_key" which returns "auth.public_keys" */
+    dropzone_user_dropzone_public_key?:
+      | GraphQLTypes["auth_public_keys"]
+      | undefined;
+    /** execute function "dropzone.user_dropzone_public_key" and query aggregates on result of table type "auth.public_keys" */
+    dropzone_user_dropzone_public_key_aggregate: GraphQLTypes["auth_public_keys_aggregate"];
     /** fetch data from the table: "invitations" */
     invitations: Array<GraphQLTypes["invitations"]>;
     /** fetch aggregated fields from the table: "invitations" */
@@ -16118,6 +16502,12 @@ export type GraphQLTypes = {
       | undefined;
     /** fetch data from the table in a streaming manner: "dropzone.distributors" */
     dropzone_distributors_stream: Array<GraphQLTypes["dropzone_distributors"]>;
+    /** execute function "dropzone.user_dropzone_public_key" which returns "auth.public_keys" */
+    dropzone_user_dropzone_public_key?:
+      | GraphQLTypes["auth_public_keys"]
+      | undefined;
+    /** execute function "dropzone.user_dropzone_public_key" and query aggregates on result of table type "auth.public_keys" */
+    dropzone_user_dropzone_public_key_aggregate: GraphQLTypes["auth_public_keys_aggregate"];
     /** fetch data from the table: "invitations" */
     invitations: Array<GraphQLTypes["invitations"]>;
     /** fetch aggregated fields from the table: "invitations" */
@@ -16138,6 +16528,7 @@ export type GraphQLTypes = {
     _neq?: GraphQLTypes["timestamptz"] | undefined;
     _nin?: Array<GraphQLTypes["timestamptz"]> | undefined;
   };
+  ["users_scalar"]: "scalar" & { name: "users_scalar" };
   ["uuid"]: "scalar" & { name: "uuid" };
   /** Boolean expression to compare columns of type "uuid". All fields are combined with logical 'AND'. */
   ["uuid_comparison_exp"]: {
@@ -16627,6 +17018,7 @@ type ZEUS_VARIABLES = {
   ["dropzone_distributors_stream_cursor_input"]: ValueTypes["dropzone_distributors_stream_cursor_input"];
   ["dropzone_distributors_stream_cursor_value_input"]: ValueTypes["dropzone_distributors_stream_cursor_value_input"];
   ["dropzone_distributors_update_column"]: ValueTypes["dropzone_distributors_update_column"];
+  ["dropzone_user_dropzone_public_key_args"]: ValueTypes["dropzone_user_dropzone_public_key_args"];
   ["invitations_bool_exp"]: ValueTypes["invitations_bool_exp"];
   ["invitations_order_by"]: ValueTypes["invitations_order_by"];
   ["invitations_select_column"]: ValueTypes["invitations_select_column"];
@@ -16638,6 +17030,7 @@ type ZEUS_VARIABLES = {
   ["order_by"]: ValueTypes["order_by"];
   ["timestamptz"]: ValueTypes["timestamptz"];
   ["timestamptz_comparison_exp"]: ValueTypes["timestamptz_comparison_exp"];
+  ["users_scalar"]: ValueTypes["users_scalar"];
   ["uuid"]: ValueTypes["uuid"];
   ["uuid_comparison_exp"]: ValueTypes["uuid_comparison_exp"];
 };

--- a/backend/reef/hasura/metadata/databases/databases.yaml
+++ b/backend/reef/hasura/metadata/databases/databases.yaml
@@ -9,3 +9,4 @@
   customization:
     naming_convention: hasura-default
   tables: "!include default/tables/tables.yaml"
+  functions: "!include default/functions/functions.yaml"

--- a/backend/reef/hasura/metadata/databases/default/functions/dropzone_user_dropzone_public_key.yaml
+++ b/backend/reef/hasura/metadata/databases/default/functions/dropzone_user_dropzone_public_key.yaml
@@ -1,0 +1,3 @@
+function:
+  name: user_dropzone_public_key
+  schema: dropzone

--- a/backend/reef/hasura/metadata/databases/default/functions/functions.yaml
+++ b/backend/reef/hasura/metadata/databases/default/functions/functions.yaml
@@ -1,0 +1,1 @@
+- "!include dropzone_user_dropzone_public_key.yaml"

--- a/backend/reef/hasura/metadata/databases/default/tables/auth_users.yaml
+++ b/backend/reef/hasura/metadata/databases/default/tables/auth_users.yaml
@@ -53,6 +53,13 @@ array_relationships:
         table:
           name: users
           schema: auth
+computed_fields:
+  - name: dropzone_public_key
+    definition:
+      function:
+        name: user_dropzone_public_key
+        schema: dropzone
+    comment: the user's first solana public key inside an array due to hasura limitation
 insert_permissions:
   - role: auth_worker
     permission:

--- a/backend/reef/hasura/migrations/default/1674856382237_add_user_dropzone_public_key_function/down.sql
+++ b/backend/reef/hasura/migrations/default/1674856382237_add_user_dropzone_public_key_function/down.sql
@@ -1,0 +1,1 @@
+DROP FUNCTION IF EXISTS dropzone.user_dropzone_public_key;

--- a/backend/reef/hasura/migrations/default/1674856382237_add_user_dropzone_public_key_function/up.sql
+++ b/backend/reef/hasura/migrations/default/1674856382237_add_user_dropzone_public_key_function/up.sql
@@ -1,0 +1,7 @@
+CREATE FUNCTION dropzone.user_dropzone_public_key(user_row auth.users)
+RETURNS auth.public_keys AS $$
+  SELECT *
+  FROM auth.public_keys
+  WHERE auth.public_keys.user_id = user_row.id
+  LIMIT 1
+$$ LANGUAGE sql STABLE;

--- a/backend/reef/hasura/migrations/default/1674856382237_add_user_dropzone_public_key_function/up.sql
+++ b/backend/reef/hasura/migrations/default/1674856382237_add_user_dropzone_public_key_function/up.sql
@@ -3,5 +3,6 @@ RETURNS auth.public_keys AS $$
   SELECT *
   FROM auth.public_keys
   WHERE auth.public_keys.user_id = user_row.id
+  AND auth.public_keys.blockchain = 'solana'
   LIMIT 1
 $$ LANGUAGE sql STABLE;


### PR DESCRIPTION
adds a convenience method for returning the first solana public key owned by a user

<img width="822" alt="Screenshot 2023-01-27 at 22 02 53" src="https://user-images.githubusercontent.com/101902546/215212195-9b505213-ee5b-44e6-ac84-b43b8ce40e8c.png">

slightly confusingly the value is an array due to a current limitation of hasura https://github.com/hasura/graphql-engine/issues/6562

future work will allow users to pick their dropzone public key and warn them if they try to remove it with unclaimed drops