### PR TITLE
fix dates in ethereum recent activity

### DIFF
--- a/packages/app-extension/src/components/Unlocked/Balances/RecentActivity.tsx
+++ b/packages/app-extension/src/components/Unlocked/Balances/RecentActivity.tsx
@@ -1,3 +1,5 @@
+// TODO: remove the line below
+/* eslint-disable react-hooks/rules-of-hooks */
 import { Suspense, useState } from "react";
 import { Blockchain, explorerUrl, XNFT_GG_LINK } from "@coral-xyz/common";
 import {
@@ -335,7 +337,10 @@ function RecentActivityListItem({ transaction, isFirst, isLast }: any) {
               {transaction.signature.slice(transaction.signature.length - 5)}
             </Typography>
             <Typography className={classes.txDate}>
-              {new Date(transaction.timestamp * 1000).toLocaleDateString()}
+              {(transaction.date
+                ? transaction.date
+                : new Date(transaction.timestamp * 1000)
+              ).toLocaleDateString()}
             </Typography>
           </div>
         </div>

--- a/packages/app-extension/src/components/Unlocked/Balances/RecentActivity.tsx
+++ b/packages/app-extension/src/components/Unlocked/Balances/RecentActivity.tsx
@@ -337,10 +337,16 @@ function RecentActivityListItem({ transaction, isFirst, isLast }: any) {
               {transaction.signature.slice(transaction.signature.length - 5)}
             </Typography>
             <Typography className={classes.txDate}>
-              {(transaction.date
-                ? transaction.date
-                : new Date(transaction.timestamp * 1000)
-              ).toLocaleDateString()}
+              {
+                // TODO: Standardize the parsed ethereum and solana transactions
+                //       so that `transaction.date` can be used for both of them
+                (transaction.date
+                  ? // ethereum transactions provide a date
+                    transaction.date
+                  : // solana transactions provide a timestamp in seconds
+                    new Date(transaction.timestamp * 1000)
+                ).toLocaleDateString()
+              }
             </Typography>
           </div>
         </div>

--- a/packages/app-extension/src/components/Unlocked/Balances/RecentActivity.tsx
+++ b/packages/app-extension/src/components/Unlocked/Balances/RecentActivity.tsx
@@ -340,12 +340,13 @@ function RecentActivityListItem({ transaction, isFirst, isLast }: any) {
               {
                 // TODO: Standardize the parsed ethereum and solana transactions
                 //       so that `transaction.date` can be used for both of them
-                (transaction.date
-                  ? // ethereum transactions provide a date
-                    transaction.date
-                  : // solana transactions provide a timestamp in seconds
-                    new Date(transaction.timestamp * 1000)
-                ).toLocaleDateString()
+                (
+                  (transaction.date
+                    ? // ethereum transactions provide a date
+                      transaction.date
+                    : // solana transactions provide a timestamp in seconds
+                      new Date(transaction.timestamp * 1000)) as Date
+                ).toLocaleString()
               }
             </Typography>
           </div>


### PR DESCRIPTION
fixes #3197

A quick fix to get in the next release, a bigger more robust fix would involve changing more code and adding some types to ensure that all expected properties are available.

Also adds a timestamp in the user's locale for some more information. Longer term it might be better to replace with time ago like "10 minutes ago" but perhaps this is better than only showing the date for now?

eth|sol
----|-----
<img width="487" alt="Screenshot 2023-03-07 at 13 47 32" src="https://user-images.githubusercontent.com/101902546/223560749-4fab1070-1141-4a3c-bbf2-38838082a4eb.png">|<img width="487" alt="Screenshot 2023-03-07 at 13 47 19" src="https://user-images.githubusercontent.com/101902546/223560753-fea4f9f8-5ecc-4050-9062-60b4e9da7b20.png">
