### PR TITLE
add auth.public_keys.is_primary computed field

### DIFF
--- a/backend/native/zeus/src/zeus/const.ts
+++ b/backend/native/zeus/src/zeus/const.ts
@@ -419,6 +419,7 @@ export const AllTypesProps: Record<string, any> = {
     blockchain: "String_comparison_exp",
     created_at: "timestamptz_comparison_exp",
     id: "Int_comparison_exp",
+    is_primary: "Boolean_comparison_exp",
     public_key: "String_comparison_exp",
     user: "auth_users_bool_exp",
     user_active_publickey_mappings:
@@ -462,6 +463,7 @@ export const AllTypesProps: Record<string, any> = {
     blockchain: "order_by",
     created_at: "order_by",
     id: "order_by",
+    is_primary: "order_by",
     public_key: "order_by",
     user: "auth_users_order_by",
     user_active_publickey_mappings_aggregate:
@@ -1924,6 +1926,7 @@ export const ReturnTypes: Record<string, any> = {
     blockchain: "String",
     created_at: "timestamptz",
     id: "Int",
+    is_primary: "Boolean",
     public_key: "String",
     user: "auth_users",
     user_active_publickey_mappings: "auth_user_active_publickey_mapping",

--- a/backend/native/zeus/src/zeus/index.ts
+++ b/backend/native/zeus/src/zeus/index.ts
@@ -2704,6 +2704,8 @@ export type ValueTypes = {
     blockchain?: boolean | `@${string}`;
     created_at?: boolean | `@${string}`;
     id?: boolean | `@${string}`;
+    /** computed field which is TRUE if there's a matching user_active_publickey_mapping */
+    is_primary?: boolean | `@${string}`;
     public_key?: boolean | `@${string}`;
     /** An object relationship */
     user?: ValueTypes["auth_users"];
@@ -2973,6 +2975,11 @@ export type ValueTypes = {
       | undefined
       | null
       | Variable<any, string>;
+    is_primary?:
+      | ValueTypes["Boolean_comparison_exp"]
+      | undefined
+      | null
+      | Variable<any, string>;
     public_key?:
       | ValueTypes["String_comparison_exp"]
       | undefined
@@ -3130,6 +3137,11 @@ export type ValueTypes = {
       | null
       | Variable<any, string>;
     id?: ValueTypes["order_by"] | undefined | null | Variable<any, string>;
+    is_primary?:
+      | ValueTypes["order_by"]
+      | undefined
+      | null
+      | Variable<any, string>;
     public_key?:
       | ValueTypes["order_by"]
       | undefined
@@ -9755,6 +9767,8 @@ export type ResolverInputTypes = {
     blockchain?: boolean | `@${string}`;
     created_at?: boolean | `@${string}`;
     id?: boolean | `@${string}`;
+    /** computed field which is TRUE if there's a matching user_active_publickey_mapping */
+    is_primary?: boolean | `@${string}`;
     public_key?: boolean | `@${string}`;
     /** An object relationship */
     user?: ResolverInputTypes["auth_users"];
@@ -9967,6 +9981,10 @@ export type ResolverInputTypes = {
       | undefined
       | null;
     id?: ResolverInputTypes["Int_comparison_exp"] | undefined | null;
+    is_primary?:
+      | ResolverInputTypes["Boolean_comparison_exp"]
+      | undefined
+      | null;
     public_key?: ResolverInputTypes["String_comparison_exp"] | undefined | null;
     user?: ResolverInputTypes["auth_users_bool_exp"] | undefined | null;
     user_active_publickey_mappings?:
@@ -10065,6 +10083,7 @@ export type ResolverInputTypes = {
     blockchain?: ResolverInputTypes["order_by"] | undefined | null;
     created_at?: ResolverInputTypes["order_by"] | undefined | null;
     id?: ResolverInputTypes["order_by"] | undefined | null;
+    is_primary?: ResolverInputTypes["order_by"] | undefined | null;
     public_key?: ResolverInputTypes["order_by"] | undefined | null;
     user?: ResolverInputTypes["auth_users_order_by"] | undefined | null;
     user_active_publickey_mappings_aggregate?:
@@ -14977,6 +14996,8 @@ export type ModelTypes = {
     blockchain: string;
     created_at: ModelTypes["timestamptz"];
     id: number;
+    /** computed field which is TRUE if there's a matching user_active_publickey_mapping */
+    is_primary?: boolean | undefined;
     public_key: string;
     /** An object relationship */
     user?: ModelTypes["auth_users"] | undefined;
@@ -15056,6 +15077,7 @@ export type ModelTypes = {
     blockchain?: ModelTypes["String_comparison_exp"] | undefined;
     created_at?: ModelTypes["timestamptz_comparison_exp"] | undefined;
     id?: ModelTypes["Int_comparison_exp"] | undefined;
+    is_primary?: ModelTypes["Boolean_comparison_exp"] | undefined;
     public_key?: ModelTypes["String_comparison_exp"] | undefined;
     user?: ModelTypes["auth_users_bool_exp"] | undefined;
     user_active_publickey_mappings?:
@@ -15135,6 +15157,7 @@ export type ModelTypes = {
     blockchain?: ModelTypes["order_by"] | undefined;
     created_at?: ModelTypes["order_by"] | undefined;
     id?: ModelTypes["order_by"] | undefined;
+    is_primary?: ModelTypes["order_by"] | undefined;
     public_key?: ModelTypes["order_by"] | undefined;
     user?: ModelTypes["auth_users_order_by"] | undefined;
     user_active_publickey_mappings_aggregate?:
@@ -17805,6 +17828,8 @@ export type GraphQLTypes = {
     blockchain: string;
     created_at: GraphQLTypes["timestamptz"];
     id: number;
+    /** computed field which is TRUE if there's a matching user_active_publickey_mapping */
+    is_primary?: boolean | undefined;
     public_key: string;
     /** An object relationship */
     user?: GraphQLTypes["auth_users"] | undefined;
@@ -17895,6 +17920,7 @@ export type GraphQLTypes = {
     blockchain?: GraphQLTypes["String_comparison_exp"] | undefined;
     created_at?: GraphQLTypes["timestamptz_comparison_exp"] | undefined;
     id?: GraphQLTypes["Int_comparison_exp"] | undefined;
+    is_primary?: GraphQLTypes["Boolean_comparison_exp"] | undefined;
     public_key?: GraphQLTypes["String_comparison_exp"] | undefined;
     user?: GraphQLTypes["auth_users_bool_exp"] | undefined;
     user_active_publickey_mappings?:
@@ -17978,6 +18004,7 @@ export type GraphQLTypes = {
     blockchain?: GraphQLTypes["order_by"] | undefined;
     created_at?: GraphQLTypes["order_by"] | undefined;
     id?: GraphQLTypes["order_by"] | undefined;
+    is_primary?: GraphQLTypes["order_by"] | undefined;
     public_key?: GraphQLTypes["order_by"] | undefined;
     user?: GraphQLTypes["auth_users_order_by"] | undefined;
     user_active_publickey_mappings_aggregate?:

--- a/backend/reef/hasura/metadata/databases/default/tables/auth_public_keys.yaml
+++ b/backend/reef/hasura/metadata/databases/default/tables/auth_public_keys.yaml
@@ -23,6 +23,13 @@ array_relationships:
         remote_table:
           name: user_nfts
           schema: auth
+computed_fields:
+  - name: is_primary
+    definition:
+      function:
+        name: public_key_is_primary
+        schema: auth
+    comment: computed field which is TRUE if there's a matching user_active_publickey_mapping
 insert_permissions:
   - role: auth_worker
     permission:
@@ -39,6 +46,8 @@ select_permissions:
         - id
         - public_key
         - user_id
+      computed_fields:
+        - is_primary
       filter: {}
       allow_aggregations: true
   - role: auth_worker
@@ -49,6 +58,8 @@ select_permissions:
         - public_key
         - created_at
         - user_id
+      computed_fields:
+        - is_primary
       filter: {}
       allow_aggregations: true
   - role: one_xnft
@@ -59,6 +70,8 @@ select_permissions:
         - public_key
         - created_at
         - user_id
+      computed_fields:
+        - is_primary
       filter: {}
       allow_aggregations: true
 delete_permissions:

--- a/backend/reef/hasura/migrations/default/1679016121566_add_public_key_is_primary_function/down.sql
+++ b/backend/reef/hasura/migrations/default/1679016121566_add_public_key_is_primary_function/down.sql
@@ -1,0 +1,1 @@
+DROP FUNCTION IF EXISTS auth.public_key_is_primary(public_key_row auth.public_keys);

--- a/backend/reef/hasura/migrations/default/1679016121566_add_public_key_is_primary_function/up.sql
+++ b/backend/reef/hasura/migrations/default/1679016121566_add_public_key_is_primary_function/up.sql
@@ -1,0 +1,10 @@
+CREATE OR REPLACE FUNCTION auth.public_key_is_primary(public_key_row auth.public_keys)
+RETURNS BOOLEAN AS $$
+  SELECT EXISTS (
+    SELECT 1
+    FROM auth.user_active_publickey_mapping AS mapping
+    WHERE mapping.blockchain = public_key_row.blockchain
+    AND mapping.user_id = public_key_row.user_id
+    AND mapping.public_key_id = public_key_row.id
+  )
+$$ LANGUAGE sql STABLE;


### PR DESCRIPTION
<img width="886" alt="Screenshot 2023-03-16 at 18 31 06" src="https://user-images.githubusercontent.com/101902546/225789216-ec61a9a7-ad3d-4208-9a04-75a728638856.png">

adds an `is_primary: boolean` computed field to `public_keys`, it effectively does the same as `user_active_publickey_mappings` but in a more optimized way

### results from an example large query in prod

before (~10s query) | after (~50ms query)
---|---
<img width="828" alt="Screenshot 2023-03-16 at 21 04 35" src="https://user-images.githubusercontent.com/101902546/225810167-b5c25712-a514-4dce-beb3-ea91e3d00945.png">|<img width="771" alt="Screenshot 2023-03-16 at 21 05 48" src="https://user-images.githubusercontent.com/101902546/225810161-062beb41-5f08-4945-9647-7ab08660805f.png">
