### PR TITLE
fix : Send button on contact profile page is not functional

### DIFF
--- a/packages/message-sdk/src/components/ProfileScreen.tsx
+++ b/packages/message-sdk/src/components/ProfileScreen.tsx
@@ -124,7 +124,7 @@ export const ProfileScreen = ({ userId }: { userId: string }) => {
           </div>
           <div>
             <IconButton
-              style={{ cursor: "auto" }}
+              style={{ cursor: "not-allowed" }}
               size="large"
               className={classes.icon}
             >


### PR DESCRIPTION
fix #2551 
Issue: The send button feature has not been implemented on the profile page yet
fix: added the **CSS cursor property 'not-allowed'** to indicate that the functionality is not currently available.

![VID](https://res.cloudinary.com/primeflix/image/upload/v1677860150/ezgif.com-video-to-gif_e9o1jy.gif)

