### PR TITLE
fix webpack-dev-server websocket connection

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,29 @@ yarn start
 
 Note: In a fresh repo, you should run `yarn build` before `yarn start`.
 
+#### Troubleshooting
+
 _If you run into issues with builds try running `yarn clean` and then start again._
+
+<details>
+  <summary>Seeing `WebSocket connection to 'wss://localhost:9997/ws' failed` error messages in your console?</summary>
+
+You need to install a SSL certificate for localhost as the one provided by [webpack-dev-server is considered invalid](https://github.com/webpack/webpack-dev-server/issues/2957).
+
+A relatively simple way of doing this is using [mkcert](https://github.com/FiloSottile/mkcert)
+
+Instructions for how to install a trusted self-signed cert on macOS -
+
+```
+cd packages/app-extension
+brew install mkcert
+mkcert localhost
+mkcert -install
+```
+
+Now the next time you run `yarn start` the errors should no longer appear.
+
+</details>
 
 ### Install the development version of the extension
 

--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ _If you run into issues with builds try running `yarn clean` and then start agai
 <details>
   <summary>Seeing `WebSocket connection to 'wss://localhost:9997/ws' failed` error messages in your console?</summary>
 
-You need to install a SSL certificate for localhost as the one provided by [webpack-dev-server is considered invalid](https://github.com/webpack/webpack-dev-server/issues/2957).
+You need to install a SSL certificate for localhost as the one provided by [webpack-dev-server is considered invalid](https://github.com/webpack/webpack-dev-server/issues/2957). This step is optional as `react-refresh` will still function without it, but it's a good idea to try and fix this error because otherwise your browser will be making a lot of failed requests and `webpack-dev-server` might not be functioning to its full capabilities.
 
 A relatively simple way of doing this is using [mkcert](https://github.com/FiloSottile/mkcert)
 

--- a/packages/app-extension/.gitignore
+++ b/packages/app-extension/.gitignore
@@ -30,3 +30,6 @@ dist
 
 # Pre build generation.
 src/generated-config.ts
+
+localhost.pem
+localhost-key.pem

--- a/packages/app-extension/webpack.config.js
+++ b/packages/app-extension/webpack.config.js
@@ -7,6 +7,7 @@ const ForkTsCheckerWebpackPlugin = require("fork-ts-checker-webpack-plugin");
 const MiniCssExtractPlugin = require("mini-css-extract-plugin");
 const path = require("path");
 const ReactRefreshWebpackPlugin = require("@pmmmwh/react-refresh-webpack-plugin");
+const fs = require("fs");
 
 const EXTENSION_NAME =
   process.env.NODE_ENV === "development" ? "(DEV) Backpack" : "Backpack";
@@ -33,6 +34,16 @@ const {
       dir: "dev",
       devServer: {
         // watchFiles: ['src/**/*', 'webpack.config.js'],
+        host: "localhost",
+        server: fs.existsSync("localhost.pem")
+          ? {
+              type: "https",
+              options: {
+                key: "localhost-key.pem",
+                cert: "localhost.pem",
+              },
+            }
+          : {},
         compress: false,
         static: {
           directory: path.join(__dirname, "../dev"),

--- a/packages/app-extension/webpack.config.js
+++ b/packages/app-extension/webpack.config.js
@@ -35,6 +35,7 @@ const {
       devServer: {
         // watchFiles: ['src/**/*', 'webpack.config.js'],
         host: "localhost",
+        port: 9997,
         server: fs.existsSync("localhost.pem")
           ? {
               type: "https",


### PR DESCRIPTION
This should stop these errors from flooding your console when running `yarn start`

<img width="503" alt="Screenshot 2023-02-08 at 14 09 59" src="https://user-images.githubusercontent.com/101902546/217640724-c108872f-115f-42ed-9646-91f4ef18686c.png">

It involves some manual steps with creating and installing a self-signed certificate for localhost, here they are for mac OS

```
cd packages/app-extension
brew install mkcert
mkcert localhost
mkcert -install

yarn start
```

If you don't do these steps things will continue to work as before. If this solves an issue for other people we can probably automate it in some way.

These errors exist because the automatically created `webpack-dev-server` certificate is considered [invalid](https://github.com/webpack/webpack-dev-server/issues/2957), at least with the mac OS & openssl versions I am using [office-addin-dev-certs](https://www.npmjs.com/package/office-addin-dev-certs) are also invalid.

---

it also changes the port from 8080 to 9997 (arbitrary number) because that currently conflicts with `backpack-api` and `expo react-native xnft` tooling