### PR TITLE
Revert "use swc isntead of terser for that final step that takes 2 mi…

### DIFF
--- a/packages/app-extension/webpack.config.js
+++ b/packages/app-extension/webpack.config.js
@@ -1,6 +1,5 @@
 const { CleanWebpackPlugin } = require("clean-webpack-plugin");
 const { ProgressPlugin, ProvidePlugin, DefinePlugin } = require("webpack");
-const TerserPlugin = require("terser-webpack-plugin");
 const CopyWebpackPlugin = require("copy-webpack-plugin");
 const ForkTsCheckerWebpackPlugin = require("fork-ts-checker-webpack-plugin");
 const MiniCssExtractPlugin = require("mini-css-extract-plugin");
@@ -219,17 +218,6 @@ const options = {
       path: require.resolve("path-browserify"),
       zlib: require.resolve("browserify-zlib"),
     },
-  },
-  optimization: {
-    minimize: true,
-    minimizer: [
-      new TerserPlugin({
-        minify: TerserPlugin.swcMinify,
-        // `terserOptions` options will be passed to `swc` (`@swc/core`)
-        // Link to options - https://swc.rs/docs/config-js-minify
-        terserOptions: {},
-      }),
-    ],
   },
   plugins: [
     new DefinePlugin({


### PR DESCRIPTION
…nutes (#3521)"

This reverts commit cf3c76c4bb1027a7978848d9bf91995e4368c95c.

`window.xnft` was not getting injected into xNFTs

I think it might be that everything in the bundle was in a shared namespace and not scoped, which led to this, but I'm not 100% sure

![screenshot_2023-04-02_at_16 46 22](https://user-images.githubusercontent.com/101902546/229364212-a57de327-71a4-4fa5-9430-db0368acc668.png)
