### PR TITLE
eslint warn if "publickey" is one word

### DIFF
--- a/packages/eslint-config-custom/index.js
+++ b/packages/eslint-config-custom/index.js
@@ -55,6 +55,18 @@ module.exports = {
         fixMixedExportsWithInlineTypeSpecifier: true,
       },
     ],
+    "no-restricted-syntax": [
+      "warn",
+      {
+        selector: "Literal[value=/publickey|PUBLICKEY/]",
+        message: "Public key should be two words",
+      },
+      {
+        selector: "Identifier[name=/publickey|PUBLICKEY/]",
+        message:
+          "Public key should be two words, publicKey or public_key are valid variable names",
+      },
+    ],
     "simple-import-sort/imports": [
       "warn",
       {


### PR DESCRIPTION
<img width="614" alt="Screenshot 2023-03-20 at 10 10 47" src="https://user-images.githubusercontent.com/101902546/226417509-9005d4a8-b2ae-422c-8063-2e5556b1d893.png">

example | is valid?
-----|----
publickey|❌
publickeys|❌
PUBLICKEY|❌
PUBLICKEYS|❌
public_key|✅
public_keys|✅
publicKey|✅
publicKeys|✅

related:
- https://github.com/coral-xyz/backpack/pull/1298#discussion_r1006879977
- https://github.com/coral-xyz/backpack/pull/1296