### PR TITLE
dependencies cleanup

### DIFF
--- a/backend/native/backend-common/package.json
+++ b/backend/native/backend-common/package.json
@@ -21,8 +21,5 @@
   "author": "",
   "scripts": {
     "build": "tsc && tsc-alias"
-  },
-  "devDependencies": {
-    "typescript": "^4.9.5"
   }
 }

--- a/backend/native/backend-ws/package.json
+++ b/backend/native/backend-ws/package.json
@@ -4,8 +4,8 @@
   "main": "index.js",
   "license": "MIT",
   "dependencies": {
-    "@coral-xyz/common": "*",
     "@coral-xyz/backend-common": "*",
+    "@coral-xyz/common": "*",
     "@coral-xyz/zeus": "*",
     "@types/express": "^4.17.14",
     "@types/redis": "^4.0.11",
@@ -22,5 +22,8 @@
     "start": "npm run build && node dist/index.js",
     "zeus-ws": "npx graphql-zeus http://localhost:8113/v1/graphql ./src --header=x-hasura-admin-secret:myadminsecretkey --header=x-hasura-role:chat  --subscriptions graphql-ws",
     "zeus": "npx graphql-zeus http://localhost:8113/v1/graphql ./src --header=x-hasura-admin-secret:myadminsecretkey --header=x-hasura-role:chat  --subscriptions"
+  },
+  "devDependencies": {
+    "esbuild": "^0.17.11"
   }
 }

--- a/backend/native/notifications-worker/package.json
+++ b/backend/native/notifications-worker/package.json
@@ -5,6 +5,7 @@
   "license": "MIT",
   "dependencies": {
     "@coral-xyz/backend-common": "*",
+    "@coral-xyz/chat-zeus": "*",
     "@coral-xyz/common": "*",
     "@coral-xyz/zeus": "*",
     "@project-serum/anchor": "^0.25.0",

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -55,7 +55,6 @@
     "@types/firefox-webext-browser": "^94.0.1",
     "@types/uuid": "^8.3.4",
     "eslint-config-custom": "*",
-    "eslint-plugin-simple-import-sort": "*",
     "tsc-alias": "^1.7.0",
     "typescript": "~4.9.3"
   }

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -17,6 +17,7 @@
     "uuid": "^9.0.0"
   },
   "devDependencies": {
+    "tsc-alias": "^1.8.3",
     "typescript": "~4.9.3"
   },
   "targets": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -14737,7 +14737,7 @@ esbuild@^0.17.10:
     "@esbuild/win32-ia32" "0.17.10"
     "@esbuild/win32-x64" "0.17.10"
 
-esbuild@^0.17.5:
+esbuild@^0.17.11, esbuild@^0.17.5:
   version "0.17.11"
   resolved "https://registry.yarnpkg.com/esbuild/-/esbuild-0.17.11.tgz#9f3122643b21d7e7731e42f18576c10bfa28152b"
   integrity sha512-pAMImyokbWDtnA/ufPxjQg0fYo2DDuzAlqwnDvbXqHLphe+m80eF++perYKVm8LeTuj2zUuFXC+xgSVxyoHUdg==
@@ -14966,11 +14966,6 @@ eslint-plugin-require-extensions@^0.1.1:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/eslint-plugin-require-extensions/-/eslint-plugin-require-extensions-0.1.2.tgz#556c337b727e831accf38c777843dedede62c054"
   integrity sha512-UtddVQMdE2SezgWwK7JO7eCBUDUqLg6jq8YGlz5RlSG06Sqlr+xcAaosho3wZYrOzfp6zKUseDFavWgoAgCimQ==
-
-eslint-plugin-simple-import-sort@*:
-  version "10.0.0"
-  resolved "https://registry.yarnpkg.com/eslint-plugin-simple-import-sort/-/eslint-plugin-simple-import-sort-10.0.0.tgz#cc4ceaa81ba73252427062705b64321946f61351"
-  integrity sha512-AeTvO9UCMSNzIHRkg8S6c3RPy5YEwKWSQPx3DYghLedo2ZQxowPFLGDN1AZ2evfg6r6mjBSZSLxLFsWSu3acsw==
 
 eslint-plugin-simple-import-sort@^7.0.0:
   version "7.0.0"
@@ -26357,6 +26352,18 @@ tsc-alias@^1.7.0, tsc-alias@^1.7.1:
   version "1.8.2"
   resolved "https://registry.yarnpkg.com/tsc-alias/-/tsc-alias-1.8.2.tgz#3cd24bba7333a5e05cb7db3ac206d7bcec079630"
   integrity sha512-ukBkcNekOgwtnSWYLD5QsMX3yQWg7JviAs8zg3qJGgu4LGtY3tsV4G6vnqvOXIDkbC+XL9vbhObWSpRA5/6wbg==
+  dependencies:
+    chokidar "^3.5.3"
+    commander "^9.0.0"
+    globby "^11.0.4"
+    mylas "^2.1.9"
+    normalize-path "^3.0.0"
+    plimit-lit "^1.2.6"
+
+tsc-alias@^1.8.3:
+  version "1.8.3"
+  resolved "https://registry.yarnpkg.com/tsc-alias/-/tsc-alias-1.8.3.tgz#fe0c8331edd69b94160b2b936752b114f8063cb5"
+  integrity sha512-/9JARcmXBrEqSuLjdSOqxY7/xI/AnvmBi4CU9/Ba2oX6Oq8vnd0OGSQTk+PIwqWJ5ZxskV0X/x15yzxCNTHU+g==
   dependencies:
     chokidar "^3.5.3"
     commander "^9.0.0"


### PR DESCRIPTION
Adds some missing, removes some unused deps.

The motivation behind this is that it can take anywhere between 10-30 minutes to build this repo from scratch and in CI, I think we can reduce this by at least 10x by using pnpm instead, but to do that the dependencies need to be correct for each package (99% done) and some bugs and circular dependencies that yarn is hiding need to be addressed.