### PR TITLE
fix backend-api sometimes throwing res.status is not a function

### DIFF
--- a/backend/native/backpack-api/src/index.ts
+++ b/backend/native/backpack-api/src/index.ts
@@ -1,5 +1,5 @@
 import cors from "cors";
-import type { Request, Response } from "express";
+import type { NextFunction, Request, Response } from "express";
 import express from "express";
 import { ZodError } from "zod";
 
@@ -65,16 +65,23 @@ app.get("/", (_req, res) => {
   });
 });
 
-// @ts-ignore
-app.use((err: any, _req: Request, res: Response) => {
-  if (err instanceof ZodError) {
-    return res.status(400).json({
-      message: zodErrorToString(err),
-    });
-  } else {
-    return res.status(500).json(err);
+app.use(
+  (
+    err: any,
+    _req: Request,
+    res: Response,
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    _DO_NOT_REMOVE_THIS_PARAMETER_: NextFunction
+  ) => {
+    if (err instanceof ZodError) {
+      return res.status(400).json({
+        message: zodErrorToString(err),
+      });
+    } else {
+      return res.status(500).json(err);
+    }
   }
-});
+);
 
 const port = process.env.PORT || 8080;
 app.listen(port);


### PR DESCRIPTION
sometimes `res.status is not a function` would show without this final unused parameter, will look into why in future, merging now as a fix