### PR TITLE
switch back from createRoot to render

### DIFF
--- a/packages/app-extension/src/index.tsx
+++ b/packages/app-extension/src/index.tsx
@@ -29,9 +29,8 @@ document.addEventListener("keypress", async function onPress(event) {
   }
 });
 
-//
-// Render the UI. TOOD(react) createRoot is required to support v18 version
-//
+// Render the UI.
+// TOOD(react) createRoot is required: https://reactjs.org/blog/2022/03/08/react-18-upgrade-guide.html#updates-to-client-rendering-apis
 const container = document.getElementById("root");
 render(
   <React.StrictMode>

--- a/packages/app-extension/src/index.tsx
+++ b/packages/app-extension/src/index.tsx
@@ -1,5 +1,5 @@
 import React, { lazy, Suspense } from "react";
-import { createRoot } from "react-dom/client";
+import { render } from "react-dom";
 import { openPopupWindow } from "@coral-xyz/common/dist/esm/browser";
 import { BACKPACK_FEATURE_POP_MODE } from "@coral-xyz/common/dist/esm/generated-config";
 
@@ -30,11 +30,10 @@ document.addEventListener("keypress", async function onPress(event) {
 });
 
 //
-// Render the UI.
+// Render the UI. TOOD(react) createRoot is required to support v18 version
 //
 const container = document.getElementById("root");
-const root = createRoot(container!);
-root.render(
+render(
   <React.StrictMode>
     <Suspense fallback={null}>
       <App />
@@ -42,5 +41,6 @@ root.render(
     <Suspense fallback={null}>
       <LedgerIframe />
     </Suspense>
-  </React.StrictMode>
+  </React.StrictMode>,
+  container
 );

--- a/packages/app-extension/src/options/index.tsx
+++ b/packages/app-extension/src/options/index.tsx
@@ -1,5 +1,5 @@
 import React, { lazy, Suspense } from "react";
-import { createRoot } from "react-dom/client";
+import { render } from "react-dom";
 
 import Options from "./Options";
 
@@ -9,12 +9,12 @@ const LedgerIframe = lazy(() => import("../components/LedgerIframe"));
 // Render the UI.
 //
 const container = document.getElementById("options");
-const root = createRoot(container!);
-root.render(
+render(
   <React.StrictMode>
     <Options />
     <Suspense fallback={null}>
       <LedgerIframe />
     </Suspense>
-  </React.StrictMode>
+  </React.StrictMode>,
+  container
 );

--- a/packages/app-extension/src/options/index.tsx
+++ b/packages/app-extension/src/options/index.tsx
@@ -5,9 +5,8 @@ import Options from "./Options";
 
 const LedgerIframe = lazy(() => import("../components/LedgerIframe"));
 
-//
 // Render the UI.
-//
+// TOOD(react) createRoot is required: https://reactjs.org/blog/2022/03/08/react-18-upgrade-guide.html#updates-to-client-rendering-apis
 const container = document.getElementById("options");
 render(
   <React.StrictMode>

--- a/packages/app-extension/src/permissions/index.tsx
+++ b/packages/app-extension/src/permissions/index.tsx
@@ -1,15 +1,15 @@
 import React from "react";
-import { createRoot } from "react-dom/client";
+import { render } from "react-dom";
 
 import Permissions from "./Permissions";
 
 //
-// Render the UI.
+// Render the UI TODO(react) v18 requires createRoot
 //
 const container = document.getElementById("permissions");
-const root = createRoot(container!);
-root.render(
+render(
   <React.StrictMode>
     <Permissions />
-  </React.StrictMode>
+  </React.StrictMode>,
+  container
 );

--- a/packages/app-extension/src/permissions/index.tsx
+++ b/packages/app-extension/src/permissions/index.tsx
@@ -3,9 +3,8 @@ import { render } from "react-dom";
 
 import Permissions from "./Permissions";
 
-//
-// Render the UI TODO(react) v18 requires createRoot
-//
+// Render the UI.
+// TOOD(react) createRoot is required: https://reactjs.org/blog/2022/03/08/react-18-upgrade-guide.html#updates-to-client-rendering-apis
 const container = document.getElementById("permissions");
 render(
   <React.StrictMode>


### PR DESCRIPTION
https://reactjs.org/blog/2022/03/08/react-18-upgrade-guide.html#updates-to-client-rendering-apis

TLDR by not using createRoot, the app will function like a v17 app