### PR TITLE
fix public key conflict endpoint

### DIFF
--- a/backend/native/backpack-api/src/db/users.ts
+++ b/backend/native/backpack-api/src/db/users.ts
@@ -137,33 +137,19 @@ export const getUsers = async (
  * Look up user IDs for multiple blockchain/public key pairs.
  */
 export const getUsersByPublicKeys = async (
-  blockchainPublicKeys: Array<{ blockchain: Blockchain; publicKey: string }>,
-  primaryOnly = true
+  blockchainPublicKeys: Array<{ blockchain: Blockchain; publicKey: string }>
 ): Promise<
   Array<{ user_id?: unknown; blockchain: string; public_key: unknown }>
 > => {
-  let where;
-  if (primaryOnly) {
-    where = {
-      user_active_publickey_mappings: {
-        public_key: {
-          public_key: { _in: blockchainPublicKeys.map((b) => b.publicKey) },
-        },
-      },
-    };
-  } else {
-    where = {
-      // Only matching public keys here, but it should be checking
-      // blockchain AND public key as the same public key will be used
-      // for different blockchains (particularly EVM)
-      public_key: { _in: blockchainPublicKeys.map((b) => b.publicKey) },
-    };
-  }
-
   const response = await chain("query")({
     auth_public_keys: [
       {
-        where,
+        where: {
+          // Only matching public keys here, but it should be checking
+          // blockchain AND public key as the same public key will be used
+          // for different blockchains (particularly EVM)
+          public_key: { _in: blockchainPublicKeys.map((b) => b.publicKey) },
+        },
         limit: 100,
       },
       {

--- a/backend/native/backpack-api/src/routes/v1/nft.ts
+++ b/backend/native/backpack-api/src/routes/v1/nft.ts
@@ -27,15 +27,12 @@ router.post("/bulk", extractUserId, async (req, res) => {
   const userId: string = req.id;
   const nfts = req.body.nfts;
   const publicKey: string = req.body.publicKey;
-  const users = await getUsersByPublicKeys(
-    [
-      {
-        blockchain: Blockchain.SOLANA,
-        publicKey,
-      },
-    ],
-    false
-  );
+  const users = await getUsersByPublicKeys([
+    {
+      blockchain: Blockchain.SOLANA,
+      publicKey,
+    },
+  ]);
   if (users[0].user_id !== userId) {
     return res.status(403).json({
       msg: "User doesn't own this public key",

--- a/backend/native/backpack-api/src/routes/v1/public-keys.ts
+++ b/backend/native/backpack-api/src/routes/v1/public-keys.ts
@@ -26,7 +26,12 @@ router.post("/", async (req: Request, res: Response, next: NextFunction) => {
     }))
   );
 
-  return res.status(200).json(users);
+  return res.status(200).json(
+    users.map((u) => ({
+      blockchain: u.blockchain,
+      public_key: u.public_key,
+    }))
+  );
 });
 
 export default router;

--- a/backend/native/backpack-api/src/routes/v1/users.ts
+++ b/backend/native/backpack-api/src/routes/v1/users.ts
@@ -141,9 +141,7 @@ router.post("/", async (req, res) => {
     blockchainPublicKeys.map((b) => ({
       blockchain: b.blockchain as Blockchain,
       publicKey: b.publicKey,
-    })),
-    // Don't restrict to primary public key only, we want any conflicts
-    false
+    }))
   );
   if (conflictingUsers.length > 0) {
     // Another user already uses this public key


### PR DESCRIPTION
Instead of restricting to primary public keys only, just strip the user id from the response. We still need to know if they exist on any accounts to allow for conflict checking.