### PR TITLE
sort swap output tokens by their popularity on jupiter

### DIFF
--- a/packages/app-extension/src/components/Unlocked/Swap.tsx
+++ b/packages/app-extension/src/components/Unlocked/Swap.tsx
@@ -216,7 +216,7 @@ export function Swap({ blockchain }: { blockchain: Blockchain }) {
       headerTitle: "Swap",
       style: isDark ? { background: "#1D1D20" } : undefined,
     });
-  }, [nav]);
+  }, [nav, isDark]);
 
   if (blockchain && blockchain !== Blockchain.SOLANA) {
     throw new Error("only Solana swaps are supported currently");
@@ -325,10 +325,18 @@ const SwapConfirmationCard: React.FC<{
 
   return (
     <div>
-      {swapState === SwapState.CONFIRMATION ? <SwapConfirmation onConfirm={onConfirm} /> : null}
-      {swapState === SwapState.CONFIRMING ? <SwapConfirming isConfirmed={false} onViewBalances={onViewBalances} /> : null}
-      {swapState === SwapState.CONFIRMED ? <SwapConfirming isConfirmed onViewBalances={onViewBalances} /> : null}
-      {swapState === SwapState.ERROR ? <SwapError onCancel={() => onClose()} onRetry={onConfirm} /> : null}
+      {swapState === SwapState.CONFIRMATION ? (
+        <SwapConfirmation onConfirm={onConfirm} />
+      ) : null}
+      {swapState === SwapState.CONFIRMING ? (
+        <SwapConfirming isConfirmed={false} onViewBalances={onViewBalances} />
+      ) : null}
+      {swapState === SwapState.CONFIRMED ? (
+        <SwapConfirming isConfirmed onViewBalances={onViewBalances} />
+      ) : null}
+      {swapState === SwapState.ERROR ? (
+        <SwapError onCancel={() => onClose()} onRetry={onConfirm} />
+      ) : null}
     </div>
   );
 };
@@ -379,15 +387,17 @@ function OutputTextField() {
       <TextField
         placeholder="0"
         startAdornment={
-          isLoadingRoutes ? <Loading
-            iconStyle={{
+          isLoadingRoutes ? (
+            <Loading
+              iconStyle={{
                 display: "flex",
                 color: theme.custom.colors.secondary,
                 marginRight: "10px",
               }}
-            size={24}
-            thickness={5}
-            /> : null
+              size={24}
+              thickness={5}
+            />
+          ) : null
         }
         endAdornment={<OutputTokensSelectorButton />}
         rootClass={classes.receiveFieldRoot}
@@ -547,18 +557,20 @@ function SwapConfirming({
           )}
         </div>
       </div>
-      {isConfirmed ? <div
-        style={{
+      {isConfirmed ? (
+        <div
+          style={{
             marginBottom: "16px",
             marginLeft: "16px",
             marginRight: "16px",
           }}
         >
-        <SecondaryButton
-          onClick={() => onViewBalances()}
-          label="View Balances"
+          <SecondaryButton
+            onClick={() => onViewBalances()}
+            label="View Balances"
           />
-      </div> : null}
+        </div>
+      ) : null}
     </div>
   );
 }
@@ -713,7 +725,11 @@ function SwapInfoRows({
   const rows = [];
   rows.push([
     "Wallet",
-    <WalletDrawerButton wallet={wallet} style={{ height: "20px" }} />,
+    <WalletDrawerButton
+      key="wallet"
+      wallet={wallet}
+      style={{ height: "20px" }}
+    />,
   ]);
   if (!compact) {
     rows.push(["You Pay", youPay]);
@@ -757,13 +773,7 @@ function SwapTokensButton({
 
 function InputTokenSelectorButton() {
   const { fromToken, setFromMint } = useSwapContext();
-  return (
-    <TokenSelectorButton
-      token={fromToken!}
-      input
-      setMint={setFromMint}
-    />
-  );
+  return <TokenSelectorButton token={fromToken!} input setMint={setFromMint} />;
 }
 
 function OutputTokensSelectorButton() {
@@ -801,11 +811,13 @@ function TokenSelectorButton({
           justifyContent: "right",
         }}
       >
-        {token ? <img
-          className={classes.tokenLogo}
-          src={token.logo}
-          onError={(event) => (event.currentTarget.style.display = "none")}
-          /> : null}
+        {token ? (
+          <img
+            className={classes.tokenLogo}
+            src={token.logo}
+            onError={(event) => (event.currentTarget.style.display = "none")}
+          />
+        ) : null}
         <Typography className={classes.tokenSelectorButtonLabel}>
           {token ? token.ticker : null}
         </Typography>
@@ -828,6 +840,15 @@ export function SwapSelectToken({
   const theme = useCustomTheme();
   const nav = useNavigation();
   const { fromTokens, toTokens } = useSwapContext();
+  useEffect(() => {
+    nav.setOptions({
+      headerTitle: "Select Token",
+      style: isDark
+        ? { background: theme.custom.colors.background }
+        : undefined,
+    });
+  }, [nav, isDark, theme]);
+
   const tokenAccounts = (
     !input ? toTokens : fromTokens
   ) as Array<TokenDataWithPrice>;
@@ -836,15 +857,6 @@ export function SwapSelectToken({
     setMint(token.mint!);
     nav.pop();
   };
-
-  useEffect(() => {
-    nav.setOptions({
-      headerTitle: "Select Token",
-      style: isDark
-        ? { background: theme.custom.colors.background }
-        : undefined,
-    });
-  }, [nav]);
 
   return (
     <SearchableTokenTable

--- a/packages/recoil/src/atoms/solana/jupiter.tsx
+++ b/packages/recoil/src/atoms/solana/jupiter.tsx
@@ -14,7 +14,7 @@ const jupiterRouteMap = selector({
     try {
       const [response, topTokensReversed] = await (async () => {
         const url =
-          "https://jupiter.xnfts.dev/v4/indexed-route-map?onlyDirectRoutes=true";
+          "https://quote-api.jup.ag/v4/indexed-route-map?onlyDirectRoutes=true";
         try {
           // Try to fetch the routes & top token list in parallel to reduce wait,
           // but fall back to just routes and an empty top token list if it fails

--- a/packages/recoil/src/atoms/solana/jupiter.tsx
+++ b/packages/recoil/src/atoms/solana/jupiter.tsx
@@ -4,31 +4,50 @@ import { selector, selectorFamily } from "recoil";
 
 import type { TokenDataWithBalance } from "../../types";
 import { blockchainBalancesSorted } from "../balance";
-import { featureGates } from "../feature-gates";
 
 import { splTokenRegistry } from "./token-registry";
-
-export const jupiterUrl = (useProxy: boolean) =>
-  useProxy ? "https://jupiter.xnfts.dev/v4/" : "https://quote-api.jup.ag/v4/";
 
 // Load the route map from the Jupiter API
 const jupiterRouteMap = selector({
   key: "jupiterRouteMap",
-  get: async ({ get }) => {
+  get: async () => {
     try {
-      const JUPITER_BASE_URL = jupiterUrl(get(featureGates).SWAP_FEES_ENABLED);
+      const [response, topTokensReversed] = await (async () => {
+        const url =
+          "https://jupiter.xnfts.dev/v4/indexed-route-map?onlyDirectRoutes=true";
+        try {
+          // Try to fetch the routes & top token list in parallel to reduce wait,
+          // but fall back to just routes and an empty top token list if it fails
+          return await Promise.all([
+            (async () => {
+              const res = await fetch(url);
+              return await res.json();
+            })(),
+            (async () => {
+              // Fetch the top token list so that it can be used to reorder the
+              // list of available output tokens with the most popular ones first
+              const res = await fetch(`https://cache.jup.ag/top-tokens`);
+              const topTokens = await res.json();
+              // Reverse the list so it makes the .sort() below a little easier
+              return topTokens.reverse();
+            })(),
+          ]);
+        } catch (err) {
+          const res = await fetch(url);
+          return [await res.json(), []];
+        }
+      })();
 
-      const response = await (
-        await fetch(
-          `${JUPITER_BASE_URL}indexed-route-map?onlyDirectRoutes=true`
-        )
-      ).json();
       const getMint = (index: number) => response["mintKeys"][index];
+
       // Replace indices with mint addresses
       return Object.keys(response["indexedRouteMap"]).reduce((acc, key) => {
-        acc[getMint(parseInt(key))] = response["indexedRouteMap"][key].map(
-          (i: number) => getMint(i)
-        );
+        acc[getMint(parseInt(key))] = response["indexedRouteMap"][key]
+          .map((i: number) => getMint(i))
+          .sort(
+            (a, b) =>
+              topTokensReversed.indexOf(b) - topTokensReversed.indexOf(a)
+          );
         return acc;
       }, {});
     } catch (e) {

--- a/packages/recoil/src/context/Swap.tsx
+++ b/packages/recoil/src/context/Swap.tsx
@@ -16,7 +16,7 @@ import * as bs58 from "bs58";
 import { BigNumber, ethers } from "ethers";
 
 import { blockchainTokenData } from "../atoms/balance";
-import { jupiterInputTokens, jupiterUrl } from "../atoms/solana/jupiter";
+import { jupiterInputTokens } from "../atoms/solana/jupiter";
 import {
   useFeatureGates,
   useJupiterOutputTokens,
@@ -105,13 +105,16 @@ export function SwapProvider({
   const { backgroundClient, connection, walletPublicKey } = solanaCtx;
   const jupiterTokenList = useJupiterTokenList();
   const { SWAP_FEES_ENABLED } = useFeatureGates();
-  const JUPITER_BASE_URL = jupiterUrl(SWAP_FEES_ENABLED);
+  const JUPITER_BASE_URL = SWAP_FEES_ENABLED
+    ? "https://jupiter.xnfts.dev/v4/"
+    : "https://quote-api.jup.ag/v4/";
   const [fromTokens] = useLoader(
     jupiterInputTokens({ publicKey: walletPublicKey.toString() }),
     []
   );
   const [token] = tokenAddress
-    ? useLoader(
+    ? // eslint-disable-next-line react-hooks/rules-of-hooks
+      useLoader(
         blockchainTokenData({
           publicKey: walletPublicKey.toString(),
           blockchain,


### PR DESCRIPTION
Fixes #416

Uses https://cache.jup.ag/top-tokens to order the available output tokens in order of popularity. Tokens that are not included in that list will maintain their original order.

### swapping from UDSC

before | after
-------|---------
<img width="487" alt="Screenshot 2023-03-02 at 11 05 13" src="https://user-images.githubusercontent.com/101902546/222527011-952358da-b3d8-406e-aa5b-2adc2582aab2.png"> |  <img width="487" alt="Screenshot 2023-03-02 at 11 04 49" src="https://user-images.githubusercontent.com/101902546/222527047-f87ccc63-2f6a-4b10-b25f-148e60c61799.png">
