### PR TITLE
fix : checkbox check mark invisible in dark mode

### DIFF
--- a/packages/app-extension/src/components/common/index.tsx
+++ b/packages/app-extension/src/components/common/index.tsx
@@ -68,7 +68,7 @@ const useStyles = styles((theme: CustomTheme) => ({
     padding: 0,
   },
   checkBoxChecked: {
-    color: `${theme.custom.colors.primaryButton} !important`,
+    color: theme?.palette?.mode === 'dark' ? `${theme.custom.colors.successButton} !important`: `${theme.custom.colors.primaryButton}`,
     background: "white",
   },
   subtext: {


### PR DESCRIPTION
Fix #1150 

Problem: The tick mark was not visible in dark mode.
Solution: Check the current theme mode and change the checkbox's checked color when in dark mode.

Dark Mode:
![DARK](https://res.cloudinary.com/primeflix/image/upload/v1677159928/dark-mode_hkmvmh.gif)

Light Mode:
![LIGHT](https://res.cloudinary.com/primeflix/image/upload/v1677159881/8d23fef05f9cb94807bc1e28f26981c8fe19b3c9_a6w4y1.gif)
