### PR TITLE
fix order of burn token drawer transition

### DIFF
--- a/packages/app-extension/src/components/Unlocked/Nfts/Detail.tsx
+++ b/packages/app-extension/src/components/Unlocked/Nfts/Detail.tsx
@@ -747,13 +747,14 @@ function BurnConfirmationCard({
           )
         ).value.amount
       );
+      setState("sending");
+
       const _signature = await Solana.burnAndCloseNft(solanaCtx, {
         solDestination: solanaCtx.walletPublicKey,
         mint: new PublicKey(nft.mint.toString()),
         amount,
       });
       setSignature(_signature);
-      setState("sending");
 
       //
       // Confirm the tx.


### PR DESCRIPTION
Loader should display while burning transaction being sent.