### PR TITLE
show dropzone xnft in dropzone wallet

### DIFF
--- a/backend/native/backpack-api/src/db/users.ts
+++ b/backend/native/backpack-api/src/db/users.ts
@@ -126,14 +126,26 @@ const transformUser = (user: {
   username: unknown;
   public_keys: Array<{ blockchain: string; public_key: string }>;
 }) => {
+  const publicKeys = user.public_keys.map((k) => ({
+    blockchain: k.blockchain as Blockchain,
+    publicKey: k.public_key,
+  }));
+
+  // Assumes the first public key is a dropzone wallet for each blockchain
+  const dropzonePublicKeys = publicKeys
+    // Filter to only include xNFT-compatible blockchains
+    .filter((k) => k.blockchain === "solana")
+    .reduce((acc, curr) => {
+      acc[curr.blockchain] ||= curr.publicKey;
+      return acc;
+    }, {} as Record<string, string>);
+
   return {
     id: user.id,
     username: user.username,
     // Camelcase public keys for response
-    publicKeys: user.public_keys.map((k) => ({
-      blockchain: k.blockchain as Blockchain,
-      publicKey: k.public_key,
-    })),
+    publicKeys,
+    dropzonePublicKeys,
     image: `${AVATAR_BASE_URL}/${user.username}`,
   };
 };

--- a/packages/background/src/backend/core.ts
+++ b/packages/background/src/backend/core.ts
@@ -1469,6 +1469,7 @@ export class Backend {
         data: {
           username: json.username,
           uuid: json.id,
+          dropzonePublicKeys: json.dropzonePublicKeys,
         },
       });
     }

--- a/packages/common/src/solana/programs/xnft.ts
+++ b/packages/common/src/solana/programs/xnft.ts
@@ -1,12 +1,8 @@
 import { externalResourceUri } from "@coral-xyz/common-public";
-import { Metadata } from "@metaplex-foundation/mpl-token-metadata";
 import type { Provider } from "@project-serum/anchor";
 import * as anchor from "@project-serum/anchor";
 import { Program } from "@project-serum/anchor";
 import { PublicKey } from "@solana/web3.js";
