### PR TITLE
fix ui issue when sending to .sol domains

### DIFF
--- a/packages/app-extension/src/components/Unlocked/Balances/TokensWidget/AddressSelector.tsx
+++ b/packages/app-extension/src/components/Unlocked/Balances/TokensWidget/AddressSelector.tsx
@@ -153,7 +153,7 @@ export const AddressSelector = ({
   const ethereumCtx = useEthereumCtx();
   const [searchResults, setSearchResults] = useState<RemoteUserData[]>([]);
   const { push } = useNavigation();
-  const { isValidAddress } = useIsValidAddress(
+  const { isValidAddress, normalizedAddress } = useIsValidAddress(
     blockchain,
     inputContent,
     solanaProvider.connection,
@@ -209,7 +209,7 @@ export const AddressSelector = ({
                   blockchain,
                   token,
                   to: {
-                    address: inputContent,
+                    address: normalizedAddress || inputContent,
                     username: user?.username,
                     image: user?.image,
                     uuid: user?.id,

--- a/packages/app-extension/src/components/Unlocked/Balances/TokensWidget/Send.tsx
+++ b/packages/app-extension/src/components/Unlocked/Balances/TokensWidget/Send.tsx
@@ -1,4 +1,4 @@
-import React, { type ChangeEvent, useEffect, useState } from "react";
+import React, { type ChangeEvent,useEffect, useState } from "react";
 import { StyleSheet, View } from "react-native";
 import {
   getHashedName,
@@ -851,7 +851,7 @@ export function useIsValidAddress(
         }
 
         // SNS Domain
-        if (address.includes(".sol")) {
+        if (address.endsWith(".sol")) {
           try {
             const hashedName = await getHashedName(address.replace(".sol", ""));
             const nameAccountKey = await getNameAccountKey(


### PR DESCRIPTION
fixes a bug where it looked like the public key you are sending to was the .sol domain

### Example

#### sending to `backpack.sol`

<img width="487" alt="Screenshot 2023-03-07 at 15 11 34" src="https://user-images.githubusercontent.com/101902546/223575303-167c5dca-700a-4086-a4aa-2a11709ebde2.png">


before | after
-----|-----
<img width="487" alt="Screenshot 2023-03-07 at 15 12 15" src="https://user-images.githubusercontent.com/101902546/223575519-02c1321a-fb3a-4548-80ed-7f706fcd8683.png">|<img width="487" alt="Screenshot 2023-03-07 at 15 11 38" src="https://user-images.githubusercontent.com/101902546/223575518-3f3f928c-87e8-489b-bcc7-8d42ed9fe0ce.png">