### PR TITLE
Fixed ctrl+g popout mode keyboard shortcut on windows

### DIFF
--- a/packages/app-extension/src/index.tsx
+++ b/packages/app-extension/src/index.tsx
@@ -13,12 +13,13 @@ chrome.runtime.connect();
 //
 // Configure event listeners.
 //
-document.addEventListener("keypress", async function onPress(event) {
+document.addEventListener("keydown", async function onKeyDown(event) {
   //
   // Pop open the window.
   //
   if (BACKPACK_FEATURE_POP_MODE) {
     if (event.key === "g" && event.ctrlKey) {
+      event.preventDefault();
       const currentWindow = await chrome.windows.getCurrent();
       const popupWindow = await openPopupWindow("popup.html");
       if (currentWindow.id !== popupWindow.id) {


### PR DESCRIPTION
Issue: https://github.com/coral-xyz/backpack/issues/3077

Problem: ctrl+g popout mode keyboard shortcut does not work on windows pc #3077 

Solution: Used keydown instead of keypress and added event.preventDefault();

https://user-images.githubusercontent.com/82360525/222441735-bc1ad419-c4a6-4dd7-8b4e-864188178c81.mp4

