### PR TITLE
Fix: redirection on friend request click

### DIFF
--- a/packages/app-extension/src/components/Unlocked/Balances/Notifications.tsx
+++ b/packages/app-extension/src/components/Unlocked/Balances/Notifications.tsx
@@ -627,7 +627,7 @@ function FriendRequestListItem({
     <ListItem
       button
       disableRipple
-      onClick={() => (isXs ? nav!.push("contacts") : onOpenDrawer!())}
+      onClick={() => (isXs ? nav!.push("contact-requests") : onOpenDrawer!())}
       style={{
         paddingLeft: "12px",
         paddingRight: "12px",


### PR DESCRIPTION
Fixes Issue #2498

Problem - Clicking on a friend request notification should push into the requests screen #2498

Solution - Replaced `contacts` with `contact-requests` in nav.push function