### PR TITLE
remove unused express-rate-limit from backpack-api

### DIFF
--- a/backend/native/backpack-api/package.json
+++ b/backend/native/backpack-api/package.json
@@ -32,7 +32,6 @@
     "esbuild": "^0.15.16",
     "ethers": "^5.7.2",
     "express": "^4.18.2",
-    "express-rate-limit": "^6.7.0",
     "graphql": "^16.6.0",
     "http-proxy-middleware": "^2.0.6",
     "http_ece": "^1.1.0",

--- a/backend/native/backpack-api/src/routes/v1/users.ts
+++ b/backend/native/backpack-api/src/routes/v1/users.ts
@@ -7,7 +7,6 @@ import {
 } from "@coral-xyz/common";
 import type { Request, Response } from "express";
 import express from "express";
-import rateLimit from "express-rate-limit";
 import jwt from "jsonwebtoken";
 
 import {
@@ -41,13 +40,6 @@ import {
   CreatePublicKeys,
   CreateUserWithPublicKeys,
 } from "../../validation/user";
-
-const apiLimiter = rateLimit({
-  windowMs: 15 * 60 * 1000,
-  max: 100,
-  standardHeaders: true,
-  legacyHeaders: false,
-});
 
 const router = express.Router();
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -14961,7 +14961,6 @@ __metadata:
     eslint-config-custom: "*"
     ethers: ^5.7.2
     express: ^4.18.2
-    express-rate-limit: ^6.7.0
     graphql: ^16.6.0
     http-proxy-middleware: ^2.0.6
     http_ece: ^1.1.0
@@ -20997,15 +20996,6 @@ __metadata:
   version: 3.1.1
   resolution: "exponential-backoff@npm:3.1.1"
   checksum: 3d21519a4f8207c99f7457287291316306255a328770d320b401114ec8481986e4e467e854cb9914dd965e0a1ca810a23ccb559c642c88f4c7f55c55778a9b48
-  languageName: node
-  linkType: hard
-
-"express-rate-limit@npm:^6.7.0":
-  version: 6.7.0
-  resolution: "express-rate-limit@npm:6.7.0"
-  peerDependencies:
-    express: ^4 || ^5
-  checksum: 7bd3f298b202cdb11c3d7c2dcff9be12c6885be5e64fb112f6c79103ba93a8e5d899ce15a5a3ce48f82190ab3515bed403e067dc3e42fc2832558cbe2620f955
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
a bit of maintenance that i wanted to keep separate from another branch i'm working on