### PR TITLE
Fixed message input text overflow

### DIFF
--- a/packages/chat-sdk/src/components/messageInput/MessageInput.tsx
+++ b/packages/chat-sdk/src/components/messageInput/MessageInput.tsx
@@ -60,6 +60,7 @@ export function MessageInput({
           outline: "0px solid transparent",
           color: theme.custom.colors.fontColor,
           fontSize: "14px",
+          wordBreak: "break-word",
         }}
         defaultValue=""
       />


### PR DESCRIPTION
Issue: Textbox overflow needs to be constrained for longer words #3159

Solution: Added wordBreak: "break-word"

https://user-images.githubusercontent.com/82360525/222877087-9c7d675c-7d38-4daa-b26b-67340c061dde.mp4

