### PR TITLE
add "Backpack" title to popup and tabs

### DIFF
--- a/packages/app-extension/src/options.html
+++ b/packages/app-extension/src/options.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+    <title>Backpack</title>
     <meta charset="UTF-8" />
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />

--- a/packages/app-extension/src/permissions.html
+++ b/packages/app-extension/src/permissions.html
@@ -1,14 +1,14 @@
 <!DOCTYPE html>
 <html lang="en">
-<head>
+  <head>
+    <title>Backpack</title>
     <meta charset="UTF-8" />
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  </head>
 
-</head>
-
-<body>
-<div id="permissions"></div>
-<script src="permissions.js"></script>
-</body>
+  <body>
+    <div id="permissions"></div>
+    <script src="permissions.js"></script>
+  </body>
 </html>

--- a/packages/app-extension/src/popup.html
+++ b/packages/app-extension/src/popup.html
@@ -1,30 +1,32 @@
 <!DOCTYPE html>
 <html lang="en">
+  <head>
+    <title>Backpack</title>
+    <meta charset="UTF-8" />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600&display=swap"
+      rel="stylesheet"
+    />
+    <style>
+      #root,
+      body,
+      html {
+        position: relative;
+        width: 100%;
+        height: 100%;
+        min-height: 600px;
+        min-width: 375px;
+        margin: 0;
+        padding: 0;
+        background: #131315;
+      }
+    </style>
+  </head>
 
-<head>
-  <meta charset="UTF-8" />
-  <link rel="preconnect" href="https://fonts.googleapis.com" />
-  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600&display=swap" rel="stylesheet" />
-  <style>
-    #root,
-    body,
-    html {
-      position: relative;
-      width: 100%;
-      height: 100%;
-      min-Height: 600px;
-      min-width: 375px;
-      margin: 0;
-      padding: 0;
-      background: #131315;
-    }
-  </style>
-</head>
-
-<body>
-  <div id="root"></div>
-  <script src="popup.js"></script>
-</body>
-
+  <body>
+    <div id="root"></div>
+    <script src="popup.js"></script>
+  </body>
 </html>


### PR DESCRIPTION
<img width="487" alt="Screenshot 2023-02-28 at 10 21 15" src="https://user-images.githubusercontent.com/101902546/221944540-c8cd03fe-e3fa-49d8-9744-b500dfb127c0.png">

<img width="829" alt="Screenshot 2023-02-28 at 10 18 32" src="https://user-images.githubusercontent.com/101902546/221944545-ca4e8b8b-4635-453e-9bf5-0154e6360a0a.png">

tiny improvement that updates the title of the tabs and popup window to `Backpack`

a future improvement could include the active username in the title like `@username - Backpack`