### PR TITLE
Fixes #3507

### DIFF
--- a/packages/app-extension/src/components/common/Layout/Nav.tsx
+++ b/packages/app-extension/src/components/common/Layout/Nav.tsx
@@ -1,5 +1,5 @@
 import React, { Suspense, useState } from "react";
-import { Loading, ProxyImage } from "@coral-xyz/react-common";
+import { Loading, LocalImage, ProxyImage } from "@coral-xyz/react-common";
 import { styles, useCustomTheme } from "@coral-xyz/themes";
 import { ArrowBack } from "@mui/icons-material";
 import KeyboardArrowDownSharpIcon from "@mui/icons-material/KeyboardArrowDownSharp";
@@ -263,7 +263,7 @@ function CenterDisplay({
             }}
             onClick={handleOpenDrawer}
           >
-            <ProxyImage
+            <LocalImage
               style={{
                 width: 25,
                 height: 25,


### PR DESCRIPTION
![Screenshot 2023-04-01 at 1 48 59 AM](https://user-images.githubusercontent.com/8079861/229221791-c1d057c2-07d3-4b0b-bdc9-3fd08de4b25b.jpg)

Header was using `ProxyImage` which uses swr-cache which is refreshed after 1 hour
Made it use `LocalImage` instead