### PR TITLE
attempt to migrate styles to tss-react to support react v18

### DIFF
--- a/packages/app-extension/package.json
+++ b/packages/app-extension/package.json
@@ -24,7 +24,6 @@
     "@metaplex-foundation/mpl-token-metadata": "^2.7.0",
     "@mui/icons-material": "^5.8.0",
     "@mui/material": "^5.8.1",
-    "@mui/styles": "^5.8.4",
     "@onsol/tldparser": "^0.3.3",
     "@project-serum/anchor": "^0.24.2",
     "@solana/web3.js": "^1.63.1",

--- a/packages/app-extension/package.json
+++ b/packages/app-extension/package.json
@@ -47,6 +47,7 @@
     "react-virtualized-auto-sizer": "^1.0.7",
     "react-window": "^1.8.8",
     "recoil": "^0.7.6",
+    "tss-react": "^4.6.1",
     "web-push": "^3.5.0"
   },
   "scripts": {

--- a/packages/app-extension/src/app/ErrorBoundary.tsx
+++ b/packages/app-extension/src/app/ErrorBoundary.tsx
@@ -3,8 +3,8 @@ import type { BackgroundClient } from "@coral-xyz/common";
 import { UI_RPC_METHOD_NAVIGATION_TO_DEFAULT } from "@coral-xyz/common";
 import { EmptyState } from "@coral-xyz/react-common";
 import { useBackgroundClient } from "@coral-xyz/recoil";
-import { styles } from "@coral-xyz/themes";
 import ErrorOutlineIcon from "@mui/icons-material/ErrorOutline";
+import { makeStyles } from "tss-react/mui";
 
 interface State {
   err: boolean;
@@ -16,7 +16,7 @@ interface Props {
   classes: any;
 }
 
-const useStyles = styles((theme) => {
+const useStyles = makeStyles()((theme) => {
   return {
     appContainer: {
       background: theme.custom.colors.backgroundBackdrop,
@@ -69,7 +69,7 @@ class ErrorBoundaryWithHooks extends React.Component<Props, State> {
 
 export function ErrorBoundary(props: { children: React.ReactNode }) {
   const background = useBackgroundClient();
-  const classes = useStyles();
+  const { classes } = useStyles();
   return (
     //@ts-ignore
     <ErrorBoundaryWithHooks classes={classes} background={background}>

--- a/packages/app-extension/src/app/Router.tsx
+++ b/packages/app-extension/src/app/Router.tsx
@@ -79,7 +79,7 @@ function _Router() {
 }
 
 function PopupView() {
-  const classes = useStyles();
+  const { classes } = useStyles();
   return (
     <div className={classes.appContainer}>
       <PopupRouter />
@@ -443,11 +443,11 @@ export function WithSuspense(props: any) {
 }
 
 export function BlankApp() {
-  const classes = useStyles();
+  const { classes } = useStyles();
   return <div className={classes.appContainer}></div>;
 }
 
-const useStyles = styles((theme) => {
+const useStyles = styles()((theme) => {
   return {
     appContainer: {
       minWidth: `${EXTENSION_WIDTH}px`,

--- a/packages/app-extension/src/components/Onboarding/pages/InviteCodeForm.tsx
+++ b/packages/app-extension/src/components/Onboarding/pages/InviteCodeForm.tsx
@@ -1,15 +1,15 @@
 import { type FormEvent, useCallback, useEffect, useState } from "react";
 import { PrimaryButton, TextInput } from "@coral-xyz/react-common";
-import { styles } from "@coral-xyz/themes";
 import { ArrowForward } from "@mui/icons-material";
 import { Box } from "@mui/material";
 import { createPopup } from "@typeform/embed";
+import { makeStyles } from "tss-react/mui";
 
 import { SubtextParagraph } from "../../common";
 import { getWaitlistId, setWaitlistId } from "../../common/WaitingRoom";
 import { BackpackHeader } from "../../Locked";
 
-const useStyles = styles(() => ({
+const useStyles = makeStyles()(() => ({
   inviteCodeBox: {
     "& .MuiFormControl-root": {
       marginTop: 0,
@@ -31,7 +31,7 @@ export const InviteCodeForm = ({
   const [waitlistResponseId, setWaitlistResponseId] = useState(
     getWaitlistId() || ""
   );
-  const classes = useStyles();
+  const { classes } = useStyles();
 
   useEffect(() => {
     setError("");

--- a/packages/app-extension/src/components/Unlocked/Approvals/ApproveTransaction.tsx
+++ b/packages/app-extension/src/components/Unlocked/Approvals/ApproveTransaction.tsx
@@ -1,17 +1,17 @@
 import type { Blockchain, FeeConfig } from "@coral-xyz/common";
 import { EmptyState, Loading } from "@coral-xyz/react-common";
 import { useTransactionData, useWalletBlockchain } from "@coral-xyz/recoil";
-import { styles } from "@coral-xyz/themes";
 import { Block as BlockIcon } from "@mui/icons-material";
 import { Typography } from "@mui/material";
 import { BigNumber, ethers } from "ethers";
+import { makeStyles } from "tss-react/mui";
 
 import { TransactionData } from "../../common/TransactionData";
 import { WithApproval } from "../../Unlocked/Approvals";
 
 const { Zero } = ethers.constants;
 
-const useStyles = styles((theme) => ({
+const useStyles = makeStyles()((theme) => ({
   title: {
     fontWeight: 500,
     fontSize: "18px",
@@ -64,7 +64,7 @@ export function ApproveTransaction({
     feeConfig?: { config: FeeConfig; disabled: boolean }
   ) => Promise<void>;
 }) {
-  const classes = useStyles();
+  const { classes } = useStyles();
   const blockchain = useWalletBlockchain(wallet);
   const transactionData = useTransactionData(blockchain as Blockchain, tx);
   const { loading, balanceChanges, transaction, solanaFeeConfig } =
@@ -199,7 +199,7 @@ export function ApproveAllTransactions({
   txs: Array<string>;
   onCompletion: (confirmed: boolean) => void;
 }) {
-  const classes = useStyles();
+  const { classes } = useStyles();
 
   const onConfirm = async () => {
     onCompletion(true);

--- a/packages/app-extension/src/components/Unlocked/Approvals/index.tsx
+++ b/packages/app-extension/src/components/Unlocked/Approvals/index.tsx
@@ -4,12 +4,12 @@ import {
   SecondaryButton,
 } from "@coral-xyz/react-common";
 import { useAvatarUrl, useUser, useWalletName } from "@coral-xyz/recoil";
-import { styles } from "@coral-xyz/themes";
+import { makeStyles } from "tss-react/mui";
 
 import { walletAddressDisplay } from "../../../components/common";
 import { UNKNOWN_ICON_SRC } from "../../common/Icon";
 
-const useStyles = styles((theme) => ({
+const useStyles = makeStyles()((theme) => ({
   connectablesContainer: {
     display: "flex",
     flexDirection: "row",
@@ -124,7 +124,7 @@ export function OriginWalletConnectIcons({
   originTitle: string;
   wallet: string;
 }) {
-  const classes = useStyles();
+  const { classes } = useStyles();
   const walletName = useWalletName(wallet);
   const avatarUrl = useAvatarUrl(56);
   const { username } = useUser();
@@ -183,7 +183,7 @@ export function Connectable({
   kind?: "small" | "medium";
   style?: React.CSSProperties;
 }) {
-  const classes = useStyles();
+  const { classes } = useStyles();
   return (
     <div className={classes.connectable} style={style}>
       <div

--- a/packages/app-extension/src/components/Unlocked/Balances/StripeRamp.tsx
+++ b/packages/app-extension/src/components/Unlocked/Balances/StripeRamp.tsx
@@ -2,14 +2,14 @@ import { useEffect, useState } from "react";
 import type { Blockchain } from "@coral-xyz/common";
 import { Loading, PrimaryButton } from "@coral-xyz/react-common";
 import type { CustomTheme } from "@coral-xyz/themes";
-import { styles } from "@coral-xyz/themes";
 import { Typography } from "@mui/material";
+import { makeStyles } from "tss-react/mui";
 
 import { useDrawerContext } from "../../common/Layout/Drawer";
 
 const STRIP_RAMP_URL = "https://auth.xnfts.dev";
 
-const useStyles = styles((theme: CustomTheme) => ({
+const useStyles = makeStyles()((theme: CustomTheme) => ({
   outerContainer: {
     height: "80vh",
     display: "flex",
@@ -39,7 +39,7 @@ export const StripeRamp = ({
   const [, setLoading] = useState(false);
   const [err, setErr] = useState("");
   const [, setClientSecret] = useState(false);
-  const classes = useStyles();
+  const { classes } = useStyles();
 
   const fetchToken = () => {
     setLoading(true);

--- a/packages/app-extension/src/components/Unlocked/Balances/TokensWidget/AddressSelector.tsx
+++ b/packages/app-extension/src/components/Unlocked/Balances/TokensWidget/AddressSelector.tsx
@@ -29,7 +29,7 @@ import BlockIcon from "@mui/icons-material/Block";
 import SearchIcon from "@mui/icons-material/Search";
 import { List, ListItem } from "@mui/material";
 import InputAdornment from "@mui/material/InputAdornment";
-import { createStyles, makeStyles } from "@mui/styles";
+import { makeStyles } from "tss-react/mui";
 
 import {
   useNavigation,
@@ -40,12 +40,13 @@ import { useIsValidAddress } from "./Send";
 
 let debouncedTimer = 0;
 
-const useStyles = makeStyles((theme: any) =>
-  createStyles({
+const useStyles = makeStyles<void, "hoverChild">()(
+  (theme: any, _params, classes) => ({
     hoverParent: {
-      "&:hover $hoverChild, & .Mui-focused $hoverChild": {
-        visibility: "visible",
-      },
+      [`&:hover .${classes.hoverChild}, & .Mui-focused .${classes.hoverChild}`]:
+        {
+          visibility: "visible",
+        },
     },
     hoverChild: {
       visibility: "hidden",
@@ -145,7 +146,7 @@ export const AddressSelector = ({
   blockchain: Blockchain;
   token: TokenDataWithPrice;
 }) => {
-  const classes = useStyles();
+  const { classes } = useStyles();
   const nav = useNavigationEphemeral();
   const [inputContent, setInputContent] = useState("");
   const { provider: solanaProvider } = useAnchorContext();
@@ -288,7 +289,7 @@ function MembersList({
 }) {
   const theme = useCustomTheme();
   const MEMBER_THRESHOLD = 3;
-  const classes = useStyles();
+  const { classes } = useStyles();
   const renderMembersStr = () => {
     if (members.length <= MEMBER_THRESHOLD) {
       return members.map(
@@ -488,7 +489,7 @@ const AddressListItem = ({
   isLast: boolean;
 }) => {
   const theme = useCustomTheme();
-  const classes = useStyles();
+  const { classes } = useStyles();
   const { push } = useNavigation();
   const { blockchain, token } = useAddressSelectorContext();
 

--- a/packages/app-extension/src/components/Unlocked/Balances/TokensWidget/Ramp.tsx
+++ b/packages/app-extension/src/components/Unlocked/Balances/TokensWidget/Ramp.tsx
@@ -9,9 +9,9 @@ import {
   useAllWalletsDisplayed,
   useWalletName,
 } from "@coral-xyz/recoil";
-import { styles } from "@coral-xyz/themes";
 import { ListItemIcon, Typography } from "@mui/material";
 import { useRecoilValue } from "recoil";
+import { makeStyles } from "tss-react/mui";
 
 import { TextField } from "../../../common";
 import { useNavigation } from "../../../common/Layout/NavStack";
@@ -22,7 +22,7 @@ import {
   BalancesTableRow,
 } from "../Balances";
 
-const useStyles = styles((theme) => ({
+const useStyles = makeStyles()((theme) => ({
   searchField: {
     marginLeft: "12px",
     marginRight: "12px",
@@ -120,7 +120,7 @@ export function Ramp({
   const wallets = useAllWalletsDisplayed();
   const [searchFilter, setSearchFilter] = useState("");
   const { push } = useNavigation();
-  const classes = useStyles();
+  const { classes } = useStyles();
 
   // If prop one is undefined, both must be undefined.
   if ((blockchain && !publicKey) || (!blockchain && publicKey)) {
@@ -225,7 +225,7 @@ export function RampCard({
 
 function RampTokenCell({ token }: any) {
   const { icon, title, subtitle } = token;
-  const classes = useStyles();
+  const { classes } = useStyles();
   return (
     <div className={classes.balancesTableCellContainer}>
       {!!icon && (

--- a/packages/app-extension/src/components/Unlocked/Balances/TokensWidget/Token.tsx
+++ b/packages/app-extension/src/components/Unlocked/Balances/TokensWidget/Token.tsx
@@ -6,8 +6,8 @@ import {
   useActiveEthereumWallet,
   useLoader,
 } from "@coral-xyz/recoil";
-import { styles } from "@coral-xyz/themes";
 import { Typography } from "@mui/material";
+import { makeStyles } from "tss-react/mui";
 
 import { Button } from "../../../../plugin/Component";
 import { CloseButton, WithDrawer } from "../../../common/Layout/Drawer";
@@ -19,7 +19,7 @@ import { TokenAmountHeader } from "../../../common/TokenAmountHeader";
 import { RecentActivityList } from "../RecentActivity";
 import { TransferWidget } from "../TransferWidget";
 
-const useStyles = styles((theme) => ({
+const useStyles = makeStyles()((theme) => ({
   tokenHeaderButtonContainer: {
     display: "flex",
     justifyContent: "space-between",
@@ -96,7 +96,7 @@ function TokenHeader({
   tokenAddress,
   publicKey,
 }: SearchParamsFor.Token["props"]) {
-  const classes = useStyles();
+  const { classes } = useStyles();
   const [token] = useLoader(
     blockchainTokenData({
       publicKey,
@@ -155,7 +155,7 @@ export function WithHeaderButton({
   label,
   routes,
 }: any) {
-  const classes = useStyles();
+  const { classes } = useStyles();
   const [openDrawer, setOpenDrawer] = useState(false);
   const initialRoute = routes[0];
   return (

--- a/packages/app-extension/src/components/Unlocked/Messages/styles.ts
+++ b/packages/app-extension/src/components/Unlocked/Messages/styles.ts
@@ -1,117 +1,121 @@
-import { styles } from "@coral-xyz/themes";
+import { makeStyles } from "tss-react/mui";
 
-export const useStyles = styles((theme) => ({
-  searchField: {
-    marginTop: "16px",
-    marginBottom: "16px",
-    width: "inherit",
-    display: "flex",
-    "& .MuiOutlinedInput-root": {
-      "& input": {
-        paddingTop: 0,
-        paddingBottom: 0,
+// TODO jss-to-tss-react codemod: usages of this hook outside of this file will not be converted.
+export const useStyles = makeStyles<void, "hoverChild">()(
+  (theme, _params, classes) => ({
+    searchField: {
+      marginTop: "16px",
+      marginBottom: "16px",
+      width: "inherit",
+      display: "flex",
+      "& .MuiOutlinedInput-root": {
+        "& input": {
+          paddingTop: 0,
+          paddingBottom: 0,
+        },
       },
     },
-  },
-  icon: {
-    background: theme.custom.colors.textBackground,
-  },
-  iconInner: {
-    background: theme.custom.colors.fontColor,
-  },
-  topImage: {
-    maxWidth: "25vw",
-  },
-  horizontalCenter: {
-    display: "flex",
-    justifyContent: "center",
-  },
-  container: {
-    marginLeft: "16px",
-    marginRight: "16px",
-  },
-  roundBtn: {
-    marginLeft: 8,
-    borderRadius: 20,
-    width: 20,
-    height: 20,
-    cursor: "pointer",
-    background: "#FFFFFF",
-    border: "2px solid #F0F0F2",
-    fontSize: 10,
-  },
-  add: {
-    width: 17,
-    paddingBottom: 6,
-    paddingRight: 1,
-  },
-  iconCircular: {
-    width: "32px",
-    height: "32px",
-    borderRadius: "16px",
-    marginRight: "8px",
-    color: theme.custom.colors.positive,
-  },
-  iconCircularBig: {
-    width: "40px",
-    height: "40px",
-    borderRadius: "16px",
-    marginRight: "8px",
-    color: theme.custom.colors.positive,
-  },
-  hoverParent: {
-    "&:hover $hoverChild, & .Mui-focused $hoverChild": {
-      visibility: "visible",
+    icon: {
+      background: theme.custom.colors.textBackground,
     },
-  },
-  hoverChild: {
-    visibility: "hidden",
-  },
-  text: {
-    color: theme.custom.colors.fontColor2,
-  },
-  smallText: {
-    fontSize: 12,
-    color: theme.custom.colors.fontColor2,
-  },
-  userText: {
-    fontSize: 16,
-    marginTop: 4,
-    color: theme.custom.colors.fontColor2,
-  },
-  userTextSmall: {
-    fontSize: 14,
-    color: theme.custom.colors.fontColor2,
-  },
-  timestamp: {
-    fontSize: 14,
-    minWidth: 60,
-    color: theme.custom.colors.fontColor2,
-  },
-  smallTitle: {
-    color: theme.custom.colors.smallTextColor,
-    fontWeight: 600,
-  },
-  smallSubTitle: {
-    color: theme.custom.colors.smallTextColor,
-    fontWeight: 500,
-  },
-  contactIconOuter: {
-    background: theme.custom.colors.textBorder,
-  },
-  menuItem: {
-    fontWeight: 400,
-    fontSize: 14,
-    color: theme.custom.colors.fontColor,
-    padding: "12px 16px",
-  },
-  menu: {
-    "& .MuiList-root": {
-      padding: 0,
+    iconInner: {
+      background: theme.custom.colors.fontColor,
     },
-    paddingTop: 0,
-    paddingBottom: 0,
-    minWidth: 184,
-    color: theme.custom.colors.fontColor,
-  },
-}));
+    topImage: {
+      maxWidth: "25vw",
+    },
+    horizontalCenter: {
+      display: "flex",
+      justifyContent: "center",
+    },
+    container: {
+      marginLeft: "16px",
+      marginRight: "16px",
+    },
+    roundBtn: {
+      marginLeft: 8,
+      borderRadius: 20,
+      width: 20,
+      height: 20,
+      cursor: "pointer",
+      background: "#FFFFFF",
+      border: "2px solid #F0F0F2",
+      fontSize: 10,
+    },
+    add: {
+      width: 17,
+      paddingBottom: 6,
+      paddingRight: 1,
+    },
+    iconCircular: {
+      width: "32px",
+      height: "32px",
+      borderRadius: "16px",
+      marginRight: "8px",
+      color: theme.custom.colors.positive,
+    },
+    iconCircularBig: {
+      width: "40px",
+      height: "40px",
+      borderRadius: "16px",
+      marginRight: "8px",
+      color: theme.custom.colors.positive,
+    },
+    hoverParent: {
+      [`&:hover .${classes.hoverChild}, & .Mui-focused .${classes.hoverChild}`]:
+        {
+          visibility: "visible",
+        },
+    },
+    hoverChild: {
+      visibility: "hidden",
+    },
+    text: {
+      color: theme.custom.colors.fontColor2,
+    },
+    smallText: {
+      fontSize: 12,
+      color: theme.custom.colors.fontColor2,
+    },
+    userText: {
+      fontSize: 16,
+      marginTop: 4,
+      color: theme.custom.colors.fontColor2,
+    },
+    userTextSmall: {
+      fontSize: 14,
+      color: theme.custom.colors.fontColor2,
+    },
+    timestamp: {
+      fontSize: 14,
+      minWidth: 60,
+      color: theme.custom.colors.fontColor2,
+    },
+    smallTitle: {
+      color: theme.custom.colors.smallTextColor,
+      fontWeight: 600,
+    },
+    smallSubTitle: {
+      color: theme.custom.colors.smallTextColor,
+      fontWeight: 500,
+    },
+    contactIconOuter: {
+      background: theme.custom.colors.textBorder,
+    },
+    menuItem: {
+      fontWeight: 400,
+      fontSize: 14,
+      color: theme.custom.colors.fontColor,
+      padding: "12px 16px",
+    },
+    menu: {
+      "& .MuiList-root": {
+        padding: 0,
+      },
+      paddingTop: 0,
+      paddingBottom: 0,
+      minWidth: 184,
+      color: theme.custom.colors.fontColor,
+    },
+  })
+);

--- a/packages/app-extension/src/components/Unlocked/Nfts/EntryONE.tsx
+++ b/packages/app-extension/src/components/Unlocked/Nfts/EntryONE.tsx
@@ -1,11 +1,11 @@
 import { useLayoutEffect, useRef, useState } from "react";
 import { isOneLive, useOpenPlugin } from "@coral-xyz/recoil";
-import { styles } from "@coral-xyz/themes";
 import { Skeleton } from "@mui/material";
 import Card from "@mui/material/Card";
 import { useRecoilValue } from "recoil";
+import { makeStyles } from "tss-react/mui";
 
-const useStyles = styles((theme) => ({
+const useStyles = makeStyles()((theme) => ({
   blockchainCard: {
     position: "relative",
     marginBottom: "12px",
@@ -67,7 +67,7 @@ export default function EntryONE() {
   const [imageLoaded, setImageLoaded] = useState(false);
   const ref = useRef<HTMLImageElement>(null);
   const isONELive = useRecoilValue(isOneLive);
-  const classes = useStyles();
+  const { classes } = useStyles();
   const openPlugin = useOpenPlugin();
 
   useLayoutEffect(() => {

--- a/packages/app-extension/src/components/Unlocked/Nfts/Experience.tsx
+++ b/packages/app-extension/src/components/Unlocked/Nfts/Experience.tsx
@@ -12,10 +12,10 @@ import {
   useNavigation,
   useUser,
 } from "@coral-xyz/recoil";
-import { styles } from "@coral-xyz/themes";
 import ArrowRightAltIcon from "@mui/icons-material/ArrowRightAlt";
+import { makeStyles } from "tss-react/mui";
 
-const useStyles = styles(() => ({
+const useStyles = makeStyles()(() => ({
   container: {
     width: "100%",
     height: "100%",
@@ -64,7 +64,7 @@ export function NftChat({ collectionId, nftMint }: any) {
 }
 
 function MainScreen({ id }: { id: string }) {
-  const classes = useStyles();
+  const { classes } = useStyles();
   const { push } = useNavigation();
   return (
     <div className={classes.container}>

--- a/packages/app-extension/src/components/Unlocked/Settings/AvatarPopover.tsx
+++ b/packages/app-extension/src/components/Unlocked/Settings/AvatarPopover.tsx
@@ -5,7 +5,7 @@ import {
   UI_RPC_METHOD_ACTIVE_USER_UPDATE,
   UI_RPC_METHOD_KEYRING_STORE_LOCK,
 } from "@coral-xyz/common";
-import { ProxyImage , useBreakpoints } from "@coral-xyz/react-common";
+import { ProxyImage, useBreakpoints } from "@coral-xyz/react-common";
 import {
   useAllUsers,
   useAvatarUrl,
@@ -15,10 +15,11 @@ import {
 import { HOVER_OPACITY, styles, useCustomTheme } from "@coral-xyz/themes";
 import { Add, Check } from "@mui/icons-material";
 import { Button, IconButton, Popover, Typography } from "@mui/material";
+import { makeStyles } from "@mui/styles";
 
 import { SettingsNavStackDrawer } from "./SettingsNavStackDrawer";
 
-const useStyles = styles((theme) => ({
+const useStyles = makeStyles((theme) => ({
   menuButton: {
     padding: "2px",
     background: `${theme.custom.colors.avatarIconBackground} !important`,

--- a/packages/app-extension/src/components/Unlocked/Settings/Preferences/index.tsx
+++ b/packages/app-extension/src/components/Unlocked/Settings/Preferences/index.tsx
@@ -14,8 +14,8 @@ import {
   useDeveloperMode,
   useIsAggregateWallets,
 } from "@coral-xyz/recoil";
+import { styles as makeStyles } from "@coral-xyz/themes";
 import { Switch } from "@mui/material";
-import { makeStyles } from "tss-react/mui";
 
 import {
   deleteSubscription,

--- a/packages/app-extension/src/components/Unlocked/Settings/Preferences/index.tsx
+++ b/packages/app-extension/src/components/Unlocked/Settings/Preferences/index.tsx
@@ -14,8 +14,8 @@ import {
   useDeveloperMode,
   useIsAggregateWallets,
 } from "@coral-xyz/recoil";
-import { styles } from "@coral-xyz/themes";
 import { Switch } from "@mui/material";
+import { makeStyles } from "tss-react/mui";
 
 import {
   deleteSubscription,
@@ -201,7 +201,7 @@ export function SwitchToggle({
   onChange: () => void;
   disableUiState?: boolean;
 }) {
-  const classes = useStyles();
+  const { classes } = useStyles();
   return (
     <Switch
       disableRipple
@@ -217,7 +217,7 @@ export function SwitchToggle({
   );
 }
 
-const useStyles = styles((theme) => ({
+const useStyles = makeStyles()((theme) => ({
   switchBase: {
     "&:hover": {
       backgroundColor: "transparent !important",

--- a/packages/app-extension/src/components/common/Account/MnemonicInput.tsx
+++ b/packages/app-extension/src/components/common/Account/MnemonicInput.tsx
@@ -15,11 +15,11 @@ import {
   TextField,
   Typography,
 } from "@mui/material";
-import makeStyles from "@mui/styles/makeStyles";
+import { makeStyles } from "tss-react/mui";
 
 import { CheckboxForm, Header, SubtextParagraph } from "../../common";
 import { WithCopyTooltip } from "../../common/WithCopyTooltip";
-const useStyles = makeStyles((theme: any) => ({
+const useStyles = makeStyles()((theme: any) => ({
   mnemonicInputRoot: {
     border: `${theme.custom.colors.borderFull}`,
     background: theme.custom.colors.textBackground,
@@ -75,7 +75,7 @@ export function MnemonicInput({
   customError?: string;
 }) {
   const theme = useCustomTheme();
-  const classes = useStyles();
+  const { classes } = useStyles();
   const background = useBackgroundClient();
   const [mnemonicWords, setMnemonicWords] = useState<string[]>([
     ...Array(12).fill(""),
@@ -254,7 +254,7 @@ export function MnemonicInputFields({
   rootClass?: any;
 }) {
   const theme = useCustomTheme();
-  const classes = useStyles();
+  const { classes } = useStyles();
   if (!rootClass) {
     rootClass = classes.mnemonicInputRoot;
   }

--- a/packages/app-extension/src/components/common/Layout/Drawer.tsx
+++ b/packages/app-extension/src/components/common/Layout/Drawer.tsx
@@ -9,13 +9,13 @@ import React, {
 } from "react";
 import { EXTENSION_HEIGHT } from "@coral-xyz/common";
 import { useEphemeralNav } from "@coral-xyz/recoil";
-import { styles } from "@coral-xyz/themes";
 import { Close } from "@mui/icons-material";
 import { Button, Drawer, IconButton } from "@mui/material";
+import { makeStyles } from "tss-react/mui";
 
 import { NAV_BAR_HEIGHT, NAV_BUTTON_WIDTH } from "./Nav";
 
-const useStyles = styles((theme) => ({
+const useStyles = makeStyles()((theme) => ({
   withDrawer: {
     height: "100%",
     display: "flex",
@@ -76,7 +76,7 @@ export function WithDrawer(
     setOpenDrawer: Dispatch<SetStateAction<boolean>>;
   }>
 ) {
-  const classes = useStyles();
+  const { classes } = useStyles();
   const { backdropStyles, children, openDrawer, paperStyles, setOpenDrawer } =
     props;
   return (
@@ -108,7 +108,7 @@ export function WithDrawer(
 }
 
 export function WithMiniDrawer(props: any) {
-  const classes = useStyles();
+  const { classes } = useStyles();
   const {
     children,
     openDrawer,
@@ -150,7 +150,7 @@ export function WithMiniDrawer(props: any) {
 }
 
 export function CloseButton({ onClick, buttonStyle }: any) {
-  const classes = useStyles();
+  const { classes } = useStyles();
   return (
     <div
       style={{
@@ -180,7 +180,7 @@ export function CloseButton({ onClick, buttonStyle }: any) {
 
 export function WithDrawerNoHeader(props: any) {
   const { children, openDrawer, setOpenDrawer } = props;
-  const classes = useStyles();
+  const { classes } = useStyles();
   return (
     <Drawer
       BackdropProps={{

--- a/packages/app-extension/src/components/common/NotificationIconWithBadge.tsx
+++ b/packages/app-extension/src/components/common/NotificationIconWithBadge.tsx
@@ -1,7 +1,7 @@
 import { useUnreadCount } from "@coral-xyz/recoil";
 import NotificationsIcon from "@mui/icons-material/Notifications";
 import { Badge } from "@mui/material";
-import { makeStyles } from "@mui/styles";
+import { makeStyles } from "tss-react/mui";
 const badgeStyle = {
   "& .MuiBadge-badge": {
     color: "white",
@@ -10,7 +10,7 @@ const badgeStyle = {
     minWidth: 16,
   },
 };
-const useStyles = makeStyles(() => ({
+const useStyles = makeStyles()(() => ({
   badge: {
     fontSize: 10,
   },
@@ -18,7 +18,7 @@ const useStyles = makeStyles(() => ({
 
 export const NotificationIconWithBadge = ({ style }: { style: any }) => {
   const unreadCount = useUnreadCount();
-  const classes = useStyles();
+  const { classes } = useStyles();
 
   if (!unreadCount) {
     return <NotificationsIcon style={style} />;

--- a/packages/app-extension/src/components/common/TokenTable.tsx
+++ b/packages/app-extension/src/components/common/TokenTable.tsx
@@ -10,8 +10,8 @@ import {
   useBlockchainConnectionUrl,
   useLoader,
 } from "@coral-xyz/recoil";
-import { styles } from "@coral-xyz/themes";
 import { Skeleton } from "@mui/material";
+import { makeStyles } from "tss-react/mui";
 
 import {
   BalancesTable,
@@ -23,7 +23,7 @@ import {
 
 export type Token = ReturnType<typeof useBlockchainTokensSorted>[number];
 
-const useStyles = styles(() => ({
+const useStyles = makeStyles()(() => ({
   searchField: {
     marginLeft: "12px",
     marginRight: "12px",
@@ -50,7 +50,7 @@ export function SearchableTokenTables({
   onClickRow: (blockchain: Blockchain, token: Token) => void;
   customFilter: (token: Token) => boolean;
 }) {
-  const classes = useStyles();
+  const { classes } = useStyles();
   const [searchFilter, setSearchFilter] = useState("");
   return (
     <>
@@ -83,7 +83,7 @@ export function SearchableTokenTable({
   tokenAccounts?: ReturnType<typeof useBlockchainTokensSorted>;
   customFilter: (token: Token) => boolean;
 }) {
-  const classes = useStyles();
+  const { classes } = useStyles();
   const [searchFilter, setSearchFilter] = useState("");
   return (
     <>
@@ -251,7 +251,7 @@ export function WalletTokenTable({
 }
 
 const SkeletonRows = () => {
-  const classes = useStyles();
+  const { classes } = useStyles();
   return (
     <BalancesTableRow>
       <div

--- a/packages/app-extension/src/permissions/PermissionsContent.tsx
+++ b/packages/app-extension/src/permissions/PermissionsContent.tsx
@@ -1,7 +1,7 @@
-import { styles } from "@coral-xyz/themes";
 import { Typography } from "@mui/material";
+import { makeStyles } from "tss-react/mui";
 
-const useStyles = styles(() => ({
+const useStyles = makeStyles()(() => ({
   containerDiv: {
     height: `100vh`,
     width: "100vw",
@@ -18,14 +18,15 @@ const useStyles = styles(() => ({
     margin: "auto",
     height: "100px",
     width: "100px",
-    backgroundColor: (props: any) => props.backgroundColor,
+    // backgroundColor: (props: any) => props.backgroundColor,
     borderRadius: "50%",
   },
   icon: {
-    marginTop: (props: any) => props.marginTop || 25,
-    marginLeft: (props: any) => props.marginLeft || 25,
+    // marginTop: (props: any) => props.marginTop || 25,
+    // marginLeft: (props: any) => props.marginLeft || 25,
   },
 }));
+
 interface Props {
   title: string;
   subtitle1: string;
@@ -44,7 +45,7 @@ export const PermissionsContent = ({
   marginTop,
   marginLeft,
 }: Props) => {
-  const classes = useStyles({ backgroundColor, marginTop, marginLeft });
+  const { classes } = useStyles();
   return (
     <div className={classes.containerDiv}>
       <div>

--- a/packages/react-common/src/components/base/Inputs.tsx
+++ b/packages/react-common/src/components/base/Inputs.tsx
@@ -153,7 +153,7 @@ export const InputListItem = ({
         height: "46px",
         padding: "10px",
       }}
-      radius={"8px"}
+      // radius={"8px"}
       button={button}
     >
       <Typography style={{ width: "80px" }}>{title}</Typography>

--- a/packages/react-common/src/components/base/Inputs.tsx
+++ b/packages/react-common/src/components/base/Inputs.tsx
@@ -10,7 +10,7 @@ function overrideErrBorder(originalBorder: string, err: boolean, theme: any) {
   return originalBorder;
 }
 
-const useStyles = styles((theme) => ({
+const useStyles = styles()((theme) => ({
   textFieldRoot: {
     color: theme.custom.colors.secondary,
     "& .MuiOutlinedInput-root": {

--- a/packages/themes/src/index.tsx
+++ b/packages/themes/src/index.tsx
@@ -1,8 +1,6 @@
-import createStyles from "@mui/styles/createStyles";
-import _makeStyles from "@mui/styles/makeStyles";
-import useTheme from "@mui/styles/useTheme";
+import { styled as muiStyled, useTheme } from "@mui/material/styles";
 import type { CreateMUIStyled, Theme } from "@mui/system";
-import muiStyled from "@mui/system/styled";
+import { makeStyles as _makeStyles } from "tss-react/mui";
 
 export const HOVER_OPACITY = 0.8;
 
@@ -136,7 +134,7 @@ type CustomColors = {
   chatFadeGradientStart: string;
 };
 
-const baseTheme = createStyles({
+const baseTheme = _makeStyles()({
   typography: {
     fontFamily: ["Inter", "sans-serif"].join(","),
     // TODO: do we need all of these?

--- a/yarn.lock
+++ b/yarn.lock
@@ -2402,17 +2402,7 @@
     source-map "^0.5.7"
     stylis "4.0.13"
 
-"@emotion/cache@^10.0.27":
-  version "10.0.29"
-  resolved "https://registry.yarnpkg.com/@emotion/cache/-/cache-10.0.29.tgz#87e7e64f412c060102d589fe7c6dc042e6f9d1e0"
-  integrity sha512-fU2VtSVlHiF27empSbxi1O2JFdNWZO+2NFHfwO0pxgTep6Xa3uGb+3pVKfLww2l/IBGLNEZl5Xf/++A4wAYDYQ==
-  dependencies:
-    "@emotion/sheet" "0.9.4"
-    "@emotion/stylis" "0.8.5"
-    "@emotion/utils" "0.11.3"
-    "@emotion/weak-memoize" "0.2.5"
-
-"@emotion/cache@^11.10.5", "@emotion/cache@^11.9.3":
+"@emotion/cache@*", "@emotion/cache@^11.10.5", "@emotion/cache@^11.9.3":
   version "11.10.5"
   resolved "https://registry.yarnpkg.com/@emotion/cache/-/cache-11.10.5.tgz#c142da9351f94e47527ed458f7bbbbe40bb13c12"
   integrity sha512-dGYHWyzTdmK+f2+EnIGBpkz1lKc4Zbj2KHd4cX3Wi8/OWr5pKslNjc3yABKH4adRGCvSX4VDC0i04mrrq0aiRA==
@@ -2422,6 +2412,16 @@
     "@emotion/utils" "^1.2.0"
     "@emotion/weak-memoize" "^0.3.0"
     stylis "4.1.3"
+
+"@emotion/cache@^10.0.27":
+  version "10.0.29"
+  resolved "https://registry.yarnpkg.com/@emotion/cache/-/cache-10.0.29.tgz#87e7e64f412c060102d589fe7c6dc042e6f9d1e0"
+  integrity sha512-fU2VtSVlHiF27empSbxi1O2JFdNWZO+2NFHfwO0pxgTep6Xa3uGb+3pVKfLww2l/IBGLNEZl5Xf/++A4wAYDYQ==
+  dependencies:
+    "@emotion/sheet" "0.9.4"
+    "@emotion/stylis" "0.8.5"
+    "@emotion/utils" "0.11.3"
+    "@emotion/weak-memoize" "0.2.5"
 
 "@emotion/hash@0.8.0", "@emotion/hash@^0.8.0":
   version "0.8.0"
@@ -2475,6 +2475,17 @@
     "@emotion/weak-memoize" "^0.2.5"
     hoist-non-react-statics "^3.3.1"
 
+"@emotion/serialize@*", "@emotion/serialize@^1.0.2", "@emotion/serialize@^1.0.4":
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/@emotion/serialize/-/serialize-1.1.1.tgz#0595701b1902feded8a96d293b26be3f5c1a5cf0"
+  integrity sha512-Zl/0LFggN7+L1liljxXdsVSVlg6E/Z/olVWpfxUTxOAmi8NU7YoeWeLfi1RmnB2TATHoaWwIBRoL+FvAJiTUQA==
+  dependencies:
+    "@emotion/hash" "^0.9.0"
+    "@emotion/memoize" "^0.8.0"
+    "@emotion/unitless" "^0.8.0"
+    "@emotion/utils" "^1.2.0"
+    csstype "^3.0.2"
+
 "@emotion/serialize@^0.11.15", "@emotion/serialize@^0.11.16":
   version "0.11.16"
   resolved "https://registry.yarnpkg.com/@emotion/serialize/-/serialize-0.11.16.tgz#dee05f9e96ad2fb25a5206b6d759b2d1ed3379ad"
@@ -2485,17 +2496,6 @@
     "@emotion/unitless" "0.7.5"
     "@emotion/utils" "0.11.3"
     csstype "^2.5.7"
-
-"@emotion/serialize@^1.0.2", "@emotion/serialize@^1.0.4":
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/@emotion/serialize/-/serialize-1.1.1.tgz#0595701b1902feded8a96d293b26be3f5c1a5cf0"
-  integrity sha512-Zl/0LFggN7+L1liljxXdsVSVlg6E/Z/olVWpfxUTxOAmi8NU7YoeWeLfi1RmnB2TATHoaWwIBRoL+FvAJiTUQA==
-  dependencies:
-    "@emotion/hash" "^0.9.0"
-    "@emotion/memoize" "^0.8.0"
-    "@emotion/unitless" "^0.8.0"
-    "@emotion/utils" "^1.2.0"
-    csstype "^3.0.2"
 
 "@emotion/sheet@0.9.4":
   version "0.9.4"
@@ -2533,15 +2533,15 @@
   resolved "https://registry.yarnpkg.com/@emotion/unitless/-/unitless-0.8.0.tgz#a4a36e9cbdc6903737cd20d38033241e1b8833db"
   integrity sha512-VINS5vEYAscRl2ZUDiT3uMPlrFQupiKgHz5AA4bCH1miKBg4qtwkim1qPmJj/4WG6TreYMY111rEFsjupcOKHw==
 
+"@emotion/utils@*", "@emotion/utils@^1.1.0", "@emotion/utils@^1.2.0":
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/@emotion/utils/-/utils-1.2.0.tgz#9716eaccbc6b5ded2ea5a90d65562609aab0f561"
+  integrity sha512-sn3WH53Kzpw8oQ5mgMmIzzyAaH2ZqFEbozVVBSYp538E06OSE6ytOp7pRAjNQR+Q/orwqdQYJSe2m3hCOeznkw==
+
 "@emotion/utils@0.11.3":
   version "0.11.3"
   resolved "https://registry.yarnpkg.com/@emotion/utils/-/utils-0.11.3.tgz#a759863867befa7e583400d322652a3f44820924"
   integrity sha512-0o4l6pZC+hI88+bzuaX/6BgOvQVhbt2PfmxauVaYOGgbsAw14wdKyvMCZXnsnsHys94iadcF+RG/wZyx6+ZZBw==
-
-"@emotion/utils@^1.1.0", "@emotion/utils@^1.2.0":
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/@emotion/utils/-/utils-1.2.0.tgz#9716eaccbc6b5ded2ea5a90d65562609aab0f561"
-  integrity sha512-sn3WH53Kzpw8oQ5mgMmIzzyAaH2ZqFEbozVVBSYp538E06OSE6ytOp7pRAjNQR+Q/orwqdQYJSe2m3hCOeznkw==
 
 "@emotion/weak-memoize@0.2.5", "@emotion/weak-memoize@^0.2.5":
   version "0.2.5"
@@ -6994,7 +6994,30 @@
     "@wallet-standard/app" "^1.0.0"
     "@wallet-standard/base" "^1.0.0"
 
-"@solana/web3.js@1.52.0", "@solana/web3.js@1.63.1", "@solana/web3.js@^1.17.0", "@solana/web3.js@^1.21.0", "@solana/web3.js@^1.30.2", "@solana/web3.js@^1.31.0", "@solana/web3.js@^1.32.0", "@solana/web3.js@^1.35.1", "@solana/web3.js@^1.36.0", "@solana/web3.js@^1.37.1", "@solana/web3.js@^1.43.2", "@solana/web3.js@^1.47.3", "@solana/web3.js@^1.56.2", "@solana/web3.js@^1.63.1", "@solana/web3.js@^1.65.0", "@solana/web3.js@^1.66.2", "@solana/web3.js@^1.68.0", "@solana/web3.js@^1.69.0", "@solana/web3.js@^1.73.0", "@solana/web3.js@^1.73.2":
+"@solana/web3.js@1.52.0":
+  version "1.52.0"
+  resolved "https://registry.yarnpkg.com/@solana/web3.js/-/web3.js-1.52.0.tgz#71bd5c322a31e3e2fa8cda2261c594846810b8ea"
+  integrity sha512-oG1+BX4nVYZ0OBzmk6DRrY8oBYMsbXVQEf9N9JOfKm+wXSmjxVEEo8v3IPV8mKwR0JvUWuE8lOn3IUDiMlRLgg==
+  dependencies:
+    "@babel/runtime" "^7.12.5"
+    "@ethersproject/sha2" "^5.5.0"
+    "@solana/buffer-layout" "^4.0.0"
+    bigint-buffer "^1.1.5"
+    bn.js "^5.0.0"
+    borsh "^0.7.0"
+    bs58 "^4.0.1"
+    buffer "6.0.1"
+    fast-stable-stringify "^1.0.0"
+    jayson "^3.4.4"
+    js-sha3 "^0.8.0"
+    node-fetch "2"
+    react-native-url-polyfill "^1.3.0"
+    rpc-websockets "^7.5.0"
+    secp256k1 "^4.0.2"
+    superstruct "^0.14.2"
+    tweetnacl "^1.0.3"
+
+"@solana/web3.js@^1.17.0", "@solana/web3.js@^1.21.0", "@solana/web3.js@^1.30.2", "@solana/web3.js@^1.31.0", "@solana/web3.js@^1.32.0", "@solana/web3.js@^1.35.1", "@solana/web3.js@^1.36.0", "@solana/web3.js@^1.37.1", "@solana/web3.js@^1.43.2", "@solana/web3.js@^1.47.3", "@solana/web3.js@^1.56.2", "@solana/web3.js@^1.63.1":
   version "1.63.1"
   resolved "https://registry.yarnpkg.com/@solana/web3.js/-/web3.js-1.63.1.tgz#88a19a17f5f4aada73ad70a94044c1067cab2b4d"
   integrity sha512-wgEdGVK5FTS2zENxbcGSvKpGZ0jDS6BUdGu8Gn6ns0CzgJkK83u4ip3THSnBPEQ5i/jrqukg998BwV1H67+qiQ==
@@ -7004,6 +7027,28 @@
     "@noble/hashes" "^1.1.2"
     "@noble/secp256k1" "^1.6.3"
     "@solana/buffer-layout" "^4.0.0"
+    bigint-buffer "^1.1.5"
+    bn.js "^5.0.0"
+    borsh "^0.7.0"
+    bs58 "^4.0.1"
+    buffer "6.0.1"
+    fast-stable-stringify "^1.0.0"
+    jayson "^3.4.4"
+    node-fetch "2"
+    rpc-websockets "^7.5.0"
+    superstruct "^0.14.2"
+
+"@solana/web3.js@^1.65.0", "@solana/web3.js@^1.66.2", "@solana/web3.js@^1.68.0", "@solana/web3.js@^1.69.0", "@solana/web3.js@^1.73.0", "@solana/web3.js@^1.73.2":
+  version "1.73.2"
+  resolved "https://registry.yarnpkg.com/@solana/web3.js/-/web3.js-1.73.2.tgz#4b30cd402b35733dae3a7d0b638be26a7742b395"
+  integrity sha512-9WACF8W4Nstj7xiDw3Oom22QmrhBh0VyZyZ7JvvG3gOxLWLlX3hvm5nPVJOGcCE/9fFavBbCUb5A6CIuvMGdoA==
+  dependencies:
+    "@babel/runtime" "^7.12.5"
+    "@noble/ed25519" "^1.7.0"
+    "@noble/hashes" "^1.1.2"
+    "@noble/secp256k1" "^1.6.3"
+    "@solana/buffer-layout" "^4.0.0"
+    agentkeepalive "^4.2.1"
     bigint-buffer "^1.1.5"
     bn.js "^5.0.0"
     borsh "^0.7.0"
@@ -8855,6 +8900,15 @@ agent-base@6:
   integrity sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==
   dependencies:
     debug "4"
+
+agentkeepalive@^4.2.1:
+  version "4.2.1"
+  resolved "https://registry.yarnpkg.com/agentkeepalive/-/agentkeepalive-4.2.1.tgz#a7975cbb9f83b367f06c90cc51ff28fe7d499717"
+  integrity sha512-Zn4cw2NEqd+9fiSVWMscnjyQ1a8Yfoc5oBajLeo5w+YBHgDUcEBY2hS4YpTz6iN5f/2zQiktcuM6tS8x1p9dpA==
+  dependencies:
+    debug "^4.1.0"
+    depd "^1.1.2"
+    humanize-ms "^1.2.1"
 
 aggregate-error@^3.0.0:
   version "3.1.0"
@@ -12039,7 +12093,7 @@ depd@2.0.0, depd@^2.0.0, depd@~2.0.0:
   resolved "https://registry.yarnpkg.com/depd/-/depd-2.0.0.tgz#b696163cc757560d09cf22cc8fad1571b79e76df"
   integrity sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==
 
-depd@~1.1.2:
+depd@^1.1.2, depd@~1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/depd/-/depd-1.1.2.tgz#9bcd52e14c097763e749b274c4346ed2e560b5a9"
   integrity sha512-7emPTl6Dpo6JRXOXjLRxck+FlLRX5847cLKEn00PLAgc3g2hTZZgr+e4c2v6QpSmLeFP3n5yUo7ft6avBK/5jQ==
@@ -12937,6 +12991,32 @@ esbuild-windows-arm64@0.15.16:
   resolved "https://registry.yarnpkg.com/esbuild-windows-arm64/-/esbuild-windows-arm64-0.15.16.tgz#77e804d60dec0390fe8f21401e39b435d5d1b863"
   integrity sha512-oCcUKrJaMn04Vxy9Ekd8x23O8LoU01+4NOkQ2iBToKgnGj5eo1vU9i27NQZ9qC8NFZgnQQZg5oZWAejmbsppNA==
 
+esbuild@0.14.51, esbuild@^0.14.42, esbuild@^0.14.43, esbuild@^0.14.47:
+  version "0.14.51"
+  resolved "https://registry.yarnpkg.com/esbuild/-/esbuild-0.14.51.tgz#1c8ecbc8db3710da03776211dc3ee3448f7aa51e"
+  integrity sha512-+CvnDitD7Q5sT7F+FM65sWkF8wJRf+j9fPcprxYV4j+ohmzVj2W7caUqH2s5kCaCJAfcAICjSlKhDCcvDpU7nw==
+  optionalDependencies:
+    esbuild-android-64 "0.14.51"
+    esbuild-android-arm64 "0.14.51"
+    esbuild-darwin-64 "0.14.51"
+    esbuild-darwin-arm64 "0.14.51"
+    esbuild-freebsd-64 "0.14.51"
+    esbuild-freebsd-arm64 "0.14.51"
+    esbuild-linux-32 "0.14.51"
+    esbuild-linux-64 "0.14.51"
+    esbuild-linux-arm "0.14.51"
+    esbuild-linux-arm64 "0.14.51"
+    esbuild-linux-mips64le "0.14.51"
+    esbuild-linux-ppc64le "0.14.51"
+    esbuild-linux-riscv64 "0.14.51"
+    esbuild-linux-s390x "0.14.51"
+    esbuild-netbsd-64 "0.14.51"
+    esbuild-openbsd-64 "0.14.51"
+    esbuild-sunos-64 "0.14.51"
+    esbuild-windows-32 "0.14.51"
+    esbuild-windows-64 "0.14.51"
+    esbuild-windows-arm64 "0.14.51"
+
 esbuild@0.16.3:
   version "0.16.3"
   resolved "https://registry.yarnpkg.com/esbuild/-/esbuild-0.16.3.tgz#5868632fa23f7a8547f2a4ea359c44e946515c94"
@@ -12964,32 +13044,6 @@ esbuild@0.16.3:
     "@esbuild/win32-arm64" "0.16.3"
     "@esbuild/win32-ia32" "0.16.3"
     "@esbuild/win32-x64" "0.16.3"
-
-esbuild@^0.14.42, esbuild@^0.14.43, esbuild@^0.14.47:
-  version "0.14.51"
-  resolved "https://registry.yarnpkg.com/esbuild/-/esbuild-0.14.51.tgz#1c8ecbc8db3710da03776211dc3ee3448f7aa51e"
-  integrity sha512-+CvnDitD7Q5sT7F+FM65sWkF8wJRf+j9fPcprxYV4j+ohmzVj2W7caUqH2s5kCaCJAfcAICjSlKhDCcvDpU7nw==
-  optionalDependencies:
-    esbuild-android-64 "0.14.51"
-    esbuild-android-arm64 "0.14.51"
-    esbuild-darwin-64 "0.14.51"
-    esbuild-darwin-arm64 "0.14.51"
-    esbuild-freebsd-64 "0.14.51"
-    esbuild-freebsd-arm64 "0.14.51"
-    esbuild-linux-32 "0.14.51"
-    esbuild-linux-64 "0.14.51"
-    esbuild-linux-arm "0.14.51"
-    esbuild-linux-arm64 "0.14.51"
-    esbuild-linux-mips64le "0.14.51"
-    esbuild-linux-ppc64le "0.14.51"
-    esbuild-linux-riscv64 "0.14.51"
-    esbuild-linux-s390x "0.14.51"
-    esbuild-netbsd-64 "0.14.51"
-    esbuild-openbsd-64 "0.14.51"
-    esbuild-sunos-64 "0.14.51"
-    esbuild-windows-32 "0.14.51"
-    esbuild-windows-64 "0.14.51"
-    esbuild-windows-arm64 "0.14.51"
 
 esbuild@^0.15.13, esbuild@^0.15.16:
   version "0.15.16"
@@ -15681,6 +15735,13 @@ human-signals@^3.0.1:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/human-signals/-/human-signals-3.0.1.tgz#c740920859dafa50e5a3222da9d3bf4bb0e5eef5"
   integrity sha512-rQLskxnM/5OCldHo+wNXbpVgDn5A17CUoKX+7Sokwaknlq7CdSnphy0W39GU8dw59XiCXmFXDg4fRuckQRKewQ==
+
+humanize-ms@^1.2.1:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/humanize-ms/-/humanize-ms-1.2.1.tgz#c46e3159a293f6b896da29316d8b6fe8bb79bbed"
+  integrity sha512-Fl70vYtsAFb/C06PTS9dZBo7ihau+Tu/DNCk/OyHhea07S+aeMWpFFkUaXRa8fI+ScZbEI8dfSxwY7gxZ9SAVQ==
+  dependencies:
+    ms "^2.0.0"
 
 husky@^8.0.1:
   version "8.0.1"
@@ -19627,7 +19688,7 @@ miniflare@2.12.0:
     source-map-support "^0.5.20"
     undici "5.11.0"
 
-miniflare@^2.9.0:
+miniflare@2.9.0, miniflare@^2.9.0:
   version "2.9.0"
   resolved "https://registry.yarnpkg.com/miniflare/-/miniflare-2.9.0.tgz#ebd737675ef6067f8514b12a812c28a6d1837bad"
   integrity sha512-HBGQ5Jj6sMU1B1hX6G3ML46ThtUvu1nvxgXjDDmhp2RhWKYj0XvcohW/nPPL/MTP1gpvfT880De9EHmobVsDsw==
@@ -19785,7 +19846,7 @@ ms@2.1.2:
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.2.tgz#d09d1f357b443f493382a8eb3ccd183872ae6009"
   integrity sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==
 
-ms@2.1.3, ms@^2.1.1:
+ms@2.1.3, ms@^2.0.0, ms@^2.1.1:
   version "2.1.3"
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.3.tgz#574c8138ce1d2b5861f0b44579dbadd60c6615b2"
   integrity sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==
@@ -20658,7 +20719,7 @@ pako@~1.0.2, pako@~1.0.5:
   resolved "https://registry.yarnpkg.com/pako/-/pako-1.0.11.tgz#6c9599d340d54dfd3946380252a35705a6b992bf"
   integrity sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==
 
-parcel@2.7.0, parcel@^2.7.0:
+parcel@^2.7.0:
   version "2.7.0"
   resolved "https://registry.yarnpkg.com/parcel/-/parcel-2.7.0.tgz#41fdd3e5c7144d4cf7f1fa3ab8d0ea0d47d31f77"
   integrity sha512-pRYwnivwtNP0tip8xYSo4zCB0XhLt7/gJzP1p8OovCqkmFjG9VG+GW9TcAKqMIo0ovEa9tT+/s6gY1Qy+BONGQ==
@@ -21751,10 +21812,20 @@ react-reconciler@^0.26.0:
     object-assign "^4.1.1"
     scheduler "^0.20.2"
 
-react-refresh@0.11.0, react-refresh@^0.14.0, react-refresh@^0.4.0, react-refresh@^0.9.0:
-  version "0.11.0"
-  resolved "https://registry.yarnpkg.com/react-refresh/-/react-refresh-0.11.0.tgz#77198b944733f0f1f1a90e791de4541f9f074046"
-  integrity sha512-F27qZr8uUqwhWZboondsPx8tnC3Ct3SxZA3V5WyEvujRyyNv0VYPhoBg1gZ8/MV5tubQp76Trw8lTv9hzRBa+A==
+react-refresh@^0.14.0:
+  version "0.14.0"
+  resolved "https://registry.yarnpkg.com/react-refresh/-/react-refresh-0.14.0.tgz#4e02825378a5f227079554d4284889354e5f553e"
+  integrity sha512-wViHqhAd8OHeLS/IRMJjTSDHF3U9eWi62F/MledQGPdJGDhodXJ9PBLNGr6WWL7qlH12Mt3TyTpbS+hGXMjCzQ==
+
+react-refresh@^0.4.0:
+  version "0.4.3"
+  resolved "https://registry.yarnpkg.com/react-refresh/-/react-refresh-0.4.3.tgz#966f1750c191672e76e16c2efa569150cc73ab53"
+  integrity sha512-Hwln1VNuGl/6bVwnd0Xdn1e84gT/8T9aYNL+HAKDArLCS7LWjwr7StE30IEYbIkx0Vi3vs+coQxe+SQDbGbbpA==
+
+react-refresh@^0.9.0:
+  version "0.9.0"
+  resolved "https://registry.yarnpkg.com/react-refresh/-/react-refresh-0.9.0.tgz#71863337adc3e5c2f8a6bfddd12ae3bfe32aafbf"
+  integrity sha512-Gvzk7OZpiqKSkxsQvO/mbTN1poglhmAV7gR/DdIrRrSMXraRQQlfikRJOr3Nb9GTMPC5kof948Zy6jJZIFtDvQ==
 
 react-rich-mentions@^0.1.10:
   version "0.1.10"
@@ -24235,6 +24306,15 @@ tslib@^2.0.0, tslib@^2.0.1, tslib@^2.0.3, tslib@^2.1.0, tslib@^2.2.0, tslib@^2.3
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.4.0.tgz#7cecaa7f073ce680a05847aa77be941098f36dc3"
   integrity sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==
 
+tss-react@^4.6.1:
+  version "4.6.1"
+  resolved "https://registry.yarnpkg.com/tss-react/-/tss-react-4.6.1.tgz#a584d720d417350bcca327752e0a4ea77868726c"
+  integrity sha512-4MktjVhHqEav6JxipiTqFU7YcXbAt0DHD4CIGFpqQdYKkUHK6URLf/2hYjwDcHkiC22K5f3vTo8q2O1WQs1H3Q==
+  dependencies:
+    "@emotion/cache" "*"
+    "@emotion/serialize" "*"
+    "@emotion/utils" "*"
+
 tsscmp@1.0.6:
   version "1.0.6"
   resolved "https://registry.yarnpkg.com/tsscmp/-/tsscmp-1.0.6.tgz#85b99583ac3589ec4bfef825b5000aa911d605eb"
@@ -25237,7 +25317,30 @@ wordwrapjs@^4.0.0:
     reduce-flatten "^2.0.0"
     typical "^5.2.0"
 
-wrangler@2.1.9, wrangler@^2.0.15, wrangler@^2.1.6, wrangler@^2.1.9, wrangler@^2.10.0, wrangler@^2.7.1:
+wrangler@2.1.9:
+  version "2.1.9"
+  resolved "https://registry.yarnpkg.com/wrangler/-/wrangler-2.1.9.tgz#295c4184c493004fab37c35c1fa364e9f4f8d4a1"
+  integrity sha512-ryrkpUEqgJZIiGgo+VCUYtl0B+shEbyp3FZzT5+GYnyfpLtQutAZlS/s5iOC0qjZ7TcRzWS1PSb9fE9nDSvCKg==
+  dependencies:
+    "@cloudflare/kv-asset-handler" "^0.2.0"
+    "@esbuild-plugins/node-globals-polyfill" "^0.1.1"
+    "@esbuild-plugins/node-modules-polyfill" "^0.1.4"
+    "@miniflare/core" "2.9.0"
+    "@miniflare/d1" "2.9.0"
+    "@miniflare/durable-objects" "2.9.0"
+    blake3-wasm "^2.1.5"
+    chokidar "^3.5.3"
+    esbuild "0.14.51"
+    miniflare "2.9.0"
+    nanoid "^3.3.3"
+    path-to-regexp "^6.2.0"
+    selfsigned "^2.0.1"
+    source-map "^0.7.4"
+    xxhash-wasm "^1.0.1"
+  optionalDependencies:
+    fsevents "~2.3.2"
+
+wrangler@^2.0.15, wrangler@^2.1.6, wrangler@^2.1.9, wrangler@^2.7.1:
   version "2.10.0"
   resolved "https://registry.yarnpkg.com/wrangler/-/wrangler-2.10.0.tgz#14f19e2bee12236ce0bdcd83308a21a8788c0150"
   integrity sha512-h/N7IN5R7P2xWMdUgLbgoWbfrTRVp2wXzT5HTXVg0DPufDY7X3Vf3xX2RW7pt+JTvbUdpOSD0dVyRR4Fxluzog==

--- a/yarn.lock
+++ b/yarn.lock
@@ -6994,30 +6994,7 @@
     "@wallet-standard/app" "^1.0.0"
     "@wallet-standard/base" "^1.0.0"
 
-"@solana/web3.js@1.52.0":
-  version "1.52.0"
-  resolved "https://registry.yarnpkg.com/@solana/web3.js/-/web3.js-1.52.0.tgz#71bd5c322a31e3e2fa8cda2261c594846810b8ea"
-  integrity sha512-oG1+BX4nVYZ0OBzmk6DRrY8oBYMsbXVQEf9N9JOfKm+wXSmjxVEEo8v3IPV8mKwR0JvUWuE8lOn3IUDiMlRLgg==
-  dependencies:
-    "@babel/runtime" "^7.12.5"
-    "@ethersproject/sha2" "^5.5.0"
-    "@solana/buffer-layout" "^4.0.0"
-    bigint-buffer "^1.1.5"
-    bn.js "^5.0.0"
-    borsh "^0.7.0"
-    bs58 "^4.0.1"
-    buffer "6.0.1"
-    fast-stable-stringify "^1.0.0"
-    jayson "^3.4.4"
-    js-sha3 "^0.8.0"
-    node-fetch "2"
-    react-native-url-polyfill "^1.3.0"
-    rpc-websockets "^7.5.0"
-    secp256k1 "^4.0.2"
-    superstruct "^0.14.2"
-    tweetnacl "^1.0.3"
-
-"@solana/web3.js@^1.17.0", "@solana/web3.js@^1.21.0", "@solana/web3.js@^1.30.2", "@solana/web3.js@^1.31.0", "@solana/web3.js@^1.32.0", "@solana/web3.js@^1.35.1", "@solana/web3.js@^1.36.0", "@solana/web3.js@^1.37.1", "@solana/web3.js@^1.43.2", "@solana/web3.js@^1.47.3", "@solana/web3.js@^1.56.2", "@solana/web3.js@^1.63.1":
+"@solana/web3.js@1.52.0", "@solana/web3.js@1.63.1", "@solana/web3.js@^1.17.0", "@solana/web3.js@^1.21.0", "@solana/web3.js@^1.30.2", "@solana/web3.js@^1.31.0", "@solana/web3.js@^1.32.0", "@solana/web3.js@^1.35.1", "@solana/web3.js@^1.36.0", "@solana/web3.js@^1.37.1", "@solana/web3.js@^1.43.2", "@solana/web3.js@^1.47.3", "@solana/web3.js@^1.56.2", "@solana/web3.js@^1.63.1", "@solana/web3.js@^1.65.0", "@solana/web3.js@^1.66.2", "@solana/web3.js@^1.68.0", "@solana/web3.js@^1.69.0", "@solana/web3.js@^1.73.0", "@solana/web3.js@^1.73.2":
   version "1.63.1"
   resolved "https://registry.yarnpkg.com/@solana/web3.js/-/web3.js-1.63.1.tgz#88a19a17f5f4aada73ad70a94044c1067cab2b4d"
   integrity sha512-wgEdGVK5FTS2zENxbcGSvKpGZ0jDS6BUdGu8Gn6ns0CzgJkK83u4ip3THSnBPEQ5i/jrqukg998BwV1H67+qiQ==
@@ -7027,28 +7004,6 @@
     "@noble/hashes" "^1.1.2"
     "@noble/secp256k1" "^1.6.3"
     "@solana/buffer-layout" "^4.0.0"
-    bigint-buffer "^1.1.5"
-    bn.js "^5.0.0"
-    borsh "^0.7.0"
-    bs58 "^4.0.1"
-    buffer "6.0.1"
-    fast-stable-stringify "^1.0.0"
-    jayson "^3.4.4"
-    node-fetch "2"
-    rpc-websockets "^7.5.0"
-    superstruct "^0.14.2"
-
-"@solana/web3.js@^1.65.0", "@solana/web3.js@^1.66.2", "@solana/web3.js@^1.68.0", "@solana/web3.js@^1.69.0", "@solana/web3.js@^1.73.0", "@solana/web3.js@^1.73.2":
-  version "1.73.2"
-  resolved "https://registry.yarnpkg.com/@solana/web3.js/-/web3.js-1.73.2.tgz#4b30cd402b35733dae3a7d0b638be26a7742b395"
-  integrity sha512-9WACF8W4Nstj7xiDw3Oom22QmrhBh0VyZyZ7JvvG3gOxLWLlX3hvm5nPVJOGcCE/9fFavBbCUb5A6CIuvMGdoA==
-  dependencies:
-    "@babel/runtime" "^7.12.5"
-    "@noble/ed25519" "^1.7.0"
-    "@noble/hashes" "^1.1.2"
-    "@noble/secp256k1" "^1.6.3"
-    "@solana/buffer-layout" "^4.0.0"
-    agentkeepalive "^4.2.1"
     bigint-buffer "^1.1.5"
     bn.js "^5.0.0"
     borsh "^0.7.0"
@@ -8900,15 +8855,6 @@ agent-base@6:
   integrity sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==
   dependencies:
     debug "4"
-
-agentkeepalive@^4.2.1:
-  version "4.2.1"
-  resolved "https://registry.yarnpkg.com/agentkeepalive/-/agentkeepalive-4.2.1.tgz#a7975cbb9f83b367f06c90cc51ff28fe7d499717"
-  integrity sha512-Zn4cw2NEqd+9fiSVWMscnjyQ1a8Yfoc5oBajLeo5w+YBHgDUcEBY2hS4YpTz6iN5f/2zQiktcuM6tS8x1p9dpA==
-  dependencies:
-    debug "^4.1.0"
-    depd "^1.1.2"
-    humanize-ms "^1.2.1"
 
 aggregate-error@^3.0.0:
   version "3.1.0"
@@ -12093,7 +12039,7 @@ depd@2.0.0, depd@^2.0.0, depd@~2.0.0:
   resolved "https://registry.yarnpkg.com/depd/-/depd-2.0.0.tgz#b696163cc757560d09cf22cc8fad1571b79e76df"
   integrity sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==
 
-depd@^1.1.2, depd@~1.1.2:
+depd@~1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/depd/-/depd-1.1.2.tgz#9bcd52e14c097763e749b274c4346ed2e560b5a9"
   integrity sha512-7emPTl6Dpo6JRXOXjLRxck+FlLRX5847cLKEn00PLAgc3g2hTZZgr+e4c2v6QpSmLeFP3n5yUo7ft6avBK/5jQ==
@@ -12991,32 +12937,6 @@ esbuild-windows-arm64@0.15.16:
   resolved "https://registry.yarnpkg.com/esbuild-windows-arm64/-/esbuild-windows-arm64-0.15.16.tgz#77e804d60dec0390fe8f21401e39b435d5d1b863"
   integrity sha512-oCcUKrJaMn04Vxy9Ekd8x23O8LoU01+4NOkQ2iBToKgnGj5eo1vU9i27NQZ9qC8NFZgnQQZg5oZWAejmbsppNA==
 
-esbuild@0.14.51, esbuild@^0.14.42, esbuild@^0.14.43, esbuild@^0.14.47:
-  version "0.14.51"
-  resolved "https://registry.yarnpkg.com/esbuild/-/esbuild-0.14.51.tgz#1c8ecbc8db3710da03776211dc3ee3448f7aa51e"
-  integrity sha512-+CvnDitD7Q5sT7F+FM65sWkF8wJRf+j9fPcprxYV4j+ohmzVj2W7caUqH2s5kCaCJAfcAICjSlKhDCcvDpU7nw==
-  optionalDependencies:
-    esbuild-android-64 "0.14.51"
-    esbuild-android-arm64 "0.14.51"
-    esbuild-darwin-64 "0.14.51"
-    esbuild-darwin-arm64 "0.14.51"
-    esbuild-freebsd-64 "0.14.51"
-    esbuild-freebsd-arm64 "0.14.51"
-    esbuild-linux-32 "0.14.51"
-    esbuild-linux-64 "0.14.51"
-    esbuild-linux-arm "0.14.51"
-    esbuild-linux-arm64 "0.14.51"
-    esbuild-linux-mips64le "0.14.51"
-    esbuild-linux-ppc64le "0.14.51"
-    esbuild-linux-riscv64 "0.14.51"
-    esbuild-linux-s390x "0.14.51"
-    esbuild-netbsd-64 "0.14.51"
-    esbuild-openbsd-64 "0.14.51"
-    esbuild-sunos-64 "0.14.51"
-    esbuild-windows-32 "0.14.51"
-    esbuild-windows-64 "0.14.51"
-    esbuild-windows-arm64 "0.14.51"
-
 esbuild@0.16.3:
   version "0.16.3"
   resolved "https://registry.yarnpkg.com/esbuild/-/esbuild-0.16.3.tgz#5868632fa23f7a8547f2a4ea359c44e946515c94"
@@ -13044,6 +12964,32 @@ esbuild@0.16.3:
     "@esbuild/win32-arm64" "0.16.3"
     "@esbuild/win32-ia32" "0.16.3"
     "@esbuild/win32-x64" "0.16.3"
+
+esbuild@^0.14.42, esbuild@^0.14.43, esbuild@^0.14.47:
+  version "0.14.51"
+  resolved "https://registry.yarnpkg.com/esbuild/-/esbuild-0.14.51.tgz#1c8ecbc8db3710da03776211dc3ee3448f7aa51e"
+  integrity sha512-+CvnDitD7Q5sT7F+FM65sWkF8wJRf+j9fPcprxYV4j+ohmzVj2W7caUqH2s5kCaCJAfcAICjSlKhDCcvDpU7nw==
+  optionalDependencies:
+    esbuild-android-64 "0.14.51"
+    esbuild-android-arm64 "0.14.51"
+    esbuild-darwin-64 "0.14.51"
+    esbuild-darwin-arm64 "0.14.51"
+    esbuild-freebsd-64 "0.14.51"
+    esbuild-freebsd-arm64 "0.14.51"
+    esbuild-linux-32 "0.14.51"
+    esbuild-linux-64 "0.14.51"
+    esbuild-linux-arm "0.14.51"
+    esbuild-linux-arm64 "0.14.51"
+    esbuild-linux-mips64le "0.14.51"
+    esbuild-linux-ppc64le "0.14.51"
+    esbuild-linux-riscv64 "0.14.51"
+    esbuild-linux-s390x "0.14.51"
+    esbuild-netbsd-64 "0.14.51"
+    esbuild-openbsd-64 "0.14.51"
+    esbuild-sunos-64 "0.14.51"
+    esbuild-windows-32 "0.14.51"
+    esbuild-windows-64 "0.14.51"
+    esbuild-windows-arm64 "0.14.51"
 
 esbuild@^0.15.13, esbuild@^0.15.16:
   version "0.15.16"
@@ -15735,13 +15681,6 @@ human-signals@^3.0.1:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/human-signals/-/human-signals-3.0.1.tgz#c740920859dafa50e5a3222da9d3bf4bb0e5eef5"
   integrity sha512-rQLskxnM/5OCldHo+wNXbpVgDn5A17CUoKX+7Sokwaknlq7CdSnphy0W39GU8dw59XiCXmFXDg4fRuckQRKewQ==
-
-humanize-ms@^1.2.1:
-  version "1.2.1"
-  resolved "https://registry.yarnpkg.com/humanize-ms/-/humanize-ms-1.2.1.tgz#c46e3159a293f6b896da29316d8b6fe8bb79bbed"
-  integrity sha512-Fl70vYtsAFb/C06PTS9dZBo7ihau+Tu/DNCk/OyHhea07S+aeMWpFFkUaXRa8fI+ScZbEI8dfSxwY7gxZ9SAVQ==
-  dependencies:
-    ms "^2.0.0"
 
 husky@^8.0.1:
   version "8.0.1"
@@ -19688,7 +19627,7 @@ miniflare@2.12.0:
     source-map-support "^0.5.20"
     undici "5.11.0"
 
-miniflare@2.9.0, miniflare@^2.9.0:
+miniflare@^2.9.0:
   version "2.9.0"
   resolved "https://registry.yarnpkg.com/miniflare/-/miniflare-2.9.0.tgz#ebd737675ef6067f8514b12a812c28a6d1837bad"
   integrity sha512-HBGQ5Jj6sMU1B1hX6G3ML46ThtUvu1nvxgXjDDmhp2RhWKYj0XvcohW/nPPL/MTP1gpvfT880De9EHmobVsDsw==
@@ -19846,7 +19785,7 @@ ms@2.1.2:
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.2.tgz#d09d1f357b443f493382a8eb3ccd183872ae6009"
   integrity sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==
 
-ms@2.1.3, ms@^2.0.0, ms@^2.1.1:
+ms@2.1.3, ms@^2.1.1:
   version "2.1.3"
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.3.tgz#574c8138ce1d2b5861f0b44579dbadd60c6615b2"
   integrity sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==
@@ -20719,7 +20658,7 @@ pako@~1.0.2, pako@~1.0.5:
   resolved "https://registry.yarnpkg.com/pako/-/pako-1.0.11.tgz#6c9599d340d54dfd3946380252a35705a6b992bf"
   integrity sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==
 
-parcel@^2.7.0:
+parcel@2.7.0, parcel@^2.7.0:
   version "2.7.0"
   resolved "https://registry.yarnpkg.com/parcel/-/parcel-2.7.0.tgz#41fdd3e5c7144d4cf7f1fa3ab8d0ea0d47d31f77"
   integrity sha512-pRYwnivwtNP0tip8xYSo4zCB0XhLt7/gJzP1p8OovCqkmFjG9VG+GW9TcAKqMIo0ovEa9tT+/s6gY1Qy+BONGQ==
@@ -21812,20 +21751,10 @@ react-reconciler@^0.26.0:
     object-assign "^4.1.1"
     scheduler "^0.20.2"
 
-react-refresh@^0.14.0:
-  version "0.14.0"
-  resolved "https://registry.yarnpkg.com/react-refresh/-/react-refresh-0.14.0.tgz#4e02825378a5f227079554d4284889354e5f553e"
-  integrity sha512-wViHqhAd8OHeLS/IRMJjTSDHF3U9eWi62F/MledQGPdJGDhodXJ9PBLNGr6WWL7qlH12Mt3TyTpbS+hGXMjCzQ==
-
-react-refresh@^0.4.0:
-  version "0.4.3"
-  resolved "https://registry.yarnpkg.com/react-refresh/-/react-refresh-0.4.3.tgz#966f1750c191672e76e16c2efa569150cc73ab53"
-  integrity sha512-Hwln1VNuGl/6bVwnd0Xdn1e84gT/8T9aYNL+HAKDArLCS7LWjwr7StE30IEYbIkx0Vi3vs+coQxe+SQDbGbbpA==
-
-react-refresh@^0.9.0:
-  version "0.9.0"
-  resolved "https://registry.yarnpkg.com/react-refresh/-/react-refresh-0.9.0.tgz#71863337adc3e5c2f8a6bfddd12ae3bfe32aafbf"
-  integrity sha512-Gvzk7OZpiqKSkxsQvO/mbTN1poglhmAV7gR/DdIrRrSMXraRQQlfikRJOr3Nb9GTMPC5kof948Zy6jJZIFtDvQ==
+react-refresh@0.11.0, react-refresh@^0.14.0, react-refresh@^0.4.0, react-refresh@^0.9.0:
+  version "0.11.0"
+  resolved "https://registry.yarnpkg.com/react-refresh/-/react-refresh-0.11.0.tgz#77198b944733f0f1f1a90e791de4541f9f074046"
+  integrity sha512-F27qZr8uUqwhWZboondsPx8tnC3Ct3SxZA3V5WyEvujRyyNv0VYPhoBg1gZ8/MV5tubQp76Trw8lTv9hzRBa+A==
 
 react-rich-mentions@^0.1.10:
   version "0.1.10"
@@ -25317,30 +25246,7 @@ wordwrapjs@^4.0.0:
     reduce-flatten "^2.0.0"
     typical "^5.2.0"
 
-wrangler@2.1.9:
-  version "2.1.9"
-  resolved "https://registry.yarnpkg.com/wrangler/-/wrangler-2.1.9.tgz#295c4184c493004fab37c35c1fa364e9f4f8d4a1"
-  integrity sha512-ryrkpUEqgJZIiGgo+VCUYtl0B+shEbyp3FZzT5+GYnyfpLtQutAZlS/s5iOC0qjZ7TcRzWS1PSb9fE9nDSvCKg==
-  dependencies:
-    "@cloudflare/kv-asset-handler" "^0.2.0"
-    "@esbuild-plugins/node-globals-polyfill" "^0.1.1"
-    "@esbuild-plugins/node-modules-polyfill" "^0.1.4"
-    "@miniflare/core" "2.9.0"
-    "@miniflare/d1" "2.9.0"
-    "@miniflare/durable-objects" "2.9.0"
-    blake3-wasm "^2.1.5"
-    chokidar "^3.5.3"
-    esbuild "0.14.51"
-    miniflare "2.9.0"
-    nanoid "^3.3.3"
-    path-to-regexp "^6.2.0"
-    selfsigned "^2.0.1"
-    source-map "^0.7.4"
-    xxhash-wasm "^1.0.1"
-  optionalDependencies:
-    fsevents "~2.3.2"
-
-wrangler@^2.0.15, wrangler@^2.1.6, wrangler@^2.1.9, wrangler@^2.7.1:
+wrangler@2.1.9, wrangler@^2.0.15, wrangler@^2.1.6, wrangler@^2.1.9, wrangler@^2.10.0, wrangler@^2.7.1:
   version "2.10.0"
   resolved "https://registry.yarnpkg.com/wrangler/-/wrangler-2.10.0.tgz#14f19e2bee12236ce0bdcd83308a21a8788c0150"
   integrity sha512-h/N7IN5R7P2xWMdUgLbgoWbfrTRVp2wXzT5HTXVg0DPufDY7X3Vf3xX2RW7pt+JTvbUdpOSD0dVyRR4Fxluzog==


### PR DESCRIPTION
mui does not support react v18 with the styling system we use `@mui/styles`. this means we have to remove `@mui/styles` and migrate it over to either tss-react or their other styling system that uses emotion under the hood:

- https://mui.com/material-ui/migration/migrating-from-jss/#2-use-tss-react

places where we use `@mui/styles`:
- [ ] app-extension
- [ ] chat-sdk
- [ ] react-common
- [ ] react-xnft-dom-renderer
- [ ] themes