### PR TITLE
Fixed navigation in full screen chat mode

### DIFF
--- a/packages/app-extension/src/components/common/Layout/Router.tsx
+++ b/packages/app-extension/src/components/common/Layout/Router.tsx
@@ -356,6 +356,9 @@ function NavScreen({
   };
 }) {
   const { title, isRoot, pop } = useNavigation();
+  const { isXs } = useBreakpoints();
+  const pathname = useLocation().pathname;
+
   const {
     style,
     navButtonLeft,
@@ -368,7 +371,7 @@ function NavScreen({
 
   const _navButtonLeft = navButtonLeft ? (
     navButtonLeft
-  ) : isRoot ? null : (
+  ) : isRoot || (!isXs && pathname.startsWith("/messages")) ? null : (
     <NavBackButton onClick={() => pop()} />
   );
 

--- a/packages/app-extension/src/components/common/Layout/Router.tsx
+++ b/packages/app-extension/src/components/common/Layout/Router.tsx
@@ -371,7 +371,7 @@ function NavScreen({
 
   const _navButtonLeft = navButtonLeft ? (
     navButtonLeft
-  ) : isRoot || (!isXs && pathname.startsWith("/messages")) ? null : (
+  ) : isRoot ? null : (
     <NavBackButton onClick={() => pop()} />
   );
 

--- a/packages/app-extension/src/components/common/Layout/Router.tsx
+++ b/packages/app-extension/src/components/common/Layout/Router.tsx
@@ -356,8 +356,6 @@ function NavScreen({
   };
 }) {
   const { title, isRoot, pop } = useNavigation();
-  const { isXs } = useBreakpoints();
-  const pathname = useLocation().pathname;
 
   const {
     style,

--- a/packages/background/src/backend/core.ts
+++ b/packages/background/src/backend/core.ts
@@ -21,7 +21,6 @@ import {
   EthereumExplorer,
   getAddMessage,
   LOAD_PUBLIC_KEY_AMOUNT,
-  NOTIFICATION_KEY_IS_COLD_UPDATE,
   NOTIFICATION_ACTIVE_BLOCKCHAIN_UPDATED,
   NOTIFICATION_AGGREGATE_WALLETS_UPDATED,
   NOTIFICATION_APPROVED_ORIGINS_UPDATE,
@@ -35,6 +34,7 @@ import {
   NOTIFICATION_ETHEREUM_CONNECTION_URL_UPDATED,
   NOTIFICATION_ETHEREUM_EXPLORER_UPDATED,
   NOTIFICATION_FEATURE_GATES_UPDATED,
+  NOTIFICATION_KEY_IS_COLD_UPDATE,
   NOTIFICATION_KEYNAME_UPDATE,
   NOTIFICATION_KEYRING_DERIVED_WALLET,
   NOTIFICATION_KEYRING_IMPORTED_SECRET_KEY,
@@ -1629,7 +1629,11 @@ export class Backend {
   // Navigation.
   ///////////////////////////////////////////////////////////////////////////////
 
-  async navigationPush(url: string, tab?: string): Promise<string> {
+  async navigationPush(
+    url: string,
+    tab?: string,
+    pushAboveRoot?: boolean
+  ): Promise<string> {
     let nav = await store.getNav();
     if (!nav) {
       throw new Error("nav not found");
@@ -1642,6 +1646,10 @@ export class Backend {
 
     if (urls.length > 0 && urls[urls.length - 1] === url) {
       return SUCCESS_RESPONSE;
+    }
+
+    if (pushAboveRoot && nav.data[targetTab].urls[0]) {
+      nav.data[targetTab].urls = [nav.data[targetTab].urls[0]];
     }
 
     nav.data[targetTab].urls.push(url);

--- a/packages/background/src/frontend/server-ui.ts
+++ b/packages/background/src/frontend/server-ui.ts
@@ -20,7 +20,6 @@ import {
   ChannelAppUi,
   getLogger,
   TAB_XNFT,
-  UI_RPC_METHOD_KEY_IS_COLD_UPDATE,
   UI_RPC_METHOD_ACTIVE_USER_UPDATE,
   UI_RPC_METHOD_ALL_USERS_READ,
   UI_RPC_METHOD_APPROVED_ORIGINS_DELETE,
@@ -39,6 +38,7 @@ import {
   UI_RPC_METHOD_ETHEREUM_SIGN_TRANSACTION,
   UI_RPC_METHOD_GET_FEATURE_GATES,
   UI_RPC_METHOD_GET_XNFT_PREFERENCES,
+  UI_RPC_METHOD_KEY_IS_COLD_UPDATE,
   UI_RPC_METHOD_KEYNAME_READ,
   UI_RPC_METHOD_KEYNAME_UPDATE,
   UI_RPC_METHOD_KEYRING_ACTIVE_WALLET_UPDATE,
@@ -239,7 +239,7 @@ async function handle<T = any>(
     // Navigation.
     //
     case UI_RPC_METHOD_NAVIGATION_PUSH:
-      return await handleNavigationPush(ctx, params[0], params[1]);
+      return await handleNavigationPush(ctx, params[0], params[1], params[2]);
     case UI_RPC_METHOD_NAVIGATION_POP:
       return await handleNavigationPop(ctx, params[0]);
     case UI_RPC_METHOD_NAVIGATION_CURRENT_URL_UPDATE:
@@ -744,9 +744,10 @@ async function handleKeyringTypeRead(ctx: Context<Backend>) {
 async function handleNavigationPush(
   ctx: Context<Backend>,
   url: string,
-  tab?: string
+  tab?: string,
+  pushAboveRoot?: boolean
 ): Promise<RpcResponse<string>> {
-  const resp = await ctx.backend.navigationPush(url, tab);
+  const resp = await ctx.backend.navigationPush(url, tab, pushAboveRoot);
   return [resp];
 }
 

--- a/packages/message-sdk/src/ParentCommunicationManager.ts
+++ b/packages/message-sdk/src/ParentCommunicationManager.ts
@@ -87,7 +87,12 @@ export class ParentCommunicationManager {
     this.nativePop?.();
   }
 
-  push(props: { title: string; componentId: string; componentProps: any }) {
+  push(props: {
+    title: string;
+    componentId: string;
+    componentProps: any;
+    pushAboveRoot?: boolean;
+  }) {
     if (IFRAME_HOSTED) {
       window.parent.postMessage(
         {

--- a/packages/message-sdk/src/components/MessageList.tsx
+++ b/packages/message-sdk/src/components/MessageList.tsx
@@ -29,12 +29,14 @@ import { useStyles } from "./styles";
 export const MessageList = ({
   activeChats,
   requestCount = 0,
+  toRoot = true,
 }: {
   activeChats: (
     | { chatType: "individual"; chatProps: EnrichedInboxDb }
     | { chatType: "collection"; chatProps: CollectionChatData }
   )[];
   requestCount?: number;
+  toRoot?: boolean;
 }) => {
   const theme = useCustomTheme();
 
@@ -57,6 +59,7 @@ export const MessageList = ({
         )}
         {activeChats.map((activeChat, index) => (
           <ChatListItem
+            toRoot={toRoot}
             type={activeChat.chatType}
             image={
               activeChat.chatType === "individual"
@@ -110,6 +113,7 @@ export function ChatListItem({
   isLast,
   id,
   isUnread,
+  toRoot,
 }: {
   type: SubscriptionType;
   image: string;
@@ -120,6 +124,7 @@ export function ChatListItem({
   isLast: boolean;
   id: string;
   isUnread: boolean;
+  toRoot: boolean;
 }) {
   const classes = useStyles();
   const { uuid } = useUser();
@@ -161,6 +166,7 @@ export function ChatListItem({
             id: id,
             fromInbox: true,
           },
+          pushAboveRoot: toRoot,
         });
       }}
       style={{
@@ -211,6 +217,8 @@ export function ChatListItem({
                     componentProps: {
                       userId: id,
                     },
+
+                    pushAboveRoot: toRoot,
                   });
                 }}
                 image={image}
@@ -293,6 +301,7 @@ export function RequestsChatItem({
           title: `Requests`,
           componentId: NAV_COMPONENT_MESSAGE_REQUESTS,
           componentProps: {},
+          pushAboveRoot: true,
         });
       }}
       style={{

--- a/packages/message-sdk/src/components/ProfileScreen.tsx
+++ b/packages/message-sdk/src/components/ProfileScreen.tsx
@@ -36,7 +36,7 @@ export const ProfileScreen = ({ userId }: { userId: string }) => {
   const classes = useStyles();
   const theme = useCustomTheme();
   const userMetadata = useUsersMetadata({ remoteUserIds: [userId] });
-  const { push, toRoot } = useNavigation();
+  const { push } = useNavigation();
 
   async function getChatRoom() {
     const res = await ParentCommunicationManager.getInstance().fetch(
@@ -97,7 +97,6 @@ export const ProfileScreen = ({ userId }: { userId: string }) => {
               size={"large"}
               className={classes.icon}
               onClick={async () => {
-                await toRoot();
                 push({
                   title: `@${user.username}`,
                   componentId: NAV_COMPONENT_MESSAGE_CHAT,

--- a/packages/message-sdk/src/components/RequestsScreen.tsx
+++ b/packages/message-sdk/src/components/RequestsScreen.tsx
@@ -29,6 +29,7 @@ export const RequestsScreen = () => {
       </div>
       {activeChats.length !== 0 && (
         <MessageList
+          toRoot={false}
           activeChats={activeChats.map((x) => ({
             chatType: "individual",
             chatProps: x,

--- a/packages/recoil/src/hooks/navigation.tsx
+++ b/packages/recoil/src/hooks/navigation.tsx
@@ -79,10 +79,12 @@ export function useNavigationSegue() {
       title,
       componentId,
       componentProps,
+      pushAboveRoot,
     }: {
       title: string;
       componentId: string;
       componentProps: any;
+      pushAboveRoot?: boolean;
     },
     tab?: string
   ) => {
@@ -92,7 +94,7 @@ export function useNavigationSegue() {
     });
     return await background.request({
       method: UI_RPC_METHOD_NAVIGATION_PUSH,
-      params: [url, tab, !isXs && url.startsWith("/messages") ? true : false],
+      params: [url, tab, !isXs && pushAboveRoot ? true : false],
     });
   };
   const pop = async (tab?: string) => {

--- a/packages/recoil/src/hooks/navigation.tsx
+++ b/packages/recoil/src/hooks/navigation.tsx
@@ -1,5 +1,6 @@
 import { useCallback } from "react";
 import { useLocation, useSearchParams } from "react-router-dom";
+import { useBreakpoints } from "@coral-xyz/app-extension/src/components/common/Layout/hooks";
 import type { Blockchain } from "@coral-xyz/common";
 import {
   TAB_SET,
@@ -71,6 +72,7 @@ export function useUpdateSearchParams(): (params: URLSearchParams) => void {
 
 export function useNavigationSegue() {
   const background = useRecoilValue(atoms.backgroundClient);
+  const { isXs } = useBreakpoints();
 
   const push = async (
     {
@@ -90,7 +92,7 @@ export function useNavigationSegue() {
     });
     return await background.request({
       method: UI_RPC_METHOD_NAVIGATION_PUSH,
-      params: [url, tab],
+      params: [url, tab, !isXs && url.startsWith("/messages") ? true : false],
     });
   };
   const pop = async (tab?: string) => {


### PR DESCRIPTION
In full screen mode, we keep pushing messages on the stack as we navigate. This causes the stack to fill up. If you now open chat in small mode, you have to pop through a bunch of screens to reach the root

This PR solves this by always being at `root + 1` state if you're in full screen mode in chats.
That way as you navigate, the stack doesn't get filled up

We also hide the `back button` in full screen mode


Longer term soln might be to have a full screen nav stack