### PR TITLE
Fix : checkbox not visible in darkmode

### DIFF
--- a/packages/app-extension/src/components/common/index.tsx
+++ b/packages/app-extension/src/components/common/index.tsx
@@ -4,6 +4,7 @@ import { HOVER_OPACITY, styles, useCustomTheme } from "@coral-xyz/themes";
 import { Box, Button, Checkbox as _Checkbox, Typography } from "@mui/material";
 import type { BigNumber } from "ethers";
 import { ethers } from "ethers";
+import { useDarkMode } from "@coral-xyz/recoil";
 
 import { TextField } from "../../plugin/Component";
 
@@ -70,6 +71,10 @@ const useStyles = styles((theme: CustomTheme) => ({
   checkBoxChecked: {
     color: `${theme.custom.colors.primaryButton} !important`,
     background: "white",
+  },
+  darkCheckboxChecked: {
+    color: `white !important`,
+    background: `${theme.custom.colors.smallTextColor} !important`,
   },
   subtext: {
     color: theme.custom.colors.subtext,
@@ -214,6 +219,7 @@ export function Checkbox({
   setChecked?: (value: boolean) => void;
 } & React.ComponentProps<typeof _Checkbox>) {
   const classes = useStyles();
+  const isDark = useDarkMode();
   return (
     <_Checkbox
       disableRipple
@@ -221,7 +227,7 @@ export function Checkbox({
       checked={checked}
       onChange={() => setChecked(!checked)}
       classes={{
-        checked: classes.checkBoxChecked,
+        checked: isDark ? classes.darkCheckboxChecked : classes.checkBoxChecked,
         root: classes.checkBoxRoot,
       }}
       {...checkboxProps}


### PR DESCRIPTION
Fix #1150 
Problem: The tick mark was not visible in dark mode.
Solution: Check the current theme mode and change the checkbox's checked color when in dark mode.

Dark Mode :
![DARK](https://res.cloudinary.com/primeflix/image/upload/v1678018226/dark_udexh6.gif)

Ligh Mode : 
![LIGHT](https://res.cloudinary.com/primeflix/image/upload/v1678018064/ligh_wfafqe.gif)

