### PR TITLE
fix size of popout for windows users

### DIFF
--- a/packages/common/src/browser/extension.ts
+++ b/packages/common/src/browser/extension.ts
@@ -54,56 +54,9 @@ export class BrowserRuntimeExtension {
     // that those promises can properly resolve with the right state,
     // i.e. user denied the request.
     //
-    UiActionRequestManager.cancelAllRequests();
-
-    return new Promise(async (resolve, reject) => {
-      // try to reuse existing popup window
-      try {
-        const popupWindowId: number | undefined =
-          await BrowserRuntimeCommon.getLocalStorage("popupWindowId");
-        if (popupWindowId) {
-          const popupWindow = await chrome?.windows.get(popupWindowId);
-          if (popupWindow) {
-            const tabs = await chrome.tabs.query({ windowId: popupWindowId });
-            if (tabs.length === 1) {
-              const tab = tabs[0];
-              const url: string = Array.isArray(options.url)
-                ? options.url[0]!
-                : options.url!;
-              const updatedTab = await chrome.tabs.update(tab.id!, { url });
-              if (updatedTab) {
-                const popupWindow = await chrome?.windows.update(
-                  updatedTab.windowId,
-                  { focused: true }
-                );
-                return resolve(popupWindow);
-              } else {
-                const error = BrowserRuntimeCommon.checkForError();
-                return reject(error);
-              }
-            }
-          }
-        }
-      } catch (e) {
-        // fall through to create new window
-      }
-      // if nothign to reuse create new window.
-      try {
-        const newPopupWindow = await chrome?.windows.create(options);
-        if (newPopupWindow) {
-          BrowserRuntimeCommon.setLocalStorage(
-            "popupWindowId",
-            newPopupWindow.id
-          );
-          resolve(newPopupWindow);
-        }
-        const error = BrowserRuntimeCommon.checkForError();
-        return reject(error);
-      } catch (e) {
-        const error = BrowserRuntimeCommon.checkForError();
-        return reject(error);
-      }
-    });
+    await UiActionRequestManager.cancelAllRequests();
+    const newPopupWindow = await chrome?.windows.create(options);
+    return newPopupWindow;
   }
 
   public static async getLastFocusedWindow(): Promise<chrome.windows.Window>;
@@ -216,40 +169,25 @@ export async function openApproveMessagePopupWindow(
 export async function openPopupWindow(
   url: string
 ): Promise<chrome.windows.Window> {
-  const MACOS_TOOLBAR_HEIGHT = 28;
-  const WINDOWS_TOOLBAR_HEIGHT = 28; // TODO: confirm this.
-  function getOs() {
-    const os = ["Windows", "Linux", "Mac"];
-    return os.find((v) => navigator.appVersion.indexOf(v) >= 0);
-  }
-  function isMacOs(): boolean {
-    return getOs() === "Mac";
-  }
-  function isWindows(): boolean {
-    return getOs() === "Windows";
-  }
+  const _window = await BrowserRuntimeExtension.getLastFocusedWindow();
 
-  return new Promise((resolve) => {
-    BrowserRuntimeExtension.getLastFocusedWindow().then((window: any) => {
-      BrowserRuntimeExtension._openWindow({
-        url: `${url}`,
-        type: "popup",
-        width: EXTENSION_WIDTH,
-        height:
-          EXTENSION_HEIGHT +
-          (isMacOs()
-            ? MACOS_TOOLBAR_HEIGHT
-            : isWindows()
-            ? WINDOWS_TOOLBAR_HEIGHT
-            : 0),
-        top: window.top,
-        left: window.left + (window.width - EXTENSION_WIDTH),
-        focused: true,
-      }).then((window: any) => {
-        resolve(window);
-      });
-    });
+  const [EXTRA_HEIGHT, EXTRA_WIDTH] =
+    (navigator as any).userAgentData.platform === "Windows"
+      ? [36, 12]
+      : [28, 0];
+
+  await BrowserRuntimeExtension._openWindow({
+    url: `${url}`,
+    type: "popup",
+    width: EXTENSION_WIDTH + EXTRA_WIDTH,
+    height: EXTENSION_HEIGHT + EXTRA_HEIGHT,
+    top: _window.top,
+    left:
+      (_window.left ?? 0) +
+      ((_window.width ?? 0) - EXTENSION_WIDTH - EXTRA_WIDTH),
+    focused: true,
   });
+  return _window;
 }
 
 export function openOnboarding() {


### PR DESCRIPTION
fixes #547

## before

popout on right of regular extension window, it's slightly shorter and a lot thinner

<img width="787" alt="Screenshot 2023-03-09 at 08 26 57" src="https://user-images.githubusercontent.com/101902546/224088748-662dc382-15ac-453e-9671-e6e7b96d3d6a.png">

## after

sizes now match

<img width="803" alt="Screenshot 2023-03-09 at 08 26 17" src="https://user-images.githubusercontent.com/101902546/224088914-0e443595-ebf7-4d46-aecc-b3b220feb771.png">

