### PR TITLE
wrap yarn script filters in quotes

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,19 +15,19 @@
     ]
   },
   "scripts": {
-    "lint": "turbo run lint --filter=!@coral-xyz/app-mobile",
-    "lint:fix": "turbo run lint:fix --filter=!@coral-xyz/app-mobile",
-    "start": "env-cmd --silent turbo run start --concurrency=100% --filter=./packages/*",
+    "lint": "turbo run lint --filter='!@coral-xyz/app-mobile'",
+    "lint:fix": "turbo run lint:fix --filter='!@coral-xyz/app-mobile'",
+    "start": "env-cmd --silent turbo run start --concurrency=100% --filter='./packages/*'",
     "start:fresh": "yarn install && yarn clean && yarn install && yarn start",
     "test": "env-cmd --silent turbo run test -- --passWithNoTests --watchAll=false",
     "build": "env-cmd --silent turbo run build --filter='!./examples/**' ",
     "build:fresh": "git clean -xfd && yarn install && yarn build --force",
     "e2e": "env-cmd --silent turbo run e2e",
     "clean": "git clean -xfd",
-    "start:ext": "env-cmd --silent turbo run start --filter=@coral-xyz/app-extension... --filter=@coral-xyz/background...",
-    "build:ext": "env-cmd --silent turbo run build --filter=@coral-xyz/app-extension... --filter=@coral-xyz/background...",
-    "start:mobile": "env-cmd --silent turbo run start --filter=@coral-xyz/app-mobile... --filter=@coral-xyz/background...",
-    "build:mobile": "env-cmd --silent turbo run build --filter=@coral-xyz/app-mobile... --filter=@coral-xyz/background...",
+    "start:ext": "env-cmd --silent turbo run start --filter='@coral-xyz/app-extension...' --filter='@coral-xyz/background...'",
+    "build:ext": "env-cmd --silent turbo run build --filter='@coral-xyz/app-extension...' --filter='@coral-xyz/background...'",
+    "start:mobile": "env-cmd --silent turbo run start --filter='@coral-xyz/app-mobile...' --filter='@coral-xyz/background...'",
+    "build:mobile": "env-cmd --silent turbo run build --filter='@coral-xyz/app-mobile...' --filter='@coral-xyz/background...'",
     "postinstall": "husky install"
   },
   "devDependencies": {


### PR DESCRIPTION
my terminal randomly started having issues with `yarn start` because of the asterisk in `env-cmd --silent turbo run start --concurrency=100% --filter=./packages/*`, so I wrapped everything in single quotes for consistency