### PR TITLE
bug: fix missing token name

### DIFF
--- a/packages/app-extension/src/components/Unlocked/Balances/TransferWidget.tsx
+++ b/packages/app-extension/src/components/Unlocked/Balances/TransferWidget.tsx
@@ -341,7 +341,7 @@ function SendToken() {
   const { push } = useNavigation();
 
   const onClickRow = (blockchain: Blockchain, token: Token) => {
-    push("select-user", { blockchain, token });
+    push("select-user", { blockchain, token, name: token.ticker });
   };
 
   return (


### PR DESCRIPTION
fixes "token name value - undefined in send flow"
closes #3484 

**Steps to reproduce:**
Balances -> click on "Send" -> select a token -> header displays "Send undefined"

**bug** - token name was not being pushed in `NavStackProvider` for `select-user` route

**Screen recording(post fix):**

https://user-images.githubusercontent.com/13575704/229135383-37ebc018-2576-422b-8aac-e4f2ec5510cd.mov

