### PR TITLE
don't block UI when loading jupiter routes

### DIFF
--- a/packages/app-extension/src/components/Unlocked/Balances/TransferWidget.tsx
+++ b/packages/app-extension/src/components/Unlocked/Balances/TransferWidget.tsx
@@ -1,3 +1,4 @@
+import React from "react";
 import type { Blockchain } from "@coral-xyz/common";
 import {
   ETH_NATIVE_MINT,
@@ -77,37 +78,51 @@ function SwapButton({
 }) {
   const theme = useCustomTheme();
 
+  const SwapButtonComponent = ({
+    routes = [],
+  }: {
+    routes?: React.ComponentProps<typeof TransferButton>["routes"];
+  }) => (
+    <TransferButton
+      label="Swap"
+      labelComponent={
+        <SwapHoriz
+          style={{
+            color: theme.custom.colors.fontColor,
+            display: "flex",
+            marginLeft: "auto",
+            marginRight: "auto",
+          }}
+        />
+      }
+      routes={routes}
+      disabled={routes.length === 0}
+    />
+  );
+
+  // Wrap in Suspense so it doesn't block if Jupiter is slow or down.
   return (
-    <SwapProvider tokenAddress={address}>
-      <TransferButton
-        label="Swap"
-        labelComponent={
-          <SwapHoriz
-            style={{
-              color: theme.custom.colors.fontColor,
-              display: "flex",
-              marginLeft: "auto",
-              marginRight: "auto",
-            }}
-          />
-        }
-        routes={[
-          {
-            name: "swap",
-            component: (props: any) => <Swap {...props} />,
-            title: `Swap`,
-            props: {
-              blockchain,
+    <React.Suspense fallback={<SwapButtonComponent />}>
+      <SwapProvider tokenAddress={address}>
+        <SwapButtonComponent
+          routes={[
+            {
+              name: "swap",
+              component: (props: any) => <Swap {...props} />,
+              title: `Swap`,
+              props: {
+                blockchain,
+              },
             },
-          },
-          {
-            title: `Select Token`,
-            name: "select-token",
-            component: (props: any) => <SwapSelectToken {...props} />,
-          },
-        ]}
-      />
-    </SwapProvider>
+            {
+              title: `Select Token`,
+              name: "select-token",
+              component: (props: any) => <SwapSelectToken {...props} />,
+            },
+          ]}
+        />
+      </SwapProvider>
+    </React.Suspense>
   );
 }
 
@@ -270,10 +285,12 @@ function TransferButton({
   label,
   labelComponent,
   routes,
+  disabled = false,
 }: {
   label: string;
   labelComponent: any;
-  routes: Array<{ props?: any; component: any; title: string; name: string }>;
+  routes?: Array<{ props?: any; component: any; title: string; name: string }>;
+  disabled?: boolean;
 }) {
   const theme = useCustomTheme();
   return (
@@ -281,6 +298,9 @@ function TransferButton({
       style={{
         width: "52px",
         height: "70px",
+        // semi-transparent and unclickable when disabled=true
+        opacity: disabled ? 0.5 : 1,
+        pointerEvents: disabled ? "none" : "auto",
       }}
     >
       <WithHeaderButton

--- a/packages/recoil/src/atoms/solana/jupiter.tsx
+++ b/packages/recoil/src/atoms/solana/jupiter.tsx
@@ -12,7 +12,7 @@ export const jupiterUrl = (useProxy: boolean) =>
   useProxy ? "https://jupiter.xnfts.dev/v4/" : "https://quote-api.jup.ag/v4/";
 
 // Load the route map from the Jupiter API
-export const jupiterRouteMap = selector({
+const jupiterRouteMap = selector({
   key: "jupiterRouteMap",
   get: async ({ get }) => {
     try {
@@ -63,7 +63,7 @@ export const jupiterTokenMap = selector<Map<string, TokenInfo>>({
 });
 
 // All input tokens for Jupiter
-export const allJupiterInputMints = selector({
+const allJupiterInputMints = selector({
   key: "allJupiterInputMints",
   get: async ({ get }) => {
     const routeMap = get(jupiterRouteMap);

--- a/packages/recoil/src/hooks/solana/useJupiter.tsx
+++ b/packages/recoil/src/hooks/solana/useJupiter.tsx
@@ -2,13 +2,7 @@ import type { TokenInfo } from "@solana/spl-token-registry";
 import { useRecoilValue } from "recoil";
 
 import * as atoms from "../../atoms";
-import type { TokenData, TokenDataWithBalance } from "../../types";
-
-export function useJupiterInputTokens(
-  publicKey: string
-): Array<TokenDataWithBalance> {
-  return useRecoilValue(atoms.jupiterInputTokens({ publicKey }));
-}
+import type { TokenData } from "../../types";
 
 export function useJupiterTokenList(): Array<TokenInfo> {
   return useRecoilValue(atoms.jupiterTokenList);


### PR DESCRIPTION
Fixes #3015 

Wraps SwapProvider in Suspense so that it the Swap button is semi-transparent and unclickable until Jupiter route maps have loaded.

I decided to make it the button semi-transparent instead of hidden so that the UI doesn't jump, hopefully it most cases it should become active within a few seconds and not really be noticeable.

This might also provide a minor speed boost when loading balances as it moves this loading into an async process that doesn't block rendering.

Light Mode while loading | Dark Mode while loading
------------|------------
<img width="487" alt="Screenshot 2023-02-27 at 20 59 56" src="https://user-images.githubusercontent.com/101902546/221759475-29941351-fa67-487d-9dc7-4340b8eaa91b.png"> | <img width="487" alt="Screenshot 2023-02-27 at 21 00 04" src="https://user-images.githubusercontent.com/101902546/221759474-3554157e-fb3e-4f3e-800e-beda066b23e3.png">