### PR TITLE
return empty array if userIds.length === 0

### DIFF
--- a/backend/native/backend-ws/src/db/users.ts
+++ b/backend/native/backend-ws/src/db/users.ts
@@ -11,6 +11,9 @@ const chain = Chain(AUTH_HASURA_URL, {
 export const getUsers = async (
   userIds: string[]
 ): Promise<{ id: string; username: string }[]> => {
+  // hotfix: empty array returns all records
+  if (userIds.length === 0) return [];
+
   const response = await chain("query")(
     {
       auth_users: [

--- a/backend/native/backend-ws/src/db/users.ts
+++ b/backend/native/backend-ws/src/db/users.ts
@@ -12,7 +12,7 @@ export const getUsers = async (
   userIds: string[]
 ): Promise<{ id: string; username: string }[]> => {
   // hotfix: empty array returns all records
-  if (userIds.length === 0) return [];
+  if (userIds.filter(Boolean).length === 0) return [];
 
   const response = await chain("query")(
     {

--- a/backend/native/backpack-api/src/db/friendships.ts
+++ b/backend/native/backpack-api/src/db/friendships.ts
@@ -457,7 +457,7 @@ export const getFriendshipStatus = async (
   }[]
 > => {
   // hotfix: empty array returns all records
-  if (userIds.length === 0) return [];
+  if (userIds.filter(Boolean).length === 0) return [];
 
   const response = await chain("query")(
     {

--- a/backend/native/backpack-api/src/db/friendships.ts
+++ b/backend/native/backpack-api/src/db/friendships.ts
@@ -456,6 +456,9 @@ export const getFriendshipStatus = async (
     remoteRequested: boolean;
   }[]
 > => {
+  // hotfix: empty array returns all records
+  if (userIds.length === 0) return [];
+
   const response = await chain("query")(
     {
       auth_friendships: [

--- a/backend/native/backpack-api/src/db/users.ts
+++ b/backend/native/backpack-api/src/db/users.ts
@@ -21,6 +21,9 @@ export const getUsersMetadata = async (
     id: unknown;
   }[]
 > => {
+  // hotfix: empty array returns all records
+  if (userIds.length === 0) return [];
+
   const response = await chain("query")(
     {
       auth_users: [
@@ -50,6 +53,9 @@ export const getUsers = async (
     publicKeys: unknown[];
   }[]
 > => {
+  // hotfix: empty array returns all records
+  if (userIds.length === 0) return [];
+
   const response = await chain("query")(
     {
       auth_users: [

--- a/backend/native/backpack-api/src/db/users.ts
+++ b/backend/native/backpack-api/src/db/users.ts
@@ -22,7 +22,7 @@ export const getUsersMetadata = async (
   }[]
 > => {
   // hotfix: empty array returns all records
-  if (userIds.length === 0) return [];
+  if (userIds.filter(Boolean).length === 0) return [];
 
   const response = await chain("query")(
     {
@@ -54,7 +54,7 @@ export const getUsers = async (
   }[]
 > => {
   // hotfix: empty array returns all records
-  if (userIds.length === 0) return [];
+  if (userIds.filter(Boolean).length === 0) return [];
 
   const response = await chain("query")(
     {


### PR DESCRIPTION
sometimes these userIds arrays are empty and zeus strips the filter, so the query gets converted into something like `query getUsersMetadata {auth_users(where: {id: {}})  {id
username}}` which fetches the id and username of all users