### PR TITLE
Clear backpack.#publicKey on disconnect

### DIFF
--- a/packages/provider-core/src/provider-solana.ts
+++ b/packages/provider-core/src/provider-solana.ts
@@ -161,6 +161,7 @@ export class ProviderSolanaInjection
       params: [],
     });
     this.#connection = this.defaultConnection();
+    this.#publicKey = undefined;
   }
 
   async openXnft(xnftAddress: string | PublicKey) {


### PR DESCRIPTION
This fixes a bug where the connect function is not called properly on a reconnect, as #publicKey is already defined

Specifically this is because of this condition in the wallet-standard wrapper (https://github.com/coral-xyz/backpack/blob/master/packages/wallet-standard/src/wallet.ts#L149):
```
    #connect: ConnectMethod = async ({ silent } = {}) => {
        if (!silent && !this.#backpack.publicKey) {
            await this.#backpack.connect();
        }

        this.#connected();

        return { accounts: this.accounts };
    };
```

On the first connect, `this.#backpack.publicKey` is undefined and `this.#backpack.connect()` is called correctly

However, on the second connect `this.#backpack.publicKey` was already set and so `this.#backpack.connect()` was not called. `this.#connected()` was called, and since this uses `this.#backpack.publicKey` it was able to emit an event that made it look to the wallet adapter UI like a connection was successfully performed. But the internal code in `this.#backpack.connect()` hadn't been called, and so signing didn't actually work.

The fix is to set `backpack.#publicKey` to undefined on disconnect, so that `this.#backpack.connect()` is called correctly on the reconnect.

Closes #3555 