### PR TITLE
add ignoreIIFE to no-floating-promises

### DIFF
--- a/packages/eslint-config-custom/index.js
+++ b/packages/eslint-config-custom/index.js
@@ -23,7 +23,12 @@ module.exports = {
     "@typescript-eslint/explicit-module-boundary-types": "off",
     "@typescript-eslint/no-empty-function": "off",
     "@typescript-eslint/no-explicit-any": "off",
-    "@typescript-eslint/no-floating-promises": "warn",
+    "@typescript-eslint/no-floating-promises": [
+      "warn",
+      {
+        ignoreIIFE: true,
+      },
+    ],
     "@typescript-eslint/no-unused-vars": "warn",
     "@typescript-eslint/no-non-null-assertion": "off",
     "import/default": "off",


### PR DESCRIPTION
Stops warning on immediate execution in `useEffect` blocks