### PR TITLE
Fixed notification avatar position to the top left of the notification list item

### DIFF
--- a/packages/app-extension/src/components/Unlocked/Balances/Notifications.tsx
+++ b/packages/app-extension/src/components/Unlocked/Balances/Notifications.tsx
@@ -662,7 +662,7 @@ function FriendRequestListItem({
           alignItems: "center",
         }}
       >
-        <div style={{ flex: 1, display: "flex" }}>
+        <div style={{ flex: 1, display: "flex", alignItems: "flex-start" }}>
           <div
             style={{
               display: "flex",


### PR DESCRIPTION
Fixes Issue [#2499](https://github.com/coral-xyz/backpack/issues/2499)

Problem - Notification avatar should be at the top left of the notification list item #2499

Solution - Added alignItems: "flex-start"