### PR TITLE
close any existing backpack windows when opening a new one

### DIFF
--- a/packages/app-extension/src/index.tsx
+++ b/packages/app-extension/src/index.tsx
@@ -1,4 +1,4 @@
-import React, { lazy, Suspense } from "react";
+import { lazy, Suspense } from "react";
 import { createRoot } from "react-dom/client";
 import { BACKPACK_FEATURE_POP_MODE, openPopupWindow } from "@coral-xyz/common";
 
@@ -6,6 +6,17 @@ import "./index.css";
 
 const App = lazy(() => import("./app/App"));
 const LedgerIframe = lazy(() => import("./components/LedgerIframe"));
+
+// Tell all existing extension instances that this instance now exists
+chrome.runtime
+  .sendMessage("new-instance-was-opened")
+  .then(() => {
+    // Close all existing extension instances so only this one is running
+    chrome.runtime.onMessage.addListener((msg) => {
+      if (msg === "new-instance-was-opened") window.close();
+    });
+  })
+  .catch(console.error);
 
 // Connect to the background script so it can detect if the popup is closed
 chrome.runtime.connect();

--- a/packages/app-extension/src/index.tsx
+++ b/packages/app-extension/src/index.tsx
@@ -11,7 +11,7 @@ const LedgerIframe = lazy(() => import("./components/LedgerIframe"));
 chrome.runtime
   .sendMessage("new-instance-was-opened")
   .then(() => {
-    // Close all existing extension instances so only this one is running
+    // Close all existing extension instances so only the newest is running
     chrome.runtime.onMessage.addListener((msg) => {
       if (msg === "new-instance-was-opened") window.close();
     });

--- a/packages/app-extension/src/index.tsx
+++ b/packages/app-extension/src/index.tsx
@@ -7,7 +7,8 @@ import "./index.css";
 const App = lazy(() => import("./app/App"));
 const LedgerIframe = lazy(() => import("./components/LedgerIframe"));
 
-// Tell all existing extension instances that this instance now exists
+// Tell all existing extension instances that this instance now exists.
+// This block ensures a single extension window is open at any given time.
 chrome.runtime
   .sendMessage("new-instance-was-opened")
   .then(() => {

--- a/packages/app-extension/src/index.tsx
+++ b/packages/app-extension/src/index.tsx
@@ -1,6 +1,10 @@
 import { lazy, Suspense } from "react";
 import { createRoot } from "react-dom/client";
-import { BACKPACK_FEATURE_POP_MODE, openPopupWindow } from "@coral-xyz/common";
+import {
+  BACKPACK_FEATURE_POP_MODE,
+  isValidEventOrigin,
+  openPopupWindow,
+} from "@coral-xyz/common";
 
 import "./index.css";
 
@@ -13,8 +17,10 @@ chrome.runtime
   .sendMessage("new-instance-was-opened")
   .then(() => {
     // Close all existing extension instances so only the newest is running
-    chrome.runtime.onMessage.addListener((msg) => {
-      if (msg === "new-instance-was-opened") window.close();
+    chrome.runtime.onMessage.addListener((msg, sender) => {
+      if (isValidEventOrigin(sender) && msg === "new-instance-was-opened") {
+        window.close();
+      }
     });
   })
   .catch(console.error);


### PR DESCRIPTION
Closes other instances of backpack upon opening, for both extension and popout mode.

When a user has multiple backpack windows open it can lead to unpredictable behaviors.

https://user-images.githubusercontent.com/101902546/223525604-5350f328-c075-4ce1-b3b0-32be6d728e50.mov

I don't yet know what the implications of this would be, it needs more testing before being merged.

There could be unforeseen issues with the autolock timer not being restarted for instance