### PR TITLE
update local hasura and postgres versions

### DIFF
--- a/backend/reef/docker-compose.yml
+++ b/backend/reef/docker-compose.yml
@@ -2,7 +2,7 @@ version: "3.8"
 
 services:
   postgres:
-    image: postgres:14-alpine@sha256:a0f7890719c3c42b9f78f1ad98b2cd45aa2ee3472da12f9d2d3bfbc07f421146
+    image: postgres:15.0-alpine
     restart: unless-stopped
     ports:
       - 4446:5432
@@ -20,7 +20,7 @@ services:
       POSTGRES_USER: user
 
   hasura:
-    image: hasura/graphql-engine:v2.16.0.cli-migrations-v3@sha256:f03990c5fd113164116db1608ff020bb45a9782c3c34d58c7631e1427007eaa0
+    image: hasura/graphql-engine:v2.18.0.cli-migrations-v3
     ports:
       - 8112:8080
     depends_on:


### PR DESCRIPTION
This doesn't include the sha256 checksums because this docker-compose is only being used locally and it would lock the platform of the images.

For example, if we pin it to the arm build for m1&2 macs, then there will be errors on amd64 systems and vice versa