### PR TITLE
plugin messaging fix

### DIFF
--- a/packages/common/src/channel/plugin.ts
+++ b/packages/common/src/channel/plugin.ts
@@ -24,13 +24,21 @@ export class PluginServer {
   public handler(handlerFn: (event: Event) => Promise<RpcResponse>) {
     return window.addEventListener("message", async (event: Event) => {
       const url = new URL(this.url);
+      const SIMULATOR_HOST = "localhost:9933";
+
+      if (url.host === SIMULATOR_HOST && !this.window) {
+        // Nothing is running in the simulator
+        return;
+      }
+
       if (
         // TODO: hardcode allowed origin(s)
-        (!url.origin.startsWith("http://localhost:9933") &&
+        (url.host !== SIMULATOR_HOST &&
           (event.origin !== url.origin || event.data.href !== url.href)) ||
         event.data.type !== this.requestChannel
       ) {
-        throw new Error("Unknown Origin or channel");
+        // Unknown Origin or channel
+        return;
       }
 
       const id = event.data.detail.id;
@@ -49,7 +57,7 @@ export class PluginServer {
         if (!this.window) {
           throw new Error("post message window not found");
         }
-        this.window.postMessage(msg, "*");
+        this.window.postMessage(msg, event.origin);
       }
     });
   }


### PR DESCRIPTION
fixes issue with xNFTs, after signing a transaction in an xNFT

`post message window not found` would be thrown if developer mode was enabled but the simulator was not being used

`Unknown Origin or channel` would be thrown by the default xNFTs installed in the wallet (prices and explorer)

it also specifies the origin as the event.origin so that it's sent as a reply and not broadcast to all listeners