### PR TITLE
clicking reply should auto focus the messaging input field 

### DIFF
--- a/packages/chat-sdk/src/components/Message.tsx
+++ b/packages/chat-sdk/src/components/Message.tsx
@@ -356,6 +356,9 @@ export const MessageLine = (props) => {
                               parent_username: `@${props.username}`,
                               parent_message_author_uuid: props.userId,
                             });
+                            document
+                              .getElementById(chatMessageInputId)
+                              ?.focus();
                           }}
                         >
                           <ReplyIcon fill={theme.custom.colors.icon} />
@@ -1041,6 +1044,9 @@ function MessageLeft(props) {
                 parent_username: `@${props.username}`,
                 parent_message_author_uuid: props.userId,
               });
+              document
+                .getElementById(chatMessageInputId)
+                ?.focus();
             }}
           >
             <ReplyIcon fill={theme.custom.colors.icon} />
@@ -1091,6 +1097,9 @@ function MessageRight(props) {
                   parent_message_author_uuid: props.userId,
                   parent_username: "Yourself",
                 });
+                document
+                  .getElementById(chatMessageInputId)
+                  ?.focus();
               }}
             >
               <ReplyIcon fill={theme.custom.colors.icon} />


### PR DESCRIPTION
Fix : #2105
 input box only focuses for the first message sent by the user and not for follow-up messages by the same user

(only focus the input box for the first message )

https://user-images.githubusercontent.com/79896602/224540002-d5f02e6e-7313-4885-8ad9-689d284a849a.mp4





Fix : There are four places that handle the **Reply** button but only one of them targets the input box and focuses on it.

https://user-images.githubusercontent.com/79896602/224539709-77cd329e-b21a-4d4a-957d-5a3a4de9bc83.mp4

