### PR TITLE
Remove the Import of ProxyImage Component from Nav.tsx 

### DIFF
--- a/packages/app-extension/src/components/common/Layout/Nav.tsx
+++ b/packages/app-extension/src/components/common/Layout/Nav.tsx
@@ -1,5 +1,5 @@
 import React, { Suspense, useState } from "react";
-import { Loading, LocalImage, ProxyImage } from "@coral-xyz/react-common";
+import { Loading, LocalImage } from "@coral-xyz/react-common";
 import { styles, useCustomTheme } from "@coral-xyz/themes";
 import { ArrowBack } from "@mui/icons-material";
 import KeyboardArrowDownSharpIcon from "@mui/icons-material/KeyboardArrowDownSharp";


### PR DESCRIPTION
After the resolution of Issue #3507 by #3524, we are no longer using the
`ProxyImage` Component in the `Nav.tsx`Module. Therefore, we no longer
need to import the Component.