### PR TITLE
add warning if removing dropzone wallet

### DIFF
--- a/packages/app-extension/src/components/Unlocked/Settings/YourAccount/EditWallets/RemoveWallet.tsx
+++ b/packages/app-extension/src/components/Unlocked/Settings/YourAccount/EditWallets/RemoveWallet.tsx
@@ -30,7 +30,8 @@ export const RemoveWallet: React.FC<{
   const background = useBackgroundClient();
   const [showSuccess, setShowSuccess] = useState(false);
   const [loading, setLoading] = useState(false);
-  const [showConfirmation, setShowConfirmation] = useState(false);
+  const [showDropzoneConfirmation, setShowDropzoneConfirmation] =
+    useState(false);
 
   useEffect(() => {
     nav.setOptions({ headerTitle: "Remove Wallet" });
@@ -39,7 +40,7 @@ export const RemoveWallet: React.FC<{
   const onRemove = useCallback(async () => {
     setLoading(true);
 
-    if (BACKPACK_FEATURE_REFERRAL_FEES && !showConfirmation) {
+    if (BACKPACK_FEATURE_REFERRAL_FEES && !showDropzoneConfirmation) {
       try {
         const response = await fetch(
           `${BACKEND_API_URL}/dropzone/claims/${publicKey}`
@@ -47,7 +48,7 @@ export const RemoveWallet: React.FC<{
         const json = await response.json();
         if (json.unclaimed.length > 0) {
           setLoading(false);
-          setShowConfirmation(true);
+          setShowDropzoneConfirmation(true);
           return;
         }
       } catch (err) {
@@ -68,7 +69,7 @@ export const RemoveWallet: React.FC<{
     }
     setLoading(false);
     setShowSuccess(true);
-  }, [showConfirmation]);
+  }, [showDropzoneConfirmation]);
 
   return (
     <>
@@ -100,7 +101,7 @@ export const RemoveWallet: React.FC<{
               color: theme.custom.colors.fontColor,
             }}
           >
-            {showConfirmation
+            {showDropzoneConfirmation
               ? "You might have unclaimed Dropzone drops"
               : `Are you sure you want to remove ${walletAddressDisplay(
                   publicKey
@@ -116,7 +117,7 @@ export const RemoveWallet: React.FC<{
               marginTop: "8px",
             }}
           >
-            {showConfirmation ? (
+            {showDropzoneConfirmation ? (
               "You can check by opening the Dropzone xNFT. Are you sure you want to go ahead?"
             ) : type === "derived" ? (
               <>

--- a/packages/app-extension/src/components/Unlocked/Settings/YourAccount/EditWallets/RemoveWallet.tsx
+++ b/packages/app-extension/src/components/Unlocked/Settings/YourAccount/EditWallets/RemoveWallet.tsx
@@ -1,6 +1,8 @@
-import React, { useEffect, useState } from "react";
+import React, { useCallback, useEffect, useState } from "react";
 import type { Blockchain } from "@coral-xyz/common";
 import {
+  BACKEND_API_URL,
+  BACKPACK_FEATURE_REFERRAL_FEES,
   UI_RPC_METHOD_KEYRING_KEY_DELETE,
   UI_RPC_METHOD_USER_ACCOUNT_PUBLIC_KEY_DELETE,
   walletAddressDisplay,
@@ -28,13 +30,31 @@ export const RemoveWallet: React.FC<{
   const background = useBackgroundClient();
   const [showSuccess, setShowSuccess] = useState(false);
   const [loading, setLoading] = useState(false);
+  const [showConfirmation, setShowConfirmation] = useState(false);
 
   useEffect(() => {
     nav.setOptions({ headerTitle: "Remove Wallet" });
   }, [nav]);
 
-  const onRemove = async () => {
+  const onRemove = useCallback(async () => {
     setLoading(true);
+
+    if (BACKPACK_FEATURE_REFERRAL_FEES && !showConfirmation) {
+      try {
+        const response = await fetch(
+          `${BACKEND_API_URL}/dropzone/claims/${publicKey}`
+        );
+        const json = await response.json();
+        if (json.unclaimed.length > 0) {
+          setLoading(false);
+          setShowConfirmation(true);
+          return;
+        }
+      } catch (err) {
+        // error loading keys
+      }
+    }
+
     if (type === "dehydrated") {
       await background.request({
         method: UI_RPC_METHOD_USER_ACCOUNT_PUBLIC_KEY_DELETE,
@@ -48,7 +68,7 @@ export const RemoveWallet: React.FC<{
     }
     setLoading(false);
     setShowSuccess(true);
-  };
+  }, [showConfirmation]);
 
   return (
     <>
@@ -80,9 +100,11 @@ export const RemoveWallet: React.FC<{
               color: theme.custom.colors.fontColor,
             }}
           >
-            {`Are you sure you want to remove ${walletAddressDisplay(
-              publicKey
-            )}?`}
+            {showConfirmation
+              ? "You might have unclaimed Dropzone drops"
+              : `Are you sure you want to remove ${walletAddressDisplay(
+                  publicKey
+                )}?`}
           </Typography>
           <Typography
             style={{
@@ -94,7 +116,9 @@ export const RemoveWallet: React.FC<{
               marginTop: "8px",
             }}
           >
-            {type === "derived" ? (
+            {showConfirmation ? (
+              "You can check by opening the Dropzone xNFT. Are you sure you want to go ahead?"
+            ) : type === "derived" ? (
               <>
                 Removing from Backpack will not delete the wallet’s contents. It
                 will still be available by importing your secret recovery phrase


### PR DESCRIPTION
if a user is trying to remove their dropzone wallet AND they have unclaimed drops

they will see this final confirmation screen before removing the wallet

<img width="487" alt="Screenshot 2023-02-13 at 13 43 27" src="https://user-images.githubusercontent.com/101902546/218567724-367d884d-21f7-4624-8d7d-000281a131f6.png">

after the wallet is removed the next available solana wallet will be the designated dropzone wallet