### PR TITLE
Fix image loads

### DIFF
--- a/packages/app-extension/src/components/Locked/index.tsx
+++ b/packages/app-extension/src/components/Locked/index.tsx
@@ -217,6 +217,7 @@ function LockScreenAvatar({
         </>
       ) : (
         <LocalImage
+          size={120}
           src={lockScreenKeyImage(user.username)}
           style={{
             height: "120px",

--- a/packages/app-extension/src/components/Unlocked/Balances/TokensWidget/Send.tsx
+++ b/packages/app-extension/src/components/Unlocked/Balances/TokensWidget/Send.tsx
@@ -480,6 +480,7 @@ function SendV2({ token, maxAmount, setAmount, sendButton, to }: any) {
           <div className={classes.horizontalCenter} style={{ marginBottom: 6 }}>
             <div className={classes.topImageOuter}>
               <LocalImage
+                size={80}
                 className={classes.topImage}
                 src={
                   to?.image ||

--- a/packages/app-extension/src/components/Unlocked/Messages/ChatDrawer.tsx
+++ b/packages/app-extension/src/components/Unlocked/Messages/ChatDrawer.tsx
@@ -249,6 +249,7 @@ function MembersList({
     >
       {members.map((member, idx) => (
         <LocalImage
+          size={30}
           key={idx}
           src={member.image}
           loadingStyles={{

--- a/packages/app-extension/src/components/Unlocked/Nfts/Detail.tsx
+++ b/packages/app-extension/src/components/Unlocked/Nfts/Detail.tsx
@@ -483,6 +483,7 @@ function SendScreen({ nft, to }: { nft: any; to: SendData }) {
               >
                 <div className={classes.topImageOuter}>
                   <LocalImage
+                    size={80}
                     className={classes.topImage}
                     src={
                       to?.image ||

--- a/packages/chat-sdk/src/components/Message.tsx
+++ b/packages/chat-sdk/src/components/Message.tsx
@@ -400,6 +400,7 @@ export const MessageLine = (props) => {
           >
             {photoURL ? (
               <LocalImage
+                size={32}
                 onClick={() => openProfilePage({ uuid: props.uuid })}
                 alt={displayName}
                 className={classes.avatar}

--- a/packages/chat-sdk/src/components/barter/BarterHeader.tsx
+++ b/packages/chat-sdk/src/components/barter/BarterHeader.tsx
@@ -59,6 +59,7 @@ export const BarterHeader = () => {
         <div style={{ flex: 1 }}>
           <div className={classes.avatar}>
             <LocalImage
+              size={32}
               style={{ width: 32, height: 32, borderRadius: "50%" }}
               src={localUserImage}
             />
@@ -70,6 +71,7 @@ export const BarterHeader = () => {
         <div style={{ flex: 1 }}>
           <div className={classes.avatar}>
             <LocalImage
+              size={32}
               style={{ width: 32, height: 32, borderRadius: "50%" }}
               src={remoteUserImage}
             />

--- a/packages/common/src/utils.ts
+++ b/packages/common/src/utils.ts
@@ -89,9 +89,12 @@ export function externalResourceUri(
   return `${uri}`;
 }
 
-export function proxyImageUrl(url: string): string {
+export function proxyImageUrl(url: string, size = 400): string {
   if (url && (url.startsWith("http://") || url.startsWith("https://"))) {
-    return `https://images.xnfts.dev/cdn-cgi/image/fit=contain,width=400,height=400,quality=85/${url}`;
+    if (url.includes("swr.xnfts.dev/avatars/")) {
+      url += `?size=${size}`;
+    }
+    return `https://images.xnfts.dev/cdn-cgi/image/fit=contain,width=${size},height=${size},quality=85/${url}`;
   }
   return url;
 }

--- a/packages/message-sdk/src/components/MessageList.tsx
+++ b/packages/message-sdk/src/components/MessageList.tsx
@@ -404,6 +404,7 @@ function UserIcon({ image }: any) {
   const classes = useStyles();
   return (
     <LocalImage
+      size={40}
       style={{ width: 40, height: 40 }}
       src={image}
       className={classes.iconCircularBig}

--- a/packages/message-sdk/src/components/ProfileScreen.tsx
+++ b/packages/message-sdk/src/components/ProfileScreen.tsx
@@ -126,6 +126,7 @@ export const ProfileScreen = ({ userId }: { userId: string }) => {
         <div className={classes.horizontalCenter}>
           <div className={classes.topImageOuter}>
             <LocalImage
+              size={150}
               className={classes.topImage}
               src={userMetadata[userId]?.image}
               style={{ width: 150, height: 150 }}

--- a/packages/message-sdk/src/components/UserList.tsx
+++ b/packages/message-sdk/src/components/UserList.tsx
@@ -345,6 +345,7 @@ function UserIcon({ image }: any) {
   const classes = useStyles();
   return (
     <LocalImage
+      size={32}
       src={image}
       className={classes.iconCircular}
       style={{ width: 32, height: 32 }}

--- a/packages/react-common/src/components/base/LocalImage.tsx
+++ b/packages/react-common/src/components/base/LocalImage.tsx
@@ -33,6 +33,7 @@ export const LocalImage = (props) => {
       className={props.className}
       style={props.style}
       loadingStyles={props.loadingStyles}
+      size={props.size}
     />
   );
 };

--- a/packages/react-common/src/components/base/ProxyImage.tsx
+++ b/packages/react-common/src/components/base/ProxyImage.tsx
@@ -1,4 +1,4 @@
-import React, { useLayoutEffect, useRef, useState } from "react";
+import React, { useEffect, useLayoutEffect, useRef, useState } from "react";
 import { proxyImageUrl } from "@coral-xyz/common";
 import { Skeleton } from "@mui/material";
 
@@ -9,10 +9,12 @@ type ImgProps = React.DetailedHTMLProps<
 export const ProxyImage = React.memo(function ProxyImage({
   removeOnError,
   loadingStyles,
+  size,
   ...imgProps
 }: {
   removeOnError?: boolean;
   loadingStyles?: React.CSSProperties;
+  size?: number;
 } & ImgProps) {
   const placeholderRef = useRef<HTMLSpanElement>(null);
   const imageRef = useRef<HTMLImageElement>(null);
@@ -34,6 +36,21 @@ export const ProxyImage = React.memo(function ProxyImage({
     position: "absolute",
     top: "0px",
   };
+
+  useEffect(() => {
+    setTimeout(() => {
+      if (placeholderRef.current) {
+        placeholderRef.current.style.display = "none";
+        if (imageRef.current) {
+          imageRef.current.style.position =
+            imgProps?.style?.position ?? "inherit";
+          /// @ts-ignore
+          imageRef.current.style.top = imgProps?.style?.top ?? "inherit";
+          imageRef.current.style.visibility = "visible";
+        }
+      }
+    }, 1500);
+  }, []);
 
   return (
     <>
@@ -57,6 +74,7 @@ export const ProxyImage = React.memo(function ProxyImage({
           ...(imgProps.style ?? {}),
           ...visuallyHidden,
         }}
+        alt=""
         onLoad={(...e) => {
           const image = e[0].target as HTMLImageElement;
           if (placeholderRef.current) {
@@ -79,7 +97,7 @@ export const ProxyImage = React.memo(function ProxyImage({
             return count + 1;
           });
         }}
-        src={proxyImageUrl(imgProps.src ?? "")}
+        src={proxyImageUrl(imgProps.src ?? "", size)}
       />
     </>
   );

--- a/packages/react-common/src/components/base/ProxyImage.tsx
+++ b/packages/react-common/src/components/base/ProxyImage.tsx
@@ -32,7 +32,6 @@ export const ProxyImage = React.memo(function ProxyImage({
   }, []);
 
   const visuallyHidden: React.CSSProperties = {
-    visibility: "hidden",
     position: "absolute",
     top: "0px",
   };
@@ -51,7 +50,7 @@ export const ProxyImage = React.memo(function ProxyImage({
           imageRef.current.style.visibility = "visible";
         }
       }
-    }, 2500);
+    }, 2000);
   }, []);
 
   return (
@@ -68,39 +67,39 @@ export const ProxyImage = React.memo(function ProxyImage({
         ref={placeholderRef}
         className={imgProps.className}
       />
-      <img
+      {imgProps.src ? <img
         loading="lazy"
         ref={imageRef}
         {...imgProps}
         style={{
-          ...(imgProps.style ?? {}),
-          ...visuallyHidden,
-        }}
+            ...(imgProps.style ?? {}),
+            ...visuallyHidden,
+          }}
         alt=""
         onLoad={(...e) => {
-          const image = e[0].target as HTMLImageElement;
-          if (placeholderRef.current) {
-            placeholderRef.current.style.display = "none";
-          }
-          image.style.position = imgProps?.style?.position ?? "inherit";
-          /// @ts-ignore
-          image.style.top = imgProps?.style?.top ?? "inherit";
-          image.style.visibility = "visible";
-        }}
-        onError={(...e) => {
-          setErrCount((count) => {
-            if (count >= 1) {
-              if (removeOnError && placeholderRef.current) {
-                placeholderRef.current.style.display = "none";
-              }
-            } else {
-              if (imageRef.current) imageRef.current.src = imgProps.src ?? "";
+            const image = e[0].target as HTMLImageElement;
+            if (placeholderRef.current) {
+              placeholderRef.current.style.display = "none";
             }
-            return count + 1;
-          });
-        }}
+            image.style.position = imgProps?.style?.position ?? "inherit";
+            /// @ts-ignore
+            image.style.top = imgProps?.style?.top ?? "inherit";
+            image.style.visibility = "visible";
+          }}
+        onError={(...e) => {
+            setErrCount((count) => {
+              if (count >= 1) {
+                if (removeOnError && placeholderRef.current) {
+                  placeholderRef.current.style.display = "none";
+                }
+              } else {
+                if (imageRef.current) imageRef.current.src = imgProps.src ?? "";
+              }
+              return count + 1;
+            });
+          }}
         src={proxyImageUrl(imgProps.src ?? "", size)}
-      />
+        /> : null}
     </>
   );
 });

--- a/packages/react-common/src/components/base/ProxyImage.tsx
+++ b/packages/react-common/src/components/base/ProxyImage.tsx
@@ -51,7 +51,7 @@ export const ProxyImage = React.memo(function ProxyImage({
           imageRef.current.style.visibility = "visible";
         }
       }
-    }, 1500);
+    }, 2500);
   }, []);
 
   return (

--- a/packages/react-common/src/components/base/ProxyImage.tsx
+++ b/packages/react-common/src/components/base/ProxyImage.tsx
@@ -38,6 +38,8 @@ export const ProxyImage = React.memo(function ProxyImage({
   };
 
   useEffect(() => {
+    // This is a hack since `onLoad` does not fire sometimes.
+    // This timeout makes the skeleton goes away.
     setTimeout(() => {
       if (placeholderRef.current) {
         placeholderRef.current.style.display = "none";

--- a/packages/react-common/src/components/base/UserIcon.tsx
+++ b/packages/react-common/src/components/base/UserIcon.tsx
@@ -7,6 +7,7 @@ export function UserIcon({ image, size, marginRight }: any) {
   const theme = useCustomTheme();
   return (
     <LocalImage
+      size={size || 44}
       src={image}
       style={{
         width: size || 44,


### PR DESCRIPTION
PR asks for small images when small image is needed
PR modifies the `skeleton loader` logic a little to fallback to original image after 1.5s. This is done because the `onLoad` event doesn't seem to fire sometimes on the image causing the loader to stay up indefinitely 