### PR TITLE
Remove Hover Styling from Wallet Connect Request

### DIFF
--- a/packages/app-extension/src/components/Unlocked/Approvals/ApproveOrigin.tsx
+++ b/packages/app-extension/src/components/Unlocked/Approvals/ApproveOrigin.tsx
@@ -44,10 +44,8 @@ const useStyles = styles((theme) => ({
   listItemRoot: {
     alignItems: "start",
     borderRadius: "4px",
-    background: theme.custom.colors.nav,
     padding: "8px",
     marginBottom: "1px",
-    border: `${theme.custom.colors.borderFull}`,
   },
   listItemIconRoot: {
     minWidth: "inherit",


### PR DESCRIPTION
This PR removes the Hover Styling from the texts "View wallet balance…"
and "Request approval…" as these are not interactive.
![Screenshot](https://user-images.githubusercontent.com/41239718/229588041-a1440c6b-2f53-488b-9b12-87e0fb3a6cb8.png)
closes  #2013 