### PR TITLE
standardize popover menu into common custom component

### DIFF
--- a/packages/app-extension/src/components/Unlocked/Messages/MessageOptions.tsx
+++ b/packages/app-extension/src/components/Unlocked/Messages/MessageOptions.tsx
@@ -9,9 +9,10 @@ import { toast } from "@coral-xyz/react-common";
 import { friendship, useDecodedSearchParams } from "@coral-xyz/recoil";
 import { useCustomTheme } from "@coral-xyz/themes";
 import MoreHorizIcon from "@mui/icons-material/MoreHoriz";
-import { Fade, Menu, MenuItem } from "@mui/material";
-import Divider from "@mui/material/Divider";
+import { Fade } from "@mui/material";
 import { useRecoilState } from "recoil";
+
+import PopoverMenu from "../../common/PopoverMenu";
 
 import { useStyles } from "./styles";
 
@@ -54,20 +55,15 @@ export const MessageOptions = () => {
         onClick={handleClick}
         style={{ cursor: "pointer", color: theme.custom.colors.icon }}
       />
-      <Menu
-        id="fade-menu"
-        MenuListProps={{
-          "aria-labelledby": "fade-button",
-        }}
-        anchorEl={anchorEl}
+      <PopoverMenu.Root
         open={open}
+        anchorEl={anchorEl}
+        anchorOrigin={{ vertical: "bottom", horizontal: "left" }}
         onClose={handleClose}
         TransitionComponent={Fade}
-        className={classes.menu}
       >
-        <div style={{ background: theme.custom.colors.background }}>
-          <MenuItem
-            className={classes.menuItem}
+        <PopoverMenu.Group>
+          <PopoverMenu.Item
             disabled={friendshipValue?.blocked}
             onClick={async () => {
               if (friendshipValue?.areFriends) {
@@ -103,10 +99,10 @@ export const MessageOptions = () => {
               : friendshipValue?.remoteRequested
               ? "Accept Contact Request"
               : "Add to contacts"}
-          </MenuItem>
-          <Divider style={{ marginTop: 0, marginBottom: 0 }} />
-          <MenuItem
-            className={classes.menuItem}
+          </PopoverMenu.Item>
+        </PopoverMenu.Group>
+        <PopoverMenu.Group>
+          <PopoverMenu.Item
             disabled={friendshipValue?.spam}
             onClick={async () => {
               const updatedValue = !friendshipValue?.blocked;
@@ -132,9 +128,8 @@ export const MessageOptions = () => {
             }}
           >
             {friendshipValue?.blocked ? "Unblock" : "Block"}
-          </MenuItem>
-          <MenuItem
-            className={classes.menuItem}
+          </PopoverMenu.Item>
+          <PopoverMenu.Item
             onClick={async () => {
               const updatedValue = !friendshipValue?.spam;
               await fetch(`${BACKEND_API_URL}/friends/spam`, {
@@ -152,9 +147,9 @@ export const MessageOptions = () => {
             }}
           >
             {friendshipValue?.spam ? `Remove spam` : `Mark as spam`}
-          </MenuItem>
-        </div>
-      </Menu>
+          </PopoverMenu.Item>
+        </PopoverMenu.Group>
+      </PopoverMenu.Root>
     </div>
   );
 };

--- a/packages/app-extension/src/components/Unlocked/Nfts/Detail.tsx
+++ b/packages/app-extension/src/components/Unlocked/Nfts/Detail.tsx
@@ -14,8 +14,6 @@ import {
   WHITELISTED_CHAT_COLLECTIONS,
 } from "@coral-xyz/common";
 import {
-  List,
-  ListItem,
   NegativeButton,
   PrimaryButton,
   ProxyImage,
@@ -37,9 +35,9 @@ import {
   useUser,
 } from "@coral-xyz/recoil";
 import { useCustomTheme } from "@coral-xyz/themes";
-import { CallMade, Whatshot } from "@mui/icons-material";
+import { Whatshot } from "@mui/icons-material";
 import MoreHorizIcon from "@mui/icons-material/MoreHoriz";
-import { IconButton, Popover, Typography } from "@mui/material";
+import { IconButton, Typography } from "@mui/material";
 import { PublicKey } from "@solana/web3.js";
 import { BigNumber } from "ethers";
 import { useRecoilValueLoadable, useSetRecoilState } from "recoil";
@@ -54,6 +52,7 @@ import {
   NavStackEphemeral,
   NavStackScreen,
 } from "../../common/Layout/NavStack";
+import PopoverMenu from "../../common/PopoverMenu";
 import { SendEthereumConfirmationCard } from "../Balances/TokensWidget/Ethereum";
 import {
   Error as ErrorConfirmation,
@@ -553,83 +552,32 @@ export function NftOptionsButton() {
           }}
         />
       </IconButton>
-      <Popover
+      <PopoverMenu.Root
         open={Boolean(anchorEl)}
         anchorEl={anchorEl}
         onClose={onClose}
-        anchorOrigin={{
-          vertical: "bottom",
-          horizontal: "right",
-        }}
-        PaperProps={{
-          style: {
-            background: theme.custom.colors.nav,
-          },
-        }}
+        anchorOrigin={{ vertical: "bottom", horizontal: "right" }}
       >
-        <div
-          style={{
-            padding: "4px",
-          }}
-        >
-          <List
-            style={{
-              margin: 0,
+        <PopoverMenu.Group>
+          <PopoverMenu.Item
+            onClick={() => {
+              const url = explorerNftUrl(explorer, nft, connectionUrl);
+              window.open(url, "_blank");
             }}
           >
-            <ListItem
-              style={{
-                width: "100%",
-                height: "30px",
-              }}
-              isFirst={true}
-              isLast={isEthereum}
-              onClick={() => {
-                const url = explorerNftUrl(explorer, nft, connectionUrl);
-                window.open(url, "_blank");
-              }}
-            >
-              <Typography
-                style={{
-                  fontSize: "14px",
-                }}
-              >
-                View on Explorer
-              </Typography>
-              <CallMade
-                style={{
-                  color: theme.custom.colors.secondary,
-                }}
-              />
-            </ListItem>
-            <ListItem
-              style={{ width: "100%", height: "30px" }}
-              onClick={onSetPfp}
-            >
-              <Typography style={{ fontSize: "14px" }}>Set as PFP</Typography>
-            </ListItem>
-            {!isEthereum && (
-              <ListItem
-                style={{
-                  width: "100%",
-                  height: "30px",
-                }}
-                isLast={true}
-                onClick={() => onBurn()}
-              >
-                <Typography
-                  style={{
-                    fontSize: "14px",
-                    color: theme.custom.colors.negative,
-                  }}
-                >
-                  Burn Token
-                </Typography>
-              </ListItem>
-            )}
-          </List>
-        </div>
-      </Popover>
+            View on Explorer
+          </PopoverMenu.Item>
+          <PopoverMenu.Item onClick={onSetPfp}>Set as PFP</PopoverMenu.Item>
+        </PopoverMenu.Group>
+        <PopoverMenu.Group>
+          <PopoverMenu.Item
+            sx={{ color: `${theme.custom.colors.negative} !important` }}
+            onClick={onBurn}
+          >
+            Burn Token
+          </PopoverMenu.Item>
+        </PopoverMenu.Group>
+      </PopoverMenu.Root>
       <ApproveTransactionDrawer
         openDrawer={openDrawer}
         setOpenDrawer={setOpenDrawer}

--- a/packages/app-extension/src/components/common/PopoverMenu.tsx
+++ b/packages/app-extension/src/components/common/PopoverMenu.tsx
@@ -1,0 +1,74 @@
+import type { FunctionComponent } from "react";
+import { useCustomTheme } from "@coral-xyz/themes";
+import Button, { type ButtonProps } from "@mui/material/Button";
+import Popover, { type PopoverProps } from "@mui/material/Popover";
+
+export const PopoverMenu: FunctionComponent<PopoverProps> = ({
+  children,
+  ...rest
+}) => {
+  const theme = useCustomTheme();
+  return (
+    <Popover {...rest}>
+      <div
+        style={{
+          width: "100%",
+          background: theme.custom.colors.background,
+          padding: 3,
+          display: "flex",
+          flexDirection: "column",
+          gap: 2,
+        }}
+      >
+        {children}
+      </div>
+    </Popover>
+  );
+};
+
+export const PopoverMenuItemGroup: FunctionComponent = ({ children }) => {
+  const theme = useCustomTheme();
+  return (
+    <div
+      style={{
+        background: theme.custom.colors.nav,
+        borderRadius: 2,
+        padding: "2px 0",
+        display: "flex",
+        flexDirection: "column",
+      }}
+    >
+      {children}
+    </div>
+  );
+};
+
+export const PopoverMenuItem: FunctionComponent<ButtonProps> = ({
+  children,
+  style,
+  ...rest
+}) => {
+  const theme = useCustomTheme();
+  return (
+    <Button
+      disableRipple
+      style={{
+        textTransform: "none",
+        color: theme.custom.colors.fontColor,
+        fontSize: "14px",
+        padding: "8px 16px",
+        display: "inline",
+        ...style,
+      }}
+      {...rest}
+    >
+      <div style={{ display: "flex", alignItems: "center" }}>{children}</div>
+    </Button>
+  );
+};
+
+export default {
+  Group: PopoverMenuItemGroup,
+  Item: PopoverMenuItem,
+  Root: PopoverMenu,
+};

--- a/packages/app-extension/src/components/common/PopoverMenu.tsx
+++ b/packages/app-extension/src/components/common/PopoverMenu.tsx
@@ -14,7 +14,7 @@ export const PopoverMenu: FunctionComponent<PopoverProps> = ({
         style={{
           width: "100%",
           background: theme.custom.colors.background,
-          padding: 3,
+          padding: 2,
           display: "flex",
           flexDirection: "column",
           gap: 2,


### PR DESCRIPTION
closes #2306 

Custom `PopoverMenu` and related children components were designed to look and operate like the current avatar popover menu.

<img width="256" alt="image" src="https://user-images.githubusercontent.com/13121516/216215245-9b2d908f-41bf-47a2-899e-10b3d75c0eb4.png">
<img width="209" alt="image" src="https://user-images.githubusercontent.com/13121516/216215314-ccf6bde2-8fb5-43d1-a912-01942109f143.png">
