### PR TITLE
discard yarn cache miss logs bc they take up too much

### DIFF
--- a/docker/backend-ws/Dockerfile
+++ b/docker/backend-ws/Dockerfile
@@ -32,6 +32,11 @@ COPY .yarnrc.yml .yarnrc.yml
 COPY .yarn/ .yarn/
 # RUN corepack enable && corepack prepare yarn@3.5.0 --activate
 
+# Append the required lines to the .yarnrc.yml file
+# YN0013 is cache-miss that will always hit on a fresh build
+RUN echo '  - code: YN0013' >> .yarnrc.yml && \
+    echo '    level: discard' >> .yarnrc.yml
+
 RUN cd /base
 RUN yarn install
 RUN cd /base/backend/native/zeus && yarn run build

--- a/docker/backpack-api/Dockerfile
+++ b/docker/backpack-api/Dockerfile
@@ -17,6 +17,11 @@ COPY .yarnrc.yml .yarnrc.yml
 COPY .yarn/ .yarn/
 # RUN corepack enable && corepack prepare yarn@3.5.0 --activate
 
+# Append the required lines to the .yarnrc.yml file
+# YN0013 is cache-miss that will always hit on a fresh build
+RUN echo '  - code: YN0013' >> .yarnrc.yml && \
+    echo '    level: discard' >> .yarnrc.yml
+
 RUN cd /base && yarn install && yarn run build && cd /base/backend/native/backpack-api && yarn run build
 
 EXPOSE 8080

--- a/docker/notifications-worker/Dockerfile
+++ b/docker/notifications-worker/Dockerfile
@@ -31,6 +31,11 @@ COPY .yarnrc.yml .yarnrc.yml
 COPY .yarn/ .yarn/
 # RUN corepack enable && corepack prepare yarn@3.5.0 --activate
 
+# Append the required lines to the .yarnrc.yml file
+# YN0013 is cache-miss that will always hit on a fresh build
+RUN echo '  - code: YN0013' >> .yarnrc.yml && \
+    echo '    level: discard' >> .yarnrc.yml
+
 RUN cd /base && yarn install && yarn run build
 RUN cd /base/backend/native/notifications-worker && yarn run build
 

--- a/docker/xnft-api-server/Dockerfile
+++ b/docker/xnft-api-server/Dockerfile
@@ -31,6 +31,11 @@ COPY .yarnrc.yml .yarnrc.yml
 COPY .yarn/ .yarn/
 # RUN corepack enable && corepack prepare yarn@3.5.0 --activate
 
+# Append the required lines to the .yarnrc.yml file
+# YN0013 is cache-miss that will always hit on a fresh build
+RUN echo '  - code: YN0013' >> .yarnrc.yml && \
+    echo '    level: discard' >> .yarnrc.yml
+
 RUN cd /base
 RUN yarn install
 RUN yarn run build


### PR DESCRIPTION
yarn log 13 is a cache miss. cache misses always happen bc these are fresh builds. no need to show all of them bc otherwise we don't see the other logs