### PR TITLE
fix devnet sol tx data hook

### DIFF
--- a/packages/recoil/src/hooks/useTransactionData.tsx
+++ b/packages/recoil/src/hooks/useTransactionData.tsx
@@ -62,9 +62,12 @@ export function useTransactionData(
   blockchain: Blockchain,
   transaction: any
 ): TransactionData {
+  // FIXME: remove lint blocker
   return blockchain === Blockchain.ETHEREUM
-    ? useEthereumTxData(transaction)
-    : useSolanaTxData(transaction);
+    ? // eslint-disable-next-line react-hooks/rules-of-hooks
+      useEthereumTxData(transaction)
+    : // eslint-disable-next-line react-hooks/rules-of-hooks
+      useSolanaTxData(transaction);
 }
 
 //
@@ -270,7 +273,7 @@ export function useSolanaTxData(serializedTx: any): TransactionData {
         const response = await connection.getFeeForMessage(
           transaction.message as Message
         );
-        setEstimatedTxFee(response.value);
+        setEstimatedTxFee(response.value ?? 0);
       } catch (e) {
         // ignore
       }


### PR DESCRIPTION
network fee for message on devnet solana is returned as `null` from the rpc method, and was not properly handled causing an uncaught data parsing error.