### PR TITLE
added zod validation api endpoints

### DIFF
--- a/backend/native/backpack-api/src/routes/v1/friends.ts
+++ b/backend/native/backpack-api/src/routes/v1/friends.ts
@@ -1,6 +1,7 @@
 import type { RemoteUserData } from "@coral-xyz/common";
 import { AVATAR_BASE_URL } from "@coral-xyz/common";
 import express from "express";
+import { z } from "zod";
 
 import { extractUserId } from "../../auth/middleware";
 import {
@@ -15,197 +16,287 @@ import {
 } from "../../db/friendships";
 import { getUser, getUsers } from "../../db/users";
 import { Redis } from "../../Redis";
+import { bodyValidator } from "../../validation/reqValidationMiddleware";
 
 import { enrichFriendships } from "./inbox";
-
 const router = express.Router();
 
-router.post("/spam", extractUserId, async (req, res) => {
-  //@ts-ignore
-  const uuid: string = req.id; // TODO from from
-  // @ts-ignore
-  const to: string = req.body.to;
-  // @ts-ignore
-
-  if (uuid === to) {
-    res.status(411).json({
-      msg: "To and from cant be the same",
-    });
-    return;
-  }
-  const spam: boolean = req.body.spam;
-  await setSpam({ from: uuid, to, spam });
-  res.json({});
-});
-
-router.post("/block", extractUserId, async (req, res) => {
-  //@ts-ignore
-  const uuid: string = req.id; // TODO from from
-  // @ts-ignore
-  const to: string = req.body.to;
-  // @ts-ignore
-
-  if (uuid === to) {
-    res.status(411).json({
-      msg: "To and from cant be the same",
-    });
-    return;
-  }
-  const block: boolean = req.body.block;
-  await setBlocked({ from: uuid, to, block });
-  res.json({});
-});
-
-router.post("/unfriend", extractUserId, async (req, res) => {
-  //@ts-ignore
-  const uuid: string = req.id; // TODO from from
-  // @ts-ignore
-  const to: string = req.body.to;
-  // @ts-ignore
-
-  if (uuid === to) {
-    res.status(411).json({
-      msg: "To and from cant be the same",
-    });
-    return;
-  }
-  await unfriend({ from: uuid, to });
-  res.json({});
-});
-
-router.get("/sent", extractUserId, async (req, res) => {
-  // @ts-ignore
-  const uuid: string = req.id;
-
-  const requestedUserIds = await getSentRequests({ uuid });
-  const users = await getUsers(requestedUserIds);
-  const requestedWithMetadata: RemoteUserData[] = requestedUserIds.map(
-    (userId) => ({
-      id: userId,
-      username: users.find((x) => x.id === userId)?.username as string,
-      image: `${AVATAR_BASE_URL}/${
-        users.find((x) => x.id === userId)?.username
-      }`,
-      areFriends: false,
-      remoteRequested: false,
-      requested: true,
+router.post(
+  "/spam",
+  bodyValidator(
+    z.object({
+      body: z.object({
+        to: z.string(),
+        spam: z.boolean(),
+      }),
+      id: z.string().uuid(),
     })
-  );
-  res.json({ requests: requestedWithMetadata });
-});
+  ),
+  extractUserId,
+  async (req, res) => {
+    //@ts-ignore
+    const uuid: string = req.id; // TODO from from
+    // @ts-ignore
+    const to: string = req.body.to;
+    // @ts-ignore
 
-router.get("/requests", extractUserId, async (req, res) => {
-  //@ts-ignore
-  const uuid: string = req.id; // TODO from from
-
-  const requestUserIds = await getReceivedRequests({ uuid });
-  const users = await getUsers(requestUserIds);
-  const requestsWithMetadata: RemoteUserData[] = requestUserIds.map(
-    (requestUserId) => ({
-      id: requestUserId,
-      username: users.find((x) => x.id === requestUserId)?.username as string,
-      image: `${AVATAR_BASE_URL}/${
-        users.find((x) => x.id === requestUserId)?.username
-      }`,
-      areFriends: false,
-      remoteRequested: true,
-      requested: false,
-    })
-  );
-  res.json({
-    requests: requestsWithMetadata,
-  });
-});
-
-router.post("/request", extractUserId, async (req, res) => {
-  //@ts-ignore
-  const uuid: string = req.id; // TODO from from
-  // @ts-ignore
-  const to: string = req.body.to;
-  // @ts-ignore
-
-  if (uuid === to) {
-    res.status(411).json({
-      msg: "To and from cant be the same",
-    });
-    return;
+    if (uuid === to) {
+      res.status(411).json({
+        msg: "To and from cant be the same",
+      });
+      return;
+    }
+    const spam: boolean = req.body.spam;
+    await setSpam({ from: uuid, to, spam });
+    res.json({});
   }
-  const sendRequest: boolean = req.body.sendRequest;
+);
 
-  const areFriends = await setFriendship({ from: uuid, to, sendRequest });
-  if (sendRequest) {
-    if (areFriends) {
-      await Redis.getInstance().send(
-        JSON.stringify({
-          type: "friend_request_accept",
-          payload: {
-            from: uuid,
-            to,
-          },
-        })
-      );
-    } else {
-      await Redis.getInstance().send(
-        JSON.stringify({
-          type: "friend_request",
-          payload: {
-            from: uuid,
-            to,
-          },
-        })
-      );
+router.post(
+  "/block",
+  bodyValidator(
+    z.object({
+      body: z.object({
+        to: z.string(),
+        block: z.boolean(),
+      }),
+      id: z.string().uuid(),
+    })
+  ),
+  extractUserId,
+  async (req, res) => {
+    //@ts-ignore
+    const uuid: string = req.id; // TODO from from
+    // @ts-ignore
+    const to: string = req.body.to;
+    // @ts-ignore
+
+    if (uuid === to) {
+      res.status(411).json({
+        msg: "To and from cant be the same",
+      });
+      return;
+    }
+    const block: boolean = req.body.block;
+    await setBlocked({ from: uuid, to, block });
+    res.json({});
+  }
+);
+
+router.post(
+  "/unfriend",
+  bodyValidator(
+    z.object({
+      body: z.object({
+        to: z.string(),
+      }),
+      id: z.string().uuid(),
+    })
+  ),
+  extractUserId,
+  async (req, res) => {
+    //@ts-ignore
+    const uuid: string = req.id; // TODO from from
+    // @ts-ignore
+    const to: string = req.body.to;
+    // @ts-ignore
+
+    if (uuid === to) {
+      res.status(411).json({
+        msg: "To and from cant be the same",
+      });
+      return;
+    }
+    await unfriend({ from: uuid, to });
+    res.json({});
+  }
+);
+
+router.get(
+  "/sent",
+  bodyValidator(
+    z.object({
+      id: z.string().uuid(),
+    })
+  ),
+  extractUserId,
+  async (req, res) => {
+    // @ts-ignore
+    const uuid: string = req.id;
+
+    const requestedUserIds = await getSentRequests({ uuid });
+    const users = await getUsers(requestedUserIds);
+    const requestedWithMetadata: RemoteUserData[] = requestedUserIds.map(
+      (userId) => ({
+        id: userId,
+        username: users.find((x) => x.id === userId)?.username as string,
+        image: `${AVATAR_BASE_URL}/${
+          users.find((x) => x.id === userId)?.username
+        }`,
+        areFriends: false,
+        remoteRequested: false,
+        requested: true,
+      })
+    );
+    res.json({ requests: requestedWithMetadata });
+  }
+);
+
+router.get(
+  "/requests",
+  bodyValidator(
+    z.object({
+      id: z.string().uuid(),
+    })
+  ),
+  extractUserId,
+  async (req, res) => {
+    //@ts-ignore
+    const uuid: string = req.id; // TODO from from
+
+    const requestUserIds = await getReceivedRequests({ uuid });
+    const users = await getUsers(requestUserIds);
+    const requestsWithMetadata: RemoteUserData[] = requestUserIds.map(
+      (requestUserId) => ({
+        id: requestUserId,
+        username: users.find((x) => x.id === requestUserId)?.username as string,
+        image: `${AVATAR_BASE_URL}/${
+          users.find((x) => x.id === requestUserId)?.username
+        }`,
+        areFriends: false,
+        remoteRequested: true,
+        requested: false,
+      })
+    );
+    res.json({
+      requests: requestsWithMetadata,
+    });
+  }
+);
+
+router.post(
+  "/request",
+  bodyValidator(
+    z.object({
+      body: z.object({
+        sendRequest: z.boolean(),
+        to: z.string(),
+      }),
+      id: z.string().uuid(),
+    })
+  ),
+  extractUserId,
+  async (req, res) => {
+    //@ts-ignore
+    const uuid: string = req.id; // TODO from from
+    // @ts-ignore
+    const to: string = req.body.to;
+    // @ts-ignore
+
+    if (uuid === to) {
+      res.status(411).json({
+        msg: "To and from cant be the same",
+      });
+      return;
+    }
+    const sendRequest: boolean = req.body.sendRequest;
+
+    const areFriends = await setFriendship({ from: uuid, to, sendRequest });
+    if (sendRequest) {
+      if (areFriends) {
+        await Redis.getInstance().send(
+          JSON.stringify({
+            type: "friend_request_accept",
+            payload: {
+              from: uuid,
+              to,
+            },
+          })
+        );
+      } else {
+        await Redis.getInstance().send(
+          JSON.stringify({
+            type: "friend_request",
+            payload: {
+              from: uuid,
+              to,
+            },
+          })
+        );
+      }
+    }
+    res.json({});
+  }
+);
+
+router.get(
+  "/all",
+  bodyValidator(
+    z.object({
+      id: z.string().uuid(),
+    })
+  ),
+  extractUserId,
+  async (req, res) => {
+    //@ts-ignore
+    const uuid: string = req.id; // TODO from from
+
+    try {
+      const friends = await getAllFriends({
+        from: uuid,
+      });
+      const enrichedFriendships = await enrichFriendships(friends, uuid);
+      res.json({ chats: enrichedFriendships });
+    } catch (e) {
+      console.log(e);
+      res.status(503).json({ msg: "Internal server error" });
     }
   }
-  res.json({});
-});
+);
 
-router.get("/all", extractUserId, async (req, res) => {
-  //@ts-ignore
-  const uuid: string = req.id; // TODO from from
+router.get(
+  "/",
+  bodyValidator(
+    z.object({
+      id: z.string().uuid(),
+      query: z.object({
+        userId: z.string(),
+      }),
+    })
+  ),
+  extractUserId,
+  async (req, res) => {
+    //@ts-ignore
+    const uuid: string = req.id; // TODO from from
+    // @ts-ignore
+    const userId: string = req.query.userId;
+    // @ts-ignore
 
-  try {
-    const friends = await getAllFriends({
-      from: uuid,
-    });
-    const enrichedFriendships = await enrichFriendships(friends, uuid);
-    res.json({ chats: enrichedFriendships });
-  } catch (e) {
-    console.log(e);
-    res.status(503).json({ msg: "Internal server error" });
+    if (userId === uuid) {
+      res.json({
+        are_friends: true,
+      });
+      return;
+    }
+
+    try {
+      const { are_friends, request_sent, blocked, spam } = await getFriendship({
+        from: uuid,
+        to: userId,
+      });
+      const user = await getUser(userId);
+      res.json({
+        user,
+        are_friends,
+        request_sent,
+        blocked,
+        spam,
+      });
+    } catch (e) {
+      console.log(e);
+      res.status(503).json({ msg: "Internal server error" });
+    }
   }
-});
-
-router.get("/", extractUserId, async (req, res) => {
-  //@ts-ignore
-  const uuid: string = req.id; // TODO from from
-  // @ts-ignore
-  const userId: string = req.query.userId;
-  // @ts-ignore
-
-  if (userId === uuid) {
-    res.json({
-      are_friends: true,
-    });
-    return;
-  }
-
-  try {
-    const { are_friends, request_sent, blocked, spam } = await getFriendship({
-      from: uuid,
-      to: userId,
-    });
-    const user = await getUser(userId);
-    res.json({
-      user,
-      are_friends,
-      request_sent,
-      blocked,
-      spam,
-    });
-  } catch (e) {
-    console.log(e);
-    res.status(503).json({ msg: "Internal server error" });
-  }
-});
+);
 
 export default router;

--- a/backend/native/backpack-api/src/routes/v1/nft.ts
+++ b/backend/native/backpack-api/src/routes/v1/nft.ts
@@ -6,6 +6,7 @@ import {
 } from "@coral-xyz/common";
 import { WHITELISTED_CHAT_COLLECTIONS } from "@coral-xyz/common/src/constants";
 import express from "express";
+import { z } from "zod";
 
 import { ensureHasRoomAccess, extractUserId } from "../../auth/middleware";
 import { getFriendshipStatus } from "../../db/friendships";
@@ -19,156 +20,200 @@ import {
 } from "../../db/nft";
 import { getUsersByPublicKeys } from "../../db/users";
 import { validateOwnership } from "../../utils/metaplex";
-
+import { bodyValidator } from "../../validation/reqValidationMiddleware";
 const router = express.Router();
 
-router.post("/bulk", extractUserId, async (req, res) => {
-  // @ts-ignore
-  const userId: string = req.id;
-  const nfts = req.body.nfts;
-  const publicKey: string = req.body.publicKey;
-  const users = await getUsersByPublicKeys([
-    {
-      blockchain: Blockchain.SOLANA,
-      publicKey,
-    },
-  ]);
-  if (users[0].user_id !== userId) {
-    return res.status(403).json({
-      msg: "User doesn't own this public key",
-    });
-  }
-
-  const responses = await Promise.all(
-    nfts.map(
-      (nft: {
-        nftId: string;
-        collectionId: string;
-        centralizedGroup: string;
-      }) =>
-        validateOwnership(
-          nft.nftId,
-          nft.collectionId,
-          nft.centralizedGroup || nft.collectionId,
-          publicKey
-        )
-    )
-  );
-
-  await addNfts(
-    publicKey,
-    nfts.filter((_x: any, index: number) => responses[index])
-  );
-  res.json({});
-});
-
-router.get("/bulk", extractUserId, async (req, res) => {
-  // @ts-ignore
-  const userId: string = req.id;
-
-  //@ts-ignore
-  const userSpecifiedId: string = req.query.uuid;
-
-  if (userId !== userSpecifiedId) {
-    return res.json({ collections: [] });
-  }
-
-  // TODO: optimise this
-  const allCollections = await getAllCollectionsFor(userId);
-  DEFAULT_GROUP_CHATS.forEach(({ id }: { id: string }) =>
-    allCollections.push({ collection_id: id })
-  );
-  const lastReadMappings = await getLastReadFor(
-    userId,
-    allCollections.map((x) => x.centralized_group || x.collection_id)
-  );
-  const collectionChatMetadata = await getCollectionChatMetadata(
-    allCollections.map((x) => x.centralized_group || x.collection_id)
-  );
-
-  const collections: CollectionChatData = allCollections.map(
-    ({ collection_id: collectionId, centralized_group: centralizedGroup }) => ({
-      collectionId: centralizedGroup || collectionId,
-      lastReadMessage:
-        lastReadMappings.find(
-          (x) => x.collection_id === (centralizedGroup || collectionId)
-        )?.last_read_message_id || null,
-      lastMessage: collectionChatMetadata.find(
-        (x) => x.collection_id === (centralizedGroup || collectionId)
-      )?.last_message,
-      lastMessageUuid: collectionChatMetadata.find(
-        (x) => x.collection_id === (centralizedGroup || collectionId)
-      )?.last_message_uuid,
-      lastMessageTimestamp: collectionChatMetadata.find(
-        (x) => x.collection_id === (centralizedGroup || collectionId)
-      )?.last_message_timestamp,
-      image:
-        DEFAULT_GROUP_CHATS.find(
-          (x) => x.id === (centralizedGroup || collectionId)
-        )?.image ||
-        WHITELISTED_CHAT_COLLECTIONS.find((x) => x.id === centralizedGroup)
-          ?.image,
-      name:
-        DEFAULT_GROUP_CHATS.find(
-          (x) => x.id === (centralizedGroup || collectionId)
-        )?.name ||
-        WHITELISTED_CHAT_COLLECTIONS.find((x) => x.id === centralizedGroup)
-          ?.name,
+router.post(
+  "/bulk",
+  bodyValidator(
+    z.object({
+      id: z.string().uuid(),
+      body: z.object({
+        nfts: z.string().array(),
+        publicKey: z.string(),
+      }),
     })
-  );
+  ),
+  extractUserId,
+  async (req, res) => {
+    // @ts-ignore
+    const userId: string = req.id;
+    const nfts = req.body.nfts;
+    const publicKey: string = req.body.publicKey;
+    const users = await getUsersByPublicKeys([
+      {
+        blockchain: Blockchain.SOLANA,
+        publicKey,
+      },
+    ]);
+    if (users[0].user_id !== userId) {
+      return res.status(403).json({
+        msg: "User doesn't own this public key",
+      });
+    }
 
-  res.json({
-    collections,
-  });
-});
+    const responses = await Promise.all(
+      nfts.map(
+        (nft: {
+          nftId: string;
+          collectionId: string;
+          centralizedGroup: string;
+        }) =>
+          validateOwnership(
+            nft.nftId,
+            nft.collectionId,
+            nft.centralizedGroup || nft.collectionId,
+            publicKey
+          )
+      )
+    );
 
-router.get("/members", extractUserId, ensureHasRoomAccess, async (req, res) => {
-  // @ts-ignore
-  const limit = req.query.limit ? parseInt(req.query.limit) : 20;
-  // @ts-ignore
-  const offset = req.query.offset ? parseInt(req.query.offset) : 0;
-  // @ts-ignore
-  const collectionId: string = req.query.room;
-  // @ts-ignore
-  const uuid: string = req.id;
-  // @ts-ignore
-  const prefix: string = req.query.prefix || "";
+    await addNfts(
+      publicKey,
+      nfts.filter((_x: any, index: number) => responses[index])
+    );
+    res.json({});
+  }
+);
 
-  const { count, users } = DEFAULT_GROUP_CHATS.map((x) => x.id).includes(
-    collectionId
-  )
-    ? await getAllUsers(prefix, limit, offset)
-    : await getNftMembers(collectionId, prefix, limit, offset);
+router.get(
+  "/bulk",
+  bodyValidator(
+    z.object({
+      id: z.string(),
+      query: z.object({
+        uuid: z.string().uuid(),
+      }),
+    })
+  ),
+  extractUserId,
+  async (req, res) => {
+    // @ts-ignore
+    const userId: string = req.id;
 
-  const memberFriendships: {
-    id: string;
-    areFriends: boolean;
-    requested: boolean;
-    remoteRequested: boolean;
-  }[] = await getFriendshipStatus(
-    users.map((x) => x.id as string),
-    uuid
-  );
+    //@ts-ignore
+    const userSpecifiedId: string = req.query.uuid;
 
-  const members: RemoteUserData[] = users
-    .filter((x) => x.id !== uuid)
-    .map(({ id, username }) => {
-      const friendship = memberFriendships.find((x) => x.id === id);
+    if (userId !== userSpecifiedId) {
+      return res.json({ collections: [] });
+    }
 
-      return {
-        id,
-        username,
-        image: `${AVATAR_BASE_URL}/${username}`,
-        requested: friendship?.requested || false,
-        remoteRequested: friendship?.remoteRequested || false,
-        areFriends: friendship?.areFriends || false,
-      };
+    // TODO: optimise this
+    const allCollections = await getAllCollectionsFor(userId);
+    DEFAULT_GROUP_CHATS.forEach(({ id }: { id: string }) =>
+      allCollections.push({ collection_id: id })
+    );
+    const lastReadMappings = await getLastReadFor(
+      userId,
+      allCollections.map((x) => x.centralized_group || x.collection_id)
+    );
+    const collectionChatMetadata = await getCollectionChatMetadata(
+      allCollections.map((x) => x.centralized_group || x.collection_id)
+    );
+
+    const collections: CollectionChatData = allCollections.map(
+      ({
+        collection_id: collectionId,
+        centralized_group: centralizedGroup,
+      }) => ({
+        collectionId: centralizedGroup || collectionId,
+        lastReadMessage:
+          lastReadMappings.find(
+            (x) => x.collection_id === (centralizedGroup || collectionId)
+          )?.last_read_message_id || null,
+        lastMessage: collectionChatMetadata.find(
+          (x) => x.collection_id === (centralizedGroup || collectionId)
+        )?.last_message,
+        lastMessageUuid: collectionChatMetadata.find(
+          (x) => x.collection_id === (centralizedGroup || collectionId)
+        )?.last_message_uuid,
+        lastMessageTimestamp: collectionChatMetadata.find(
+          (x) => x.collection_id === (centralizedGroup || collectionId)
+        )?.last_message_timestamp,
+        image:
+          DEFAULT_GROUP_CHATS.find(
+            (x) => x.id === (centralizedGroup || collectionId)
+          )?.image ||
+          WHITELISTED_CHAT_COLLECTIONS.find((x) => x.id === centralizedGroup)
+            ?.image,
+        name:
+          DEFAULT_GROUP_CHATS.find(
+            (x) => x.id === (centralizedGroup || collectionId)
+          )?.name ||
+          WHITELISTED_CHAT_COLLECTIONS.find((x) => x.id === centralizedGroup)
+            ?.name,
+      })
+    );
+
+    res.json({
+      collections,
     });
+  }
+);
 
-  res.json({
-    members: members,
-    count,
-  });
-});
+router.get(
+  "/members",
+  bodyValidator(
+    z.object({
+      query: z.object({
+        limit: z.string(),
+        offset: z.string(),
+        room: z.string(),
+        prefix: z.string().optional(),
+      }),
+      id: z.string().uuid(),
+    })
+  ),
+  extractUserId,
+  ensureHasRoomAccess,
+  async (req, res) => {
+    // @ts-ignore
+    const limit = req.query.limit ? parseInt(req.query.limit) : 20;
+    // @ts-ignore
+    const offset = req.query.offset ? parseInt(req.query.offset) : 0;
+    // @ts-ignore
+    const collectionId: string = req.query.room;
+    // @ts-ignore
+    const uuid: string = req.id;
+    // @ts-ignore
+    const prefix: string = req.query.prefix || "";
+
+    const { count, users } = DEFAULT_GROUP_CHATS.map((x) => x.id).includes(
+      collectionId
+    )
+      ? await getAllUsers(prefix, limit, offset)
+      : await getNftMembers(collectionId, prefix, limit, offset);
+
+    const memberFriendships: {
+      id: string;
+      areFriends: boolean;
+      requested: boolean;
+      remoteRequested: boolean;
+    }[] = await getFriendshipStatus(
+      users.map((x) => x.id as string),
+      uuid
+    );
+
+    const members: RemoteUserData[] = users
+      .filter((x) => x.id !== uuid)
+      .map(({ id, username }) => {
+        const friendship = memberFriendships.find((x) => x.id === id);
+
+        return {
+          id,
+          username,
+          image: `${AVATAR_BASE_URL}/${username}`,
+          requested: friendship?.requested || false,
+          remoteRequested: friendship?.remoteRequested || false,
+          areFriends: friendship?.areFriends || false,
+        };
+      });
+
+    res.json({
+      members: members,
+      count,
+    });
+  }
+);
 
 export default router;

--- a/backend/native/backpack-api/src/validation/reqValidationMiddleware.ts
+++ b/backend/native/backpack-api/src/validation/reqValidationMiddleware.ts
@@ -1,0 +1,12 @@
+import type { NextFunction, Request, Response } from "express";
+import type { z } from "zod";
+export const bodyValidator = (schema: z.ZodObject<{}>) => {
+  return async (req: Request, res: Response, next: NextFunction) => {
+    try {
+      await schema.parseAsync(req);
+      next();
+    } catch (err) {
+      next(err);
+    }
+  };
+};


### PR DESCRIPTION
### WHY?

Added zod validation to most API endpoints. See for ref: #1815 

### HOW?

Earlier thought was to write middleware for handling req[data] validation, based upon the requested path/route the schema logic would be switched and validated/parsed against the req object without mutating it. However due to the high entropy (every endpoint consumes unique data), extending, omit/pick on base zod schema was helpless. Furthermore handling the edge case like the same route of “/” with different HTTP methods contributed to the long switch cases. Plus adding a new route required making adjustments at many places.

Therefore. I wrote a middleware wrapper (sort of), which takes zod schema/types as a param and validates/parses them against a req object.If succeeded next would be call else next(err)[for global middleware] 
```
router.get(
 "/",
 bodyValidator(
   z.object({
     query: z.object({
       usernamePrefix: z.string(),
     }),
     id: z.string().uuid(),
 })
 ),
 extractUserId,
 async (req, res) => {
   // @ts-ignore
   const usernamePrefix: string = req.query.usernamePrefix;
   // @ts-ignore
   const uuid = req.id as string;
```
The above code depicts how to write validation schema if needed to validate `req.query.usernamePrefix` and `req.id`. 
### Anything
If the author seems to be okay with the approach can further strengthen the sanitation and validation rules by forcing custom types for `publicKey, etc`. Also incorporating OWASP validation rules.
