### PR TITLE
async jupiter route loading follow-up

### DIFF
--- a/packages/app-extension/src/components/Unlocked/Balances/TransferWidget.tsx
+++ b/packages/app-extension/src/components/Unlocked/Balances/TransferWidget.tsx
@@ -78,50 +78,45 @@ function SwapButton({
 }) {
   const theme = useCustomTheme();
 
-  const SwapButtonComponent = ({
-    routes = [],
-  }: {
-    routes?: React.ComponentProps<typeof TransferButton>["routes"];
-  }) => (
-    <TransferButton
-      label="Swap"
-      labelComponent={
-        <SwapHoriz
-          style={{
-            color: theme.custom.colors.fontColor,
-            display: "flex",
-            marginLeft: "auto",
-            marginRight: "auto",
-          }}
-        />
-      }
-      routes={routes}
-      disabled={routes.length === 0}
-    />
-  );
-
   // Wrap in Suspense so it doesn't block if Jupiter is slow or down.
   return (
-    <React.Suspense fallback={<SwapButtonComponent />}>
-      <SwapProvider tokenAddress={address}>
-        <SwapButtonComponent
-          routes={[
-            {
-              name: "swap",
-              component: (props: any) => <Swap {...props} />,
-              title: `Swap`,
-              props: {
-                blockchain,
-              },
+    <React.Suspense fallback={null}>
+      <TransferButton
+        label="Swap"
+        labelComponent={
+          <SwapHoriz
+            style={{
+              color: theme.custom.colors.fontColor,
+              display: "flex",
+              marginLeft: "auto",
+              marginRight: "auto",
+            }}
+          />
+        }
+        routes={[
+          {
+            name: "swap",
+            component: (props) => (
+              <SwapProvider tokenAddress={address}>
+                <Swap {...props} />
+              </SwapProvider>
+            ),
+            title: `Swap`,
+            props: {
+              blockchain,
             },
-            {
-              title: `Select Token`,
-              name: "select-token",
-              component: (props: any) => <SwapSelectToken {...props} />,
-            },
-          ]}
-        />
-      </SwapProvider>
+          },
+          {
+            title: `Select Token`,
+            name: "select-token",
+            component: (props) => (
+              <SwapProvider tokenAddress={address}>
+                <SwapSelectToken {...props} />
+              </SwapProvider>
+            ),
+          },
+        ]}
+      />
     </React.Suspense>
   );
 }
@@ -154,7 +149,7 @@ function SendButton({
           ? [
               {
                 name: "select-user",
-                component: (props: any) => <AddressSelectorLoader {...props} />,
+                component: (props) => <AddressSelectorLoader {...props} />,
                 title: "",
                 props: {
                   blockchain,
@@ -164,7 +159,7 @@ function SendButton({
               },
               {
                 name: "send",
-                component: (props: any) => <Send {...props} />,
+                component: (props) => <Send {...props} />,
                 title: `Send`,
               },
             ]
@@ -176,12 +171,12 @@ function SendButton({
               },
               {
                 name: "select-user",
-                component: (props: any) => <AddressSelector {...props} />,
+                component: (props) => <AddressSelector {...props} />,
                 title: "",
               },
               {
                 name: "send",
-                component: (props: any) => <Send {...props} />,
+                component: (props) => <Send {...props} />,
                 title: "",
               },
             ]
@@ -252,7 +247,7 @@ function RampButton({
           ? [
               {
                 name: "stripe",
-                component: (props: any) => <StripeRamp {...props} />,
+                component: (props) => <StripeRamp {...props} />,
                 title: "Buy",
                 props: {
                   blockchain,
@@ -271,7 +266,7 @@ function RampButton({
                 },
               },
               {
-                component: (props: any) => <StripeRamp {...props} />,
+                component: (props) => <StripeRamp {...props} />,
                 title: "Buy using Link",
                 name: "stripe",
               },
@@ -289,7 +284,12 @@ function TransferButton({
 }: {
   label: string;
   labelComponent: any;
-  routes?: Array<{ props?: any; component: any; title: string; name: string }>;
+  routes?: Array<{
+    props?: any;
+    component: (props: any) => React.ReactElement;
+    title: string;
+    name: string;
+  }>;
   disabled?: boolean;
 }) {
   const theme = useCustomTheme();


### PR DESCRIPTION
follow up to #3036

now the swap button is always clickable with full opacity

if the routes haven't loaded before the user clicks, they will see a loading spinner on the Swap page

<img width="487" alt="Screenshot 2023-02-28 at 10 04 28" src="https://user-images.githubusercontent.com/101902546/221941068-8f686902-94e1-48f6-bce9-56efc8a1eab0.png">

if they have already loaded then the Swap page will open immediately

<img width="487" alt="Screenshot 2023-02-28 at 10 05 11" src="https://user-images.githubusercontent.com/101902546/221941085-b09c2a47-2048-49d8-87c1-1de65da55c91.png">