-
-import { BACKEND_API_URL } from "../../constants";
-import { BACKPACK_FEATURE_REFERRAL_FEES } from "../../generated-config";
 
 export const XNFT_PROGRAM_ID = new PublicKey(
   "xnft5aaToUM4UFETUQfj7NUDUBdvYHTVhNFThEYTm55"
@@ -14,34 +10,19 @@ export const XNFT_PROGRAM_ID = new PublicKey(
 
 export async function fetchXnfts(
   provider: Provider,
-  wallet: PublicKey
+  wallet: PublicKey,
+  isDropzoneWallet: boolean
 ): Promise<Array<{ publicKey: PublicKey; medtadata: any; metadataBlob: any }>> {
   const client = xnftClient(provider);
 
-  const [xnftInstalls, isDropzoneWallet] = await Promise.all([
-    // Fetch all xnfts installed by this user.
-    client.account.install.all([
-      {
-        memcmp: {
-          offset: 8, // Discriminator
-          bytes: wallet.toString(),
-        },
+  // Fetch all xnfts installed by this user.
+  const xnftInstalls = await client.account.install.all([
+    {
+      memcmp: {
+        offset: 8, // Discriminator
+        bytes: wallet.toString(),
       },
-    ]),
-    // Check if this wallet is the dropzone wallet.
-    (async function isDropzoneWallet() {
-      if (!BACKPACK_FEATURE_REFERRAL_FEES) return false;
-      try {
-        const response = await fetch(`${BACKEND_API_URL}/users/me`);
-        const { publicKeys } = await response.json();
-        const dropzonePublicKeyString = publicKeys.find(
-          (k) => k.blockchain === "solana"
-        )?.publicKey;
-        return dropzonePublicKeyString === wallet.toString();
-      } catch (err) {
-        return false;
-      }
-    })(),
+    },
   ]);
 
   // HACK to get ONE xNFT installed for everyone

--- a/packages/recoil/src/atoms/preferences/index.tsx
+++ b/packages/recoil/src/atoms/preferences/index.tsx
@@ -120,6 +120,7 @@ export const user = atom<{ username: string; uuid: string; jwt: string }>({
 export const authenticatedUser = atom<{
   username: string;
   uuid: string;
+  dropzonePublicKeys: Record<Blockchain, string>;
 } | null>({
   key: "authenticatedUser",
   default: null,

--- a/packages/recoil/src/atoms/solana/xnft.tsx
+++ b/packages/recoil/src/atoms/solana/xnft.tsx
@@ -1,5 +1,6 @@
 import {
   BACKPACK_CONFIG_XNFT_PROXY,
+  BACKPACK_FEATURE_REFERRAL_FEES,
   Blockchain,
   DEFAULT_PUBKEY_STR,
   fetchXnfts,
@@ -137,7 +138,7 @@ export const xnfts = atomFamily<
         const xnfts = await fetchXnfts(
           provider,
           new PublicKey(publicKey),
-          publicKey === dropzonePublicKey
+          BACKPACK_FEATURE_REFERRAL_FEES && publicKey === dropzonePublicKey
         );
         return xnfts.map((xnft) => {
           return {

--- a/packages/recoil/src/atoms/solana/xnft.tsx
+++ b/packages/recoil/src/atoms/solana/xnft.tsx
@@ -11,7 +11,7 @@ import { PublicKey } from "@solana/web3.js";
 import * as cheerio from "cheerio";
 import { atomFamily, selectorFamily } from "recoil";
 
-import { isDeveloperMode } from "../preferences";
+import { authenticatedUser, isDeveloperMode } from "../preferences";
 import { connectionUrls } from "../preferences/connection-urls";
 import { activePublicKeys } from "../wallet";
 
@@ -124,13 +124,7 @@ export const xnfts = atomFamily<
   default: selectorFamily({
     key: "xnftsDefault",
     get:
-      ({
-        connectionUrl,
-        publicKey,
-      }: {
-        connectionUrl: string;
-        publicKey: string;
-      }) =>
+      ({ publicKey }: { connectionUrl: string; publicKey: string }) =>
       async ({ get }) => {
         const _activeWallets = get(activePublicKeys);
         const _connectionUrls = get(connectionUrls);
@@ -138,7 +132,13 @@ export const xnfts = atomFamily<
         if (!publicKey) {
           return [];
         }
-        const xnfts = await fetchXnfts(provider, new PublicKey(publicKey));
+        const dropzonePublicKey =
+          get(authenticatedUser)?.dropzonePublicKeys?.solana;
+        const xnfts = await fetchXnfts(
+          provider,
+          new PublicKey(publicKey),
+          publicKey === dropzonePublicKey
+        );
         return xnfts.map((xnft) => {
           return {
             ...xnft,

--- a/packages/recoil/src/context/Notifications.tsx
+++ b/packages/recoil/src/context/Notifications.tsx
@@ -2,7 +2,6 @@ import React, { useEffect } from "react";
 import type {
   AutolockSettings,
   Blockchain,
-  FEATURE_GATES_MAP,
   Notification,
 } from "@coral-xyz/common";
 import {
@@ -615,6 +614,7 @@ export function NotificationsProvider(props: any) {
       setAuthenticatedUser({
         username: notif.data.username,
         uuid: notif.data.uuid,
+        dropzonePublicKeys: notif.data.dropzonePublicKeys,
       });
     };
 


### PR DESCRIPTION
### API changes

adds `dropzonePublicKeys: Record<Blockchain, PublicKeyString>` to the `/users/:username` API response

it will only have a  solana key/value now, but this approach should make things a bit easier if we add other blockchain support in future.

I considered adding a dropzone tag to the existing `publicKeys: Array<{ blockchain: Blockchain; publicKey: PublicKeyString }>` array, but decided to keep things simple and make it clear there's only a single dropzone wallet for now

### Extension changes

Added `isDropzoneWallet` in recoil, which is used when loading xNFTs