### PR TITLE
add index to public_keys.user_id

### DIFF
--- a/backend/reef/hasura/migrations/default/1678649211108_create_index_public_keys_user_id_idx/down.sql
+++ b/backend/reef/hasura/migrations/default/1678649211108_create_index_public_keys_user_id_idx/down.sql
@@ -1,0 +1,1 @@
+DROP INDEX IF EXISTS "auth"."public_keys_user_id_idx";

--- a/backend/reef/hasura/migrations/default/1678649211108_create_index_public_keys_user_id_idx/up.sql
+++ b/backend/reef/hasura/migrations/default/1678649211108_create_index_public_keys_user_id_idx/up.sql
@@ -1,0 +1,2 @@
+CREATE  INDEX "public_keys_user_id_idx" on
+  "auth"."public_keys" using btree ("user_id");


### PR DESCRIPTION
adds index to `auth.public_keys.user_id`

reduces total cost of 

```graphql
query {
  auth_users(where:{username:{_eq:"backpack_dev"}}) {
    id
    public_keys {
      public_key
    }
  }
}
```

from `20,500` to `17`

before | after
-------|------
<img width="959" alt="Screenshot 2023-03-12 at 12 31 29" src="https://user-images.githubusercontent.com/101902546/224568508-c22cd001-d875-4285-9a1f-bc7d1713d3ff.png">|<img width="884" alt="Screenshot 2023-03-12 at 12 31 37" src="https://user-images.githubusercontent.com/101902546/224568514-127e576d-b8b0-495b-be0a-d1727f5cf1ce.png">
