### PR TITLE
fix extra rerenders closing wallet list

### DIFF
--- a/packages/app-extension/src/components/Unlocked/Settings/AddConnectWallet/ImportSecretKey.tsx
+++ b/packages/app-extension/src/components/Unlocked/Settings/AddConnectWallet/ImportSecretKey.tsx
@@ -14,7 +14,10 @@ import * as bs58 from "bs58";
 import { ethers } from "ethers";
 
 import { Header, SubtextParagraph } from "../../../common";
-import { WithMiniDrawer } from "../../../common/Layout/Drawer";
+import {
+  useDrawerContext,
+  WithMiniDrawer,
+} from "../../../common/Layout/Drawer";
 import { useNavStack } from "../../../common/Layout/NavStack";
 
 import { ConfirmCreateWallet } from ".";
@@ -36,6 +39,7 @@ export function ImportSecretKey({
   const [openDrawer, setOpenDrawer] = useState(false);
   const [newPublicKey, setNewPublicKey] = useState("");
   const [loading, setLoading] = useState(false);
+  const { close: closeParentDrawer } = useDrawerContext();
 
   useEffect(() => {
     const prevTitle = nav.title;
@@ -165,7 +169,10 @@ export function ImportSecretKey({
         <ConfirmCreateWallet
           blockchain={blockchain}
           publicKey={newPublicKey}
-          setOpenDrawer={setOpenDrawer}
+          onClose={() => {
+            setOpenDrawer(false);
+            closeParentDrawer();
+          }}
         />
       </WithMiniDrawer>
     </>

--- a/packages/app-extension/src/components/Unlocked/Settings/AddConnectWallet/index.tsx
+++ b/packages/app-extension/src/components/Unlocked/Settings/AddConnectWallet/index.tsx
@@ -3,13 +3,10 @@ import type { Blockchain } from "@coral-xyz/common";
 import {
   openAddUserAccount,
   openConnectHardware,
-  TAB_APPS,
-  TAB_BALANCES,
   UI_RPC_METHOD_BLOCKCHAIN_KEYRINGS_ADD,
   UI_RPC_METHOD_BLOCKCHAIN_KEYRINGS_READ,
   UI_RPC_METHOD_FIND_SIGNED_WALLET_DESCRIPTOR,
   UI_RPC_METHOD_KEYRING_DERIVE_WALLET,
-  UI_RPC_METHOD_NAVIGATION_ACTIVE_TAB_UPDATE,
 } from "@coral-xyz/common";
 import {
   CheckIcon,
@@ -192,6 +189,7 @@ export function AddWalletMenu({
   const [newPublicKey, setNewPublicKey] = useState("");
   const [openDrawer, setOpenDrawer] = useState(false);
   const [loading, setLoading] = useState(false);
+  const { close: closeParentDrawer } = useDrawerContext();
 
   // Lock to ensure that the create new wallet button cannot be accidentally
   // spammed or double clicked, which is undesireable as it creates more wallets
@@ -317,7 +315,10 @@ export function AddWalletMenu({
         <ConfirmCreateWallet
           blockchain={blockchain}
           publicKey={newPublicKey}
-          setOpenDrawer={setOpenDrawer}
+          onClose={() => {
+            setOpenDrawer(false);
+            closeParentDrawer();
+          }}
           isLoading={loading}
         />
       </WithMiniDrawer>
@@ -337,6 +338,7 @@ export function RecoverWalletMenu({
   const nav = useNavStack();
   const theme = useCustomTheme();
   const [openDrawer, setOpenDrawer] = useState(false);
+  const { close: closeParentDrawer } = useDrawerContext();
 
   return (
     <>
@@ -410,7 +412,10 @@ export function RecoverWalletMenu({
         <ConfirmCreateWallet
           blockchain={blockchain}
           publicKey={publicKey}
-          setOpenDrawer={setOpenDrawer}
+          onClose={() => {
+            setOpenDrawer(false);
+            closeParentDrawer();
+          }}
         />
       </WithMiniDrawer>
     </>
@@ -420,14 +425,14 @@ export function RecoverWalletMenu({
 export const ConfirmCreateWallet: React.FC<{
   blockchain: Blockchain;
   publicKey: string;
-  setOpenDrawer: (b: boolean) => void;
+  onClose: () => void;
   isLoading?: boolean;
-}> = ({ blockchain, publicKey, setOpenDrawer, isLoading = false }) => {
+}> = ({ blockchain, publicKey, onClose, isLoading = false }) => {
   const theme = useCustomTheme();
   const walletName = useWalletName(publicKey);
   const background = useBackgroundClient();
   const tab = useTab();
-  const { close } = useDrawerContext();
+
   return (
     <div
       style={{
@@ -474,23 +479,7 @@ export const ConfirmCreateWallet: React.FC<{
               isFirst={true}
               isLast={true}
               onClick={() => {
-                if (tab === TAB_BALANCES) {
-                  // Experience won't go back to TAB_BALANCES so we poke it
-                  background.request({
-                    method: UI_RPC_METHOD_NAVIGATION_ACTIVE_TAB_UPDATE,
-                    params: [TAB_APPS],
-                  });
-                }
-
-                background.request({
-                  method: UI_RPC_METHOD_NAVIGATION_ACTIVE_TAB_UPDATE,
-                  params: [TAB_BALANCES],
-                });
-
-                // Close mini drawer.
-                setOpenDrawer(false);
-                // Close main drawer.
-                close();
+                onClose();
               }}
             />
           </div>

--- a/packages/app-extension/src/components/Unlocked/Settings/AddConnectWallet/index.tsx
+++ b/packages/app-extension/src/components/Unlocked/Settings/AddConnectWallet/index.tsx
@@ -14,6 +14,7 @@ import {
 import {
   CheckIcon,
   HardwareWalletIcon,
+  Loading,
   PrimaryButton,
   ProxyImage,
   SecondaryButton,
@@ -190,6 +191,7 @@ export function AddWalletMenu({
   const theme = useCustomTheme();
   const [newPublicKey, setNewPublicKey] = useState("");
   const [openDrawer, setOpenDrawer] = useState(false);
+  const [loading, setLoading] = useState(false);
 
   // Lock to ensure that the create new wallet button cannot be accidentally
   // spammed or double clicked, which is undesireable as it creates more wallets
@@ -205,6 +207,8 @@ export function AddWalletMenu({
     if (lockCreateButton) {
       return;
     }
+    setOpenDrawer(true);
+    setLoading(true);
     setLockCreateButton(true);
     let newPublicKey;
     if (!keyringExists) {
@@ -226,7 +230,7 @@ export function AddWalletMenu({
       });
     }
     setNewPublicKey(newPublicKey);
-    setOpenDrawer(true);
+    setLoading(false);
     setLockCreateButton(false);
   };
 
@@ -314,6 +318,7 @@ export function AddWalletMenu({
           blockchain={blockchain}
           publicKey={newPublicKey}
           setOpenDrawer={setOpenDrawer}
+          isLoading={loading}
         />
       </WithMiniDrawer>
     </>
@@ -416,7 +421,8 @@ export const ConfirmCreateWallet: React.FC<{
   blockchain: Blockchain;
   publicKey: string;
   setOpenDrawer: (b: boolean) => void;
-}> = ({ blockchain, publicKey, setOpenDrawer }) => {
+  isLoading?: boolean;
+}> = ({ blockchain, publicKey, setOpenDrawer, isLoading = false }) => {
   const theme = useCustomTheme();
   const walletName = useWalletName(publicKey);
   const background = useBackgroundClient();
@@ -433,57 +439,63 @@ export const ConfirmCreateWallet: React.FC<{
         justifyContent: "space-between",
       }}
     >
-      <div>
-        <Typography
-          style={{
-            marginTop: "16px",
-            textAlign: "center",
-            fontWeight: 500,
-            fontSize: "18px",
-            lineHeight: "24px",
-            color: theme.custom.colors.fontColor,
-          }}
-        >
-          Wallet Created
-        </Typography>
-        <div
-          style={{
-            textAlign: "center",
-            marginTop: "24px",
-          }}
-        >
-          <CheckIcon />
-        </div>
-      </div>
-      <div>
-        <WalletListItem
-          blockchain={blockchain}
-          name={walletName}
-          publicKey={publicKey}
-          showDetailMenu={false}
-          isFirst={true}
-          isLast={true}
-          onClick={() => {
-            if (tab === TAB_BALANCES) {
-              // Experience won't go back to TAB_BALANCES so we poke it
-              background.request({
-                method: UI_RPC_METHOD_NAVIGATION_ACTIVE_TAB_UPDATE,
-                params: [TAB_APPS],
-              });
-            }
+      {isLoading ? (
+        <Loading />
+      ) : (
+        <>
+          <div>
+            <Typography
+              style={{
+                marginTop: "16px",
+                textAlign: "center",
+                fontWeight: 500,
+                fontSize: "18px",
+                lineHeight: "24px",
+                color: theme.custom.colors.fontColor,
+              }}
+            >
+              Wallet Created
+            </Typography>
+            <div
+              style={{
+                textAlign: "center",
+                marginTop: "24px",
+              }}
+            >
+              <CheckIcon />
+            </div>
+          </div>
+          <div>
+            <WalletListItem
+              blockchain={blockchain}
+              name={walletName}
+              publicKey={publicKey}
+              showDetailMenu={false}
+              isFirst={true}
+              isLast={true}
+              onClick={() => {
+                if (tab === TAB_BALANCES) {
+                  // Experience won't go back to TAB_BALANCES so we poke it
+                  background.request({
+                    method: UI_RPC_METHOD_NAVIGATION_ACTIVE_TAB_UPDATE,
+                    params: [TAB_APPS],
+                  });
+                }
 
-            background.request({
-              method: UI_RPC_METHOD_NAVIGATION_ACTIVE_TAB_UPDATE,
-              params: [TAB_BALANCES],
-            });
+                background.request({
+                  method: UI_RPC_METHOD_NAVIGATION_ACTIVE_TAB_UPDATE,
+                  params: [TAB_BALANCES],
+                });
 
-            // Close mini drawer.
-            setOpenDrawer(false);
-            // Close main drawer.
-            close();
-          }}
-        />
-      </div>
+                // Close mini drawer.
+                setOpenDrawer(false);
+                // Close main drawer.
+                close();
+              }}
+            />
+          </div>
+        </>
+      )}
     </div>
   );
 };

--- a/packages/app-extension/src/components/Unlocked/Settings/SettingsNavStackDrawer.tsx
+++ b/packages/app-extension/src/components/Unlocked/Settings/SettingsNavStackDrawer.tsx
@@ -1,6 +1,5 @@
 import {
   AllWalletsList,
-  WalletList as _WalletList,
   WalletListBlockchainSelector,
 } from "../../../components/common/WalletList";
 import { CloseButton, WithDrawer } from "../../common/Layout/Drawer";

--- a/packages/app-extension/src/components/Unlocked/index.tsx
+++ b/packages/app-extension/src/components/Unlocked/index.tsx
@@ -2,6 +2,7 @@ import { useBootstrapFast } from "@coral-xyz/recoil";
 
 import { Router } from "../common/Layout/Router";
 import { WithTabs } from "../common/Layout/Tab";
+import { WalletDrawerProvider } from "../common/WalletList";
 
 import { ApproveTransactionRequest } from "./ApproveTransactionRequest";
 import { WithVersion } from "./WithVersion";
@@ -15,16 +16,18 @@ export function Unlocked() {
   return (
     <WithVersion>
       <WithTabs>
-        <div
-          style={{
-            display: "flex",
-            flexDirection: "column",
-            height: "100%",
-          }}
-        >
-          <Router />
-          <ApproveTransactionRequest />
-        </div>
+        <WalletDrawerProvider>
+          <div
+            style={{
+              display: "flex",
+              flexDirection: "column",
+              height: "100%",
+            }}
+          >
+            <Router />
+            <ApproveTransactionRequest />
+          </div>
+        </WalletDrawerProvider>
       </WithTabs>
     </WithVersion>
   );

--- a/packages/app-extension/src/components/common/WalletList.tsx
+++ b/packages/app-extension/src/components/common/WalletList.tsx
@@ -15,6 +15,7 @@ import {
 import { styles, useCustomTheme } from "@coral-xyz/themes";
 import { Add, ExpandMore, MoreHoriz } from "@mui/icons-material";
 import ContentCopyIcon from "@mui/icons-material/ContentCopy";
+import ErrorIcon from "@mui/icons-material/Error";
 import InfoIcon from "@mui/icons-material/Info";
 import { Box, Button, Grid, Tooltip, Typography } from "@mui/material";
 
@@ -731,26 +732,13 @@ export function WalletListItem({
               justifyContent: "center",
             }}
           >
-            {type === "dehydrated" ? (
-              <RecoverButton
-                inverted={inverted}
-                onClick={() => {
-                  nav.push("add-connect-wallet", {
-                    blockchain: wallet.blockchain,
-                    publicKey: wallet.publicKey,
-                    isRecovery: true,
-                  });
-                }}
-              />
-            ) : (
-              <CopyButton
-                inverted={inverted}
-                isEditWallets={false}
-                onClick={() => {
-                  navigator.clipboard.writeText(publicKey);
-                }}
-              />
-            )}
+            <CopyButton
+              inverted={inverted}
+              isEditWallets={false}
+              onClick={() => {
+                navigator.clipboard.writeText(publicKey);
+              }}
+            />
           </div>
           <div
             style={{
@@ -792,7 +780,9 @@ function CopyButton({
       disableRipple
       variant="contained"
       sx={{
-        padding: "4px 12px",
+        width: "60px",
+        height: "32px",
+        padding: 0,
         textTransform: "none",
         color: inverted
           ? theme.custom.colorsInverted.fontColor
@@ -827,44 +817,6 @@ function CopyButton({
   );
 }
 
-function RecoverButton({
-  onClick,
-  inverted,
-}: {
-  onClick: () => void;
-  inverted?: boolean;
-}) {
-  const theme = useCustomTheme();
-  return (
-    <Button
-      disableElevation
-      disableRipple
-      variant="contained"
-      sx={{
-        padding: "4px 12px",
-        textTransform: "none",
-        color: inverted
-          ? theme.custom.colorsInverted.fontColor
-          : theme.custom.colors.fontColor,
-        backgroundColor: inverted
-          ? theme.custom.colorsInverted.bg2
-          : theme.custom.colors.bg2,
-        "&:hover": {
-          backgroundColor: inverted
-            ? `${theme.custom.colorsInverted.walletCopyButtonHover} !important`
-            : `${theme.custom.colors.walletCopyButtonHover} !important`,
-        },
-      }}
-      onClick={(e) => {
-        e.stopPropagation();
-        onClick();
-      }}
-    >
-      Recover
-    </Button>
-  );
-}
-
 export function StackedWalletAddress({
   publicKey,
   name,
@@ -885,10 +837,9 @@ export function StackedWalletAddress({
         style={{
           fontSize: "16px",
           fontWeight: isSelected ? 600 : 500,
-          color: type === "dehydrated" ? theme.custom.colors.negative : "",
         }}
       >
-        {type === "dehydrated" ? "Import error" : name}
+        {name}
       </Typography>
       <div
         style={{

--- a/packages/app-extension/src/components/common/WalletList.tsx
+++ b/packages/app-extension/src/components/common/WalletList.tsx
@@ -883,16 +883,56 @@ export function StackedWalletAddress({
 }
 
 function WalletTypeIcon({ type, fill }: { type: string; fill?: string }) {
+  const theme = useCustomTheme();
   switch (type) {
     case "imported":
       return <ImportedIcon fill={fill} />;
     case "hardware":
       return <HardwareIcon fill={fill} />;
     case "dehydrated":
-      return null;
+      return (
+        <ErrorIcon
+          style={{
+            color: theme.custom.colors.dangerButton,
+            height: "24px",
+            width: "24px",
+            padding: "4px",
+          }}
+        />
+      );
     default:
       return <MnemonicIcon fill={fill} />;
   }
+}
+
+export function ImportTypeBadge({ type }: { type: string }) {
+  const theme = useCustomTheme();
+  return type === "derived" ? (
+    <></>
+  ) : (
+    <div
+      style={{
+        paddingLeft: "10px",
+        paddingRight: "10px",
+        paddingTop: "2px",
+        paddingBottom: "2px",
+        backgroundColor: theme.custom.colors.bg2,
+        height: "20px",
+        borderRadius: "10px",
+      }}
+    >
+      <Typography
+        style={{
+          color: theme.custom.colors.fontColor,
+          fontSize: "12px",
+          lineHeight: "16px",
+          fontWeight: 600,
+        }}
+      >
+        {type === "imported" ? "IMPORTED" : "HARDWARE"}
+      </Typography>
+    </div>
+  );
 }
 
 function NetworkIcon({


### PR DESCRIPTION
Removes render problems by rendering the wallet list higher up the component tree and standardises closing behaviour when wallet is clicked on after creation.

Closes #1992 