### PR TITLE
use auth_users.public_keys.is_primary in all relevant queries

### DIFF
--- a/.actrc
+++ b/.actrc
@@ -1,0 +1,2 @@
+-P ubuntu-latest=catthehacker/ubuntu:full-latest
+--container-architecture linux/amd64

--- a/.github/actions/backend-tests/action.yml
+++ b/.github/actions/backend-tests/action.yml
@@ -2,34 +2,43 @@ name: Backend tests
 description: Runs backend tests using pm2 and docker-compose
 
 runs:
-  using: "composite"
+  using: composite
   steps:
     - name: "Install pm2 to run node backend services for tests"
+      shell: bash
       run: npm install pm2 --global
 
     - name: "Start backend/reef/docker-compose.yml containers for backend services"
+      shell: bash
       run: cd backend/reef && docker compose up -d --build --wait
 
     - name: "Run xnft-api-server"
+      shell: bash
       run: pm2 start backend/native/xnft-api-server/dist/index.js -- --port 8080
 
     - name: "Test xnft-api-server"
+      shell: bash
       run: cd backend/native/xnft-api-server && npx vitest
 
     - if: always()
       name: "Stop xnft-api-server"
+      shell: bash
       run: pm2 kill
 
     - name: "Run backpack-api"
+      shell: bash
       run: pm2 start backend/native/backpack-api/dist/index.js -- --port 8080
 
     - name: "Test backpack-api"
+      shell: bash
       run: cd backend/native/backpack-api && npx vitest
 
     - if: always()
       name: "Stop backpack-api"
+      shell: bash
       run: pm2 kill
 
     - if: always()
       name: "Stop docker containers"
+      shell: bash
       run: cd backend/reef && docker compose down --remove-orphans --volumes

--- a/.github/actions/backend-tests/action.yml
+++ b/.github/actions/backend-tests/action.yml
@@ -1,0 +1,35 @@
+name: Backend tests
+description: Runs backend tests using pm2 and docker-compose
+
+runs:
+  using: "composite"
+  steps:
+    - name: "Install pm2 to run node backend services for tests"
+      run: npm install pm2 --global
+
+    - name: "Start backend/reef/docker-compose.yml containers for backend services"
+      run: cd backend/reef && docker compose up -d --build --wait
+
+    - name: "Run xnft-api-server"
+      run: pm2 start backend/native/xnft-api-server/dist/index.js -- --port 8080
+
+    - name: "Test xnft-api-server"
+      run: cd backend/native/xnft-api-server && npx vitest
+
+    - if: always()
+      name: "Stop xnft-api-server"
+      run: pm2 kill
+
+    - name: "Run backpack-api"
+      run: pm2 start backend/native/backpack-api/dist/index.js -- --port 8080
+
+    - name: "Test backpack-api"
+      run: cd backend/native/backpack-api && npx vitest
+
+    - if: always()
+      name: "Stop backpack-api"
+      run: pm2 kill
+
+    - if: always()
+      name: "Stop docker containers"
+      run: cd backend/reef && docker compose down --remove-orphans --volumes

--- a/.github/workflows/pull_requests_and_merges.yml
+++ b/.github/workflows/pull_requests_and_merges.yml
@@ -65,6 +65,17 @@ jobs:
 
       - run: yarn test
 
+      - name: "Check if any backend code has changed, to know if we should run backend tests"
+        uses: dorny/paths-filter@v2
+        id: changes
+        with:
+          filters: |
+            backend:
+              - 'backend/**'
+
+      - if: steps.changes.outputs.backend == 'true'
+        uses: ./.github/actions/backend-tests
+
       ##########################################################################
       # GitHub Pages (mobile app and hardware wallet support)
       ##########################################################################

--- a/backend/native/backpack-api/package.json
+++ b/backend/native/backpack-api/package.json
@@ -52,7 +52,8 @@
   "devDependencies": {
     "@types/passport": "^1.0.12",
     "@types/passport-twitter": "^1.0.37",
-    "eslint-config-custom": "*"
+    "eslint-config-custom": "*",
+    "vitest": "^0.29.8"
   },
   "scripts": {
     "build": "esbuild ./src/index.js --bundle --platform=node --outfile=dist/index.js",

--- a/backend/native/backpack-api/src/db/users.ts
+++ b/backend/native/backpack-api/src/db/users.ts
@@ -56,90 +56,36 @@ export const getUsers = async (
   // hotfix: empty array returns all records
   if (userIds.filter(Boolean).length === 0) return [];
 
-  const response = await chain("query")(
+  const { auth_users } = await chain("query")(
     {
       auth_users: [
         {
-          where: { id: { _in: userIds } },
+          where: {
+            id: { _in: userIds },
+            public_keys: { is_primary: { _eq: true } },
+          },
         },
         {
           id: true,
           username: true,
-        },
-      ],
-      auth_public_keys: [
-        {
-          where: { user_id: { _in: userIds } },
-        },
-        {
-          public_key: true,
-          id: true,
-          blockchain: true,
-          user_id: true,
-        },
-      ],
-      auth_user_active_publickey_mapping: [
-        {
-          where: {
-            user_id: {
-              _in: userIds,
+          public_keys: [
+            {
+              where: { is_primary: { _eq: true } },
             },
-          },
-        },
-        {
-          user_id: true,
-          public_key_id: true,
+            {
+              public_key: true,
+              id: true,
+              blockchain: true,
+              is_primary: true,
+            },
+          ],
         },
       ],
     },
     { operationName: "getUsers" }
   );
 
-  const publicKeyMapping: { [public_key_id: string]: true } = {};
-  const userToPublicKeyMapping: {
-    [user_id: string]: {
-      public_key: string;
-      id: number;
-      blockchain: string;
-    }[];
-  } = {};
-
-  response.auth_user_active_publickey_mapping.map((x) => {
-    publicKeyMapping[x.public_key_id] = true;
-  });
-
-  response.auth_public_keys.map((x) => {
-    //@ts-ignore
-    const userId: string = x.user_id;
-    if (!userToPublicKeyMapping[userId]) {
-      userToPublicKeyMapping[userId] = [];
-    }
-    userToPublicKeyMapping[userId].push({
-      public_key: x.public_key,
-      blockchain: x.blockchain,
-      id: x.id,
-    });
-  });
-
-  const transformUserResponseInput = response.auth_users.map(
-    (userResponse) => ({
-      id: userResponse.id,
-      username: userResponse.username,
-      public_keys:
-        userToPublicKeyMapping[userResponse.id as string].map((x) => ({
-          blockchain: x.blockchain,
-          public_key: x.public_key,
-          user_active_publickey_mappings: publicKeyMapping[x.id]
-            ? [
-                {
-                  user_id: userResponse.id as string,
-                },
-              ]
-            : undefined,
-        })) || [],
-    })
-  );
-  return transformUsers(transformUserResponseInput, true);
+  return auth_users.map((x) => transformUser(x, true));
 };
 
 /**
@@ -189,23 +135,26 @@ export const getUsersByPublicKeys = async (
  * Get a user by their username.
  */
 export const getUserByUsername = async (username: string) => {
-  const response = await chain("query")(
+  const { auth_users } = await chain("query")(
     {
       auth_users: [
         {
           limit: 1,
-          where: { username: { _eq: username } },
+          where: {
+            username: { _eq: username },
+            public_keys: { is_primary: { _eq: true } },
+          },
         },
         {
           id: true,
           username: true,
           public_keys: [
-            {},
+            { where: { is_primary: { _eq: true } } },
             {
-              blockchain: true,
               id: true,
+              blockchain: true,
               public_key: true,
-              user_active_publickey_mappings: [{}, { user_id: true }],
+              is_primary: true,
             },
           ],
         },
@@ -213,10 +162,10 @@ export const getUserByUsername = async (username: string) => {
     },
     { operationName: "getUserByUsername" }
   );
-  if (!response.auth_users[0]) {
+  if (!auth_users[0]) {
     throw new Error("user not found");
   }
-  return transformUser(response.auth_users[0]);
+  return transformUser(auth_users[0], true);
 };
 
 /**
@@ -238,7 +187,7 @@ export const getUser = async (id: string, onlyActiveKeys?: boolean) => {
               blockchain: true,
               id: true,
               public_key: true,
-              user_active_publickey_mappings: [{}, { user_id: true }],
+              is_primary: true,
             },
           ],
         },
@@ -272,20 +221,6 @@ export const getReferrer = async (userId: string) => {
   return auth_users_by_pk?.referrer;
 };
 
-const transformUsers = (
-  users: {
-    id: unknown;
-    username: unknown;
-    public_keys: Array<{
-      blockchain: string;
-      public_key: string;
-      user_active_publickey_mappings?: { user_id: string }[];
-    }>;
-  }[],
-  onlyActiveKeys?: boolean
-) => {
-  return users.map((x) => transformUser(x, onlyActiveKeys));
-};
 /**
  * Utility method to format a user for responses from a raw user object.
  */
@@ -296,7 +231,7 @@ const transformUser = (
     public_keys: Array<{
       blockchain: string;
       public_key: string;
-      user_active_publickey_mappings?: { user_id: string }[];
+      is_primary?: boolean;
     }>;
   },
   onlyActiveKeys?: boolean
@@ -309,8 +244,7 @@ const transformUser = (
       .map((k) => ({
         blockchain: k.blockchain as Blockchain,
         publicKey: k.public_key,
-        primary:
-          k.user_active_publickey_mappings?.length || 0 >= 1 ? true : false,
+        primary: Boolean(k.is_primary),
       }))
       .filter((x) => {
         if (onlyActiveKeys && !x.primary) {
@@ -402,27 +336,35 @@ export async function getUsersByPrefix({
   usernamePrefix: string;
   uuid: string;
   limit?: number;
-}): Promise<{ username: string; id: string }[]> {
-  const response = await chain("query")(
+}) {
+  const { auth_users } = await chain("query")(
     {
       auth_users: [
         {
           where: {
             username: { _like: `${usernamePrefix}%` },
             id: { _neq: uuid },
+            public_keys: { is_primary: { _eq: true } },
           },
           limit: limit || 25,
         },
         {
           id: true,
           username: true,
+          public_keys: [
+            { where: { is_primary: { _eq: true } } },
+            {
+              blockchain: true,
+              public_key: true,
+            },
+          ],
         },
       ],
     },
     { operationName: "getUsersByPrefix" }
   );
 
-  return response.auth_users || [];
+  return auth_users;
 }
 
 /**
@@ -555,18 +497,20 @@ export const getUserByPublicKeyAndChain = async (
             public_keys: {
               blockchain: { _eq: blockchain },
               public_key: { _eq: publicKey },
-              user_active_publickey_mappings: {
-                blockchain: { _eq: blockchain },
-                public_key: {
-                  public_key: { _eq: publicKey },
-                },
-              },
+              is_primary: { _eq: true },
             },
           },
         },
         {
           id: true,
           username: true,
+          public_keys: [
+            { where: { is_primary: { _eq: true } } },
+            {
+              blockchain: true,
+              public_key: true,
+            },
+          ],
         },
       ],
     },

--- a/backend/native/backpack-api/src/routes/v1/__tests__/_constants.ts
+++ b/backend/native/backpack-api/src/routes/v1/__tests__/_constants.ts
@@ -1,0 +1,93 @@
+export const users = {
+  alice: {
+    id: "c7709c76-aa1a-4dfe-8242-786f7d6e8b19",
+    jwt: "eyJhbGciOiJSUzI1NiJ9.eyJzdWIiOiJjNzcwOWM3Ni1hYTFhLTRkZmUtODI0Mi03ODZmN2Q2ZThiMTkiLCJpc3MiOiJhdXRoLnhuZnRzLmRldiIsImF1ZCI6ImJhY2twYWNrIiwiaWF0IjoxNjgwNzAxMjk5fQ.HnMEi_acM9uauL-17isLEU97WKctpdv10rvdTvHzd5dfbAbkyqqpJpepwLHRI86nejMxeHYyrNTSN4xk3pyeR1Xc--mj4Z7jHnwBXaV_ZROhAxz3y0koeUS7UaJ5oP7pqzzqC4dux6yUkqYIlpVqUZHrTauswILWGwdjxgAdrxDme81EkR5_QhDqSCfE0GvORto8xOoDHFxLQWWI3LAaXwFpHdfQcowLM_4lJGv-KKU3pPYT41OTCQFFP4JZbb2mkSslSnMu0kUN1NAXIQWf67X1ijogFndss3N4Cm0EUNwGkln1nXh7Gzx98HConrGJSjmeXtqwPSx5P7IBFzDL3w",
+    public_keys: {
+      solana: {
+        primary: 0,
+        keys: [
+          "J6QiUPJPo3obf8aQFLai8jTU6EGBkV2hyBMoQ4K7k7hS",
+          "2HPCw1XC8oJMR2gNZDGJAapZWWkgc9TQ4wsYErEW7sqd",
+        ],
+      },
+      ethereum: {
+        primary: 0,
+        keys: ["0xbBe322d172f49232b024Ec756D3F0DDf6D92A12a"],
+      },
+    },
+  },
+  bob: {
+    id: "bb3d0b94-15f1-4610-a198-ec1bf1bd5aac",
+    jwt: "eyJhbGciOiJSUzI1NiJ9.eyJzdWIiOiJiYjNkMGI5NC0xNWYxLTQ2MTAtYTE5OC1lYzFiZjFiZDVhYWMiLCJpc3MiOiJhdXRoLnhuZnRzLmRldiIsImF1ZCI6ImJhY2twYWNrIiwiaWF0IjoxNjgwNzAxNjM4fQ.P2FydtVjmrCFoS31If4nwzj-NHZ1j8CJ4GYcv7A7QiVEZQh4jH3fSk3uZM_OU67GF2u6OG_u_-M6l67aOfdtrkwowCCpk0iEbmB-eSz1oTHg_jgn6qgAzuSw3sStAtqNlOKwdquk2k0NmOvIphHH0_JW-n58WNTUWE2gV41Hs-MN61goE4230DcDYTaVCwkDYs4qjpoOK3AuJ76sYKuxJp78rTc12xtYScSi3s6Lzi1btCOVSID41n7UX9btv1nQxm6UH6HWa5lH5Pb5C8Mqf7RuNg_rrUXC36clzvqLj63A8gLwnGYPNlY1bpDwowy9toUixsBs_X92I4bxl_lOrg",
+    public_keys: {
+      solana: {
+        primary: 1,
+        keys: [
+          "4rRGXiiHqZ4ePypCG3RZE1EBTru2L6HxKfh3SRa8Gjpu",
+          "D5TpbcEsFVTeF6cHt3nT4j8vUAYCQX4YWeMiZr37UQik",
+          "5bDxPkA2WGgJNRHh7bfprH6epaJWir4prTy3kCEgPUix",
+        ],
+      },
+      ethereum: {
+        primary: 0,
+        keys: ["0x01B9E593bc84eD499C02241b88b82F274c372Eb1"],
+      },
+    },
+  },
+  eth_only: {
+    id: "fb14ab0c-f20f-4b5d-a8d9-f9409eb69380",
+    jwt: "eyJhbGciOiJSUzI1NiJ9.eyJzdWIiOiJmYjE0YWIwYy1mMjBmLTRiNWQtYThkOS1mOTQwOWViNjkzODAiLCJpc3MiOiJhdXRoLnhuZnRzLmRldiIsImF1ZCI6ImJhY2twYWNrIiwiaWF0IjoxNjgwNzAyMTAxfQ.ClllrJvRXQZzFKwmJJi_2Ek1JSad2VMugodEq9GEg0D40HNNak7iMLEOfYlaE7uZ6yq5nKIaHm6QUJ7mRbPrWBQq0Zr5GFnzt-16aL3reYAtt_o5ho-fijZ-TAZGL6dGCfJ05zzLMJGH7rjaEXAQkoOceWP6P8_FCdJds2XFraMTNUQzNvrNbsB6f3v2mAnIr1mWYykztWTW-EDzz3Bkpg0sOrccFOjI-rpO1GZ9OclOEuzYRb08WVQVbVsQc6VK0Z8FjE9xWNNPKj4swuNsXEnd3CZdVB4fniyHKVpXQg7QSb5LzBz60ywi9A64c1D7kfZX95zMQlRMoq1qYbD2eA",
+    public_keys: {
+      ethereum: {
+        primary: 0,
+        keys: ["0x6Ecc980c2acB5aaCA12e3DBC2bdE2bC7dDc4d2D9"],
+      },
+    },
+    primary_keys: {
+      ethereum: ["0x6Ecc980c2acB5aaCA12e3DBC2bdE2bC7dDc4d2D9"],
+    },
+  },
+  sol_only: {
+    id: "3682450b-c79b-4b62-a3d9-5afdbd6d34d7",
+    jwt: "eyJhbGciOiJSUzI1NiJ9.eyJzdWIiOiIzNjgyNDUwYi1jNzliLTRiNjItYTNkOS01YWZkYmQ2ZDM0ZDciLCJpc3MiOiJhdXRoLnhuZnRzLmRldiIsImF1ZCI6ImJhY2twYWNrIiwiaWF0IjoxNjgwNzAyMjY4fQ.Ufx857qRiHE-NdM_olG97818Ouru72fLCEuSoC4huojEOvDfWQwP3MWGomyh6D70J7lASw-XIGR-vlv6wTdO6EdfZFJ7UMCosKoUrWnRZb-JekDBqxwIvKRfl2kEiwrWAZ8XT-3VnEigX6sGn340rVMmzPl87EZ7u6zeb0Sej7yggtGdzK5We7iqRip2ZYkeD2obIGGBdHcmy-XHOeJTVJBvG-F9jPUM6HsVpohCFMsPscJjPuLi0UuqhKBPmZUfSPWRY_VLky8_cvgjU7K7ldl_3xkp0gRgtK7UJfDIJLNbAgOkUFiOOkjn-VFU5zXQYXhXp5RFd8nx9ftQtxBUbQ",
+    public_keys: {
+      solana: {
+        primary: 0,
+        keys: ["7LugqdvheW9gmNNvt9dJRf4RDGWn9PyM2ssEtoZuUpDk"],
+      },
+    },
+  },
+  unregistered_user: {
+    id: "",
+    jwt: "",
+    public_keys: {},
+  },
+} as const;
+
+const asUser =
+  (username?: keyof typeof users) =>
+  (method: "get" | "post") =>
+  async (path: string, data?: any) => {
+    const res = await fetch(`${API_URL}/${path}`, {
+      method,
+      headers: {
+        "Content-Type": "application/json",
+        Cookie: username ? `jwt=${users[username].jwt}` : "",
+      },
+      body: data ? JSON.stringify(data) : undefined,
+    });
+    return await res.json();
+  };
+
+export const { alice, bob, sol_only, eth_only, unregistered_user } =
+  Object.entries(users).reduce((acc, [username, user]) => {
+    const u = username as keyof typeof users;
+    acc[u] = {
+      ...user,
+      get: asUser(u)("get"),
+      post: asUser(u)("post"),
+    };
+    return acc;
+  }, {} as { [key in keyof typeof users]: (typeof users)[key] & { get: (path: string) => Promise<any>; post: (path: string, data?: any) => Promise<any> } });
+
+export const API_URL = "http://localhost:8080" as const;

--- a/backend/native/backpack-api/src/routes/v1/__tests__/_setup.ts
+++ b/backend/native/backpack-api/src/routes/v1/__tests__/_setup.ts
@@ -1,0 +1,141 @@
+import { beforeAll, expect } from "vitest";
+
+import { Chain } from "../../../../../zeus/dist/esm";
+import { HASURA_URL, JWT } from "../../../config";
+
+import { users } from "./_constants";
+
+if (process.env.NODE_ENV !== "test" || !HASURA_URL.includes("localhost:")) {
+  console.error("This is not a test environment");
+  process.exit(1);
+}
+
+expect.extend({
+  toOnlyIncludePrimaryPublicKeysFor(
+    keys,
+    user: (typeof users)[keyof typeof users]
+  ) {
+    const { isNot } = this;
+    const primaryKeys = Object.entries(user.public_keys).reduce(
+      (acc, [chain, { keys, primary }]) => {
+        acc[chain] = keys[primary];
+        return acc;
+      },
+      {}
+    );
+    return {
+      pass:
+        Object.keys(primaryKeys).length === keys.length &&
+        keys.every(
+          (key) =>
+            ((key.public_key || key.publicKey) &&
+              primaryKeys[key.blockchain] === key.public_key) ||
+            key.publicKey
+        ),
+      message: () =>
+        `${
+          isNot ? "only includes" : "includes hidden and"
+        } primary public keys`,
+    };
+  },
+  toIncludeHiddenNonPrimaryPublicKeysFor(
+    keys,
+    user: (typeof users)[keyof typeof users]
+  ) {
+    const { isNot } = this;
+    const allKeysLength = Object.values(user.public_keys).reduce(
+      (acc, { keys }) => acc + keys.length,
+      0
+    );
+    return {
+      pass:
+        allKeysLength === keys.length &&
+        keys.every(
+          (key) =>
+            (key.public_key || key.publicKey) &&
+            user.public_keys[key.blockchain].keys.includes(
+              key.public_key || key.publicKey
+            )
+        ),
+      message: () =>
+        `${
+          isNot ? "does not include non-primary" : "includes non-primary"
+        } public keys`,
+    };
+  },
+});
+
+beforeAll(async () => {
+  const LOCAL_ADMIN_PASSWORD = "myadminsecretkey";
+  await fetch(HASURA_URL, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      "x-hasura-admin-secret": LOCAL_ADMIN_PASSWORD,
+    },
+    body: JSON.stringify({
+      // TODO: add DELETE cascades to remove all associated data with users
+      query: `mutation {
+        delete_auth_friendships(where: {}) { affected_rows }
+        delete_auth_friend_requests(where: {}) { affected_rows }
+        delete_auth_user_active_publickey_mapping(where: {}) { affected_rows }
+        delete_auth_public_keys(where: {}) { affected_rows }
+        delete_auth_users(where: {}) { affected_rows }
+        delete_auth_invitations(where: {}) { affected_rows }
+      }`,
+    }),
+  });
+
+  const chain = Chain(HASURA_URL, {
+    headers: { Authorization: `Bearer ${JWT}` },
+  });
+  await chain("mutation")({
+    insert_auth_invitations: [
+      {
+        objects: Object.values(users)
+          .filter(({ id }) => id)
+          .map((user) => ({ id: user.id })),
+      },
+      { affected_rows: true },
+    ],
+  });
+  await chain("mutation")({
+    insert_auth_users: [
+      {
+        objects: Object.entries(users)
+          .filter(([_, { id }]) => id)
+          .map(([username, user]) => ({
+            id: user.id,
+            username,
+            invitation_id: user.id,
+            public_keys: {
+              data: Object.entries(user.public_keys).reduce(
+                (acc, [blockchain, { primary, keys }]) => {
+                  keys.forEach((key, i) => {
+                    acc.push({
+                      blockchain,
+                      public_key: key,
+                      user_active_publickey_mappings: {
+                        data:
+                          i === primary
+                            ? [
+                                {
+                                  user_id: user.id,
+                                  blockchain,
+                                },
+                              ]
+                            : [],
+                      },
+                    });
+                  });
+                  return acc;
+                },
+                [] as any[]
+              ),
+            },
+          })),
+      },
+      { affected_rows: true },
+    ],
+  });
+});

--- a/backend/native/backpack-api/src/routes/v1/__tests__/authenticate.test.ts
+++ b/backend/native/backpack-api/src/routes/v1/__tests__/authenticate.test.ts
@@ -1,0 +1,28 @@
+import { decodeJwt } from "jose";
+import { expect, test } from "vitest";
+
+import { alice, API_URL } from "./_constants";
+
+test("authenticate with solana", async () => {
+  const res = await fetch(`${API_URL}/authenticate`, {
+    headers: {
+      "content-type": "application/json",
+    },
+    method: "post",
+    body: JSON.stringify({
+      blockchain: "solana",
+      publicKey:
+        alice.public_keys.solana.keys[alice.public_keys.solana.primary],
+      message:
+        "4cP2Yu38KqhPTXvB76F1BTruaFH2YEgskkRWbF9Gexh2qZvNv7oaatjVGcCdgkSbiWvWLY", // Backpack login ${alice.id}
+      signature:
+        "419pZ7qXoMQQKUv5pZKCK581U6Jph225HcDzgG5b95XNtwL3i6jMPubpxyq8PVxAen3dzT8r9vUhQ2PWU8SxeT6b",
+    }),
+  });
+
+  const jwt = res.headers.get("set-cookie")?.match(/jwt=([^;]+)/)?.[1];
+
+  expect(decodeJwt(jwt!).sub).toEqual(alice.id);
+
+  expect((await res.json()).username).toEqual("alice");
+});

--- a/backend/native/backpack-api/src/routes/v1/__tests__/friends.test.ts
+++ b/backend/native/backpack-api/src/routes/v1/__tests__/friends.test.ts
@@ -1,0 +1,43 @@
+import { expect, test } from "vitest";
+
+import { alice, bob } from "./_constants";
+
+test("adding a friend", async () => {
+  expect((await alice.get("friends/sent")).requests).toEqual([]);
+  expect((await bob.get("friends/requests")).requests).toEqual([]);
+
+  expect((await alice.get(`friends?userId=${bob.id}`)).are_friends).toBeFalsy();
+  expect((await bob.get(`friends?userId=${alice.id}`)).are_friends).toBeFalsy();
+
+  await alice.post("friends/request", { to: bob.id, sendRequest: true });
+
+  expect((await alice.get("friends/sent")).requests).toMatchObject([
+    {
+      username: "bob",
+      areFriends: false,
+      requested: true,
+      remoteRequested: false,
+    },
+  ]);
+
+  expect((await bob.get("friends/requests")).requests).toMatchObject([
+    {
+      username: "alice",
+      areFriends: false,
+      requested: false,
+      remoteRequested: true,
+    },
+  ]);
+
+  await bob.post("friends/request", { to: alice.id, sendRequest: true });
+
+  expect(
+    (await alice.get(`friends?userId=${bob.id}`)).are_friends
+  ).toBeTruthy();
+  expect(
+    (await bob.get(`friends?userId=${alice.id}`)).are_friends
+  ).toBeTruthy();
+
+  expect((await alice.post("inbox", { to: bob.id })).areFriends).toBeTruthy();
+  expect((await bob.post("inbox", { to: alice.id })).areFriends).toBeTruthy();
+});

--- a/backend/native/backpack-api/src/routes/v1/__tests__/referrals.test.ts
+++ b/backend/native/backpack-api/src/routes/v1/__tests__/referrals.test.ts
@@ -1,0 +1,14 @@
+import { expect, test } from "vitest";
+
+import { API_URL, sol_only } from "./_constants";
+
+test("referring a user sets a referrer cookie and redirect to chrome store", async () => {
+  const res = await fetch(`${API_URL}/referrals/sol_only`, {
+    redirect: "manual",
+  });
+  expect(res.headers.get("set-cookie")).toContain(`referrer=${sol_only.id};`);
+  expect(res.status).toBe(302);
+  expect(res.headers.get("location")).toEqual(
+    "https://chrome.google.com/webstore/detail/backpack/aflkmfhebedbjioipglgcbcmnbpgliof"
+  );
+});

--- a/backend/native/backpack-api/src/routes/v1/__tests__/users.test.ts
+++ b/backend/native/backpack-api/src/routes/v1/__tests__/users.test.ts
@@ -1,0 +1,38 @@
+import { expect, test } from "vitest";
+
+import { alice, bob, unregistered_user } from "./_constants";
+
+test.todo("creating a user");
+
+test("getting the primary solana public key", async () => {
+  expect((await bob.get("users/primarySolPubkey/alice")).publicKey).toEqual(
+    alice.public_keys.solana.keys[alice.public_keys.solana.primary]
+  );
+
+  expect((await bob.get("users/primarySolPubkey/eth_only")).msg).toEqual(
+    "No active pubkey on SOL for this user"
+  );
+});
+
+test("getting a user", async () => {
+  const res = await unregistered_user.get("users/alice");
+  expect(res.id).toEqual(alice.id);
+  expect(res.publicKeys).toOnlyIncludePrimaryPublicKeysFor(alice);
+});
+
+test("getting a user by their ID", async () => {
+  const res = await bob.get(`users/userById?remoteUserId=${alice.id}`);
+  expect(res.user.username).toEqual("alice");
+  expect(res.user.publicKeys).toOnlyIncludePrimaryPublicKeysFor(alice);
+});
+
+test("a registered user can get information about themselves", async () => {
+  const res = await alice.get(`users/me`);
+  expect(res.id).toEqual(alice.id);
+  expect(res.publicKeys).toIncludeHiddenNonPrimaryPublicKeysFor(alice);
+});
+
+test("an unregistered user cannot get information about themselves", async () => {
+  const res = await unregistered_user.get(`users/me`);
+  expect(res.id).toBeFalsy();
+});

--- a/backend/native/backpack-api/src/routes/v1/users.ts
+++ b/backend/native/backpack-api/src/routes/v1/users.ts
@@ -25,7 +25,6 @@ import {
   getUser,
   getUserByPublicKeyAndChain,
   getUserByUsername,
-  getUsers,
   getUsersByPrefix,
   getUsersByPublicKeys,
   getUsersMetadata,
@@ -76,13 +75,10 @@ router.get("/", extractUserId, async (req, res) => {
     uuid
   );
 
-  const metadatas = await getUsers(users.map((x) => x.id));
   const usersWithFriendshipMetadata: RemoteUserData[] = users
     .filter((x) => x.id !== uuid)
-    .map(({ id, username }) => {
+    .map(({ id, username, public_keys }) => {
       const friendship = friendships.find((x) => x.id === id);
-      const public_keys = (metadatas.find((x) => x.id === id)?.publicKeys ||
-        []) as { blockchain: string; publicKey: string }[];
 
       return {
         id,

--- a/backend/native/backpack-api/tsconfig.json
+++ b/backend/native/backpack-api/tsconfig.json
@@ -11,6 +11,10 @@
     "esModuleInterop": true,
     "resolveJsonModule": true
   },
-  "include": ["src/types/express/index.d.ts"],
+  "include": [
+    "src/types/express/index.d.ts",
+    "src/**/__tests__/**/*.ts",
+    "vite.config.ts"
+  ],
   "files": ["src/index.ts"]
 }

--- a/backend/native/backpack-api/vite.config.ts
+++ b/backend/native/backpack-api/vite.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    setupFiles: ["./src/routes/v1/__tests__/_setup.ts"],
+    threads: false,
+  },
+});

--- a/backend/native/xnft-api-server/package.json
+++ b/backend/native/xnft-api-server/package.json
@@ -23,5 +23,8 @@
   "scripts": {
     "build": "esbuild ./src/index.js --bundle --platform=node --outfile=dist/index.js",
     "start": "npm run build && node dist/index.js"
+  },
+  "devDependencies": {
+    "vitest": "^0.29.8"
   }
 }

--- a/backend/native/xnft-api-server/src/db/users.ts
+++ b/backend/native/xnft-api-server/src/db/users.ts
@@ -23,14 +23,8 @@ export const getUser = async (id: string) => {
           id: true,
           username: true,
           public_keys: [
-            {
-              where: {
-                user_active_publickey_mappings: {
-                  user_id: { _eq: id },
-                },
-              },
-            },
-            { blockchain: true, public_key: true },
+            { where: { is_primary: { _eq: true } } },
+            { blockchain: true, public_key: true, is_primary: true },
           ],
         },
       ],
@@ -98,58 +92,28 @@ export const getUserFromUsername = async ({
 }: {
   username: string;
 }) => {
-  const response = await chain("query")(
+  const { auth_users } = await chain("query")(
     {
       auth_users: [
         {
           limit: 1,
           where: {
             username: { _eq: username },
+            public_keys: { is_primary: { _eq: true } },
           },
         },
         {
           id: true,
           username: true,
-          public_keys: [{}, { blockchain: true, public_key: true }],
+          public_keys: [
+            { where: { is_primary: { _eq: true } } },
+            { blockchain: true, public_key: true },
+          ],
         },
       ],
     },
     { operationName: "getUserFromUsername" }
   );
 
-  const user = response.auth_users[0];
-  if (!user) {
-    return null;
-  }
-
-  const activePubkeys = await chain("query")(
-    {
-      auth_user_active_publickey_mapping: [
-        {
-          where: {
-            user_id: { _eq: user?.id },
-          },
-        },
-        {
-          public_key: {
-            public_key: true,
-          },
-        },
-      ],
-    },
-    { operationName: "getUserFromUsername" }
-  );
-
-  const activePubKeyArray: string[] =
-    activePubkeys.auth_user_active_publickey_mapping.map(
-      (x) => x.public_key.public_key
-    );
-
-  const gaurdedUser = {
-    ...user,
-    public_keys: user.public_keys.filter((x) =>
-      activePubKeyArray.includes(x.public_key)
-    ),
-  };
-  return gaurdedUser;
+  return auth_users[0];
 };

--- a/backend/native/xnft-api-server/src/v1/__tests__/users.test.ts
+++ b/backend/native/xnft-api-server/src/v1/__tests__/users.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, test } from "vitest";
+
+import {
+  alice,
+  bob,
+} from "../../../../backpack-api/src/routes/v1/__tests__/_constants";
+
+describe("getting a user with a public key", () => {
+  const keys = [...alice.public_keys.solana.keys];
+  const primaryKey = keys.splice(alice.public_keys.solana.primary, 1)[0];
+
+  test("using a primary public key", async () => {
+    const res = await bob.get(
+      `v1/users/fromPubkey?publicKey=${primaryKey}&blockchain=solana`
+    );
+    expect(res.user.username).toEqual("alice");
+    expect(res.user.public_keys).toOnlyIncludePrimaryPublicKeysFor(alice);
+  });
+
+  test("using a hidden public key", async () => {
+    expect(
+      (
+        await alice.get(
+          `v1/users/fromPubkey?publicKey=${keys[0]}&blockchain=solana`
+        )
+      ).msg
+    ).toMatch(/not found/i);
+  });
+});
+
+test("getting a user with an id", async () => {
+  const res = await bob.get(`v1/users?user_id=${alice.id}`);
+  expect(res.user.username).toEqual("alice");
+  expect(res.user.publicKeys).toOnlyIncludePrimaryPublicKeysFor(alice);
+});
+
+test("getting a user with a username", async () => {
+  const res = await bob.get(`v1/users/fromUsername?username=alice`);
+  expect(res.user.id).toEqual(alice.id);
+  expect(res.user.public_keys).toOnlyIncludePrimaryPublicKeysFor(alice);
+});

--- a/backend/native/xnft-api-server/src/v1/users.ts
+++ b/backend/native/xnft-api-server/src/v1/users.ts
@@ -6,56 +6,49 @@ import { getUser, getUserFromUsername, getUserIdFromPubkey } from "../db/users";
 const router = express.Router();
 
 router.get("/fromPubkey", authMiddleware, async (req, res) => {
-  // @ts-ignore
-  const publicKey: string = req.query.publicKey;
-  // @ts-ignore
-  const blockchain: string = req.query.blockchain;
+  const publicKey = req.query.publicKey as string;
+  const blockchain = req.query.blockchain as string;
 
-  await getUserIdFromPubkey({ blockchain, publicKey })
-    .then((user) => {
-      if (user) {
-        res.status(200).json({ user });
-      } else {
-        res.status(411).json({ msg: "User not found" });
-      }
-    })
-    .catch((e) => {
-      res.status(500).json({ msg: "Failed to fetch user details" });
-    });
+  try {
+    const user = await getUserIdFromPubkey({ blockchain, publicKey });
+    if (user) {
+      res.status(200).json({ user });
+    } else {
+      res.status(411).json({ msg: "User not found" });
+    }
+  } catch (_err) {
+    res.status(500).json({ msg: "Failed to fetch user details" });
+  }
 });
 
 router.get("/fromUsername", authMiddleware, async (req, res) => {
-  // @ts-ignore
-  const username: string = req.query.username;
+  const username = req.query.username as string;
 
-  await getUserFromUsername({ username })
-    .then((user) => {
-      if (user) {
-        res.status(200).json({ user });
-      } else {
-        res.status(411).json({ msg: "User not found" });
-      }
-    })
-    .catch((e) => {
-      res.status(500).json({ msg: "Failed to fetch user details" });
-    });
+  try {
+    const user = await getUserFromUsername({ username });
+    if (user) {
+      res.status(200).json({ user });
+    } else {
+      res.status(411).json({ msg: "User not found" });
+    }
+  } catch (_err) {
+    res.status(500).json({ msg: "Failed to fetch user details" });
+  }
 });
 
 router.get("/", authMiddleware, async (req, res) => {
-  // @ts-ignore
-  const id: string = req.query.user_id;
+  const id = req.query.user_id as string;
 
-  await getUser(id)
-    .then((user) => {
-      if (user) {
-        res.status(200).json({ user });
-      } else {
-        res.status(411).json({ msg: "User not found" });
-      }
-    })
-    .catch((e) => {
-      res.status(500).json({ msg: "Failed to fetch user details" });
-    });
+  try {
+    const user = await getUser(id);
+    if (user) {
+      res.status(200).json({ user });
+    } else {
+      res.status(411).json({ msg: "User not found" });
+    }
+  } catch (_err) {
+    res.status(500).json({ msg: "Failed to fetch user details" });
+  }
 });
 
 export default router;

--- a/backend/native/xnft-api-server/tsconfig.json
+++ b/backend/native/xnft-api-server/tsconfig.json
@@ -11,5 +11,6 @@
     "esModuleInterop": true,
     "resolveJsonModule": true
   },
+  "include": ["src/**/__tests__/**/*.ts", "vite.config.ts"],
   "files": ["src/index.ts"]
 }

--- a/backend/native/xnft-api-server/vite.config.ts
+++ b/backend/native/xnft-api-server/vite.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    setupFiles: ["../backpack-api/src/routes/v1/__tests__/_setup.ts"],
+    threads: false,
+  },
+});

--- a/backend/native/zeus/src/zeus/const.ts
+++ b/backend/native/zeus/src/zeus/const.ts
@@ -770,6 +770,7 @@ export const AllTypesProps: Record<string, any> = {
   },
   auth_users_constraint: "enum" as const,
   auth_users_insert_input: {
+    id: "uuid",
     invitation: "auth_invitations_obj_rel_insert_input",
     invitation_id: "uuid",
     public_keys: "auth_public_keys_arr_rel_insert_input",

--- a/backend/native/zeus/src/zeus/index.ts
+++ b/backend/native/zeus/src/zeus/index.ts
@@ -4298,6 +4298,7 @@ export type ValueTypes = {
   ["auth_users_constraint"]: auth_users_constraint;
   /** input type for inserting data into table "auth.users" */
   ["auth_users_insert_input"]: {
+    id?: ValueTypes["uuid"] | undefined | null | Variable<any, string>;
     invitation?:
       | ValueTypes["auth_invitations_obj_rel_insert_input"]
       | undefined
@@ -10894,6 +10895,7 @@ export type ResolverInputTypes = {
   ["auth_users_constraint"]: auth_users_constraint;
   /** input type for inserting data into table "auth.users" */
   ["auth_users_insert_input"]: {
+    id?: ResolverInputTypes["uuid"] | undefined | null;
     invitation?:
       | ResolverInputTypes["auth_invitations_obj_rel_insert_input"]
       | undefined
@@ -15730,6 +15732,7 @@ export type ModelTypes = {
   ["auth_users_constraint"]: auth_users_constraint;
   /** input type for inserting data into table "auth.users" */
   ["auth_users_insert_input"]: {
+    id?: ModelTypes["uuid"] | undefined;
     invitation?:
       | ModelTypes["auth_invitations_obj_rel_insert_input"]
       | undefined;
@@ -18613,6 +18616,7 @@ export type GraphQLTypes = {
   ["auth_users_constraint"]: auth_users_constraint;
   /** input type for inserting data into table "auth.users" */
   ["auth_users_insert_input"]: {
+    id?: GraphQLTypes["uuid"] | undefined;
     invitation?:
       | GraphQLTypes["auth_invitations_obj_rel_insert_input"]
       | undefined;

--- a/backend/reef/docker-compose.yml
+++ b/backend/reef/docker-compose.yml
@@ -5,6 +5,17 @@ version: "3.8"
 # with local development environments by supporting every achitecture.
 
 services:
+  redis:
+    image: redis:7-alpine
+    restart: unless-stopped
+    ports:
+      - 6379:6379
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 5s
+      timeout: 2s
+      retries: 10
+
   postgres:
     image: postgres:15.0-alpine
     restart: unless-stopped
@@ -15,16 +26,16 @@ services:
     command: "postgres -c listen_addresses='*'"
     healthcheck:
       test: pg_isready --username=user --dbname=reef_dev --quiet
-      interval: 15s
-      timeout: 5s
-      retries: 5
+      interval: 5s
+      timeout: 2s
+      retries: 10
     environment:
       POSTGRES_DB: reef_dev
       POSTGRES_PASSWORD: pass
       POSTGRES_USER: user
 
   hasura:
-    image: hasura/graphql-engine:v2.18.0.cli-migrations-v3
+    image: hasura/graphql-engine:v2.22.0.cli-migrations-v3
     ports:
       - 8112:8080
     depends_on:
@@ -32,7 +43,12 @@ services:
     volumes:
       - "./hasura/metadata:/hasura-metadata"
       - "./hasura/migrations:/hasura-migrations"
-    restart: always
+    restart: unless-stopped
+    healthcheck:
+      test: curl -f http://localhost:8080/healthz || exit 1
+      interval: 5s
+      timeout: 2s
+      retries: 15
     environment:
       HASURA_GRAPHQL_CORS_DOMAIN: "*"
       HASURA_GRAPHQL_DATABASE_URL: postgres://user:pass@postgres/reef_dev

--- a/backend/reef/docker-compose.yml
+++ b/backend/reef/docker-compose.yml
@@ -46,8 +46,8 @@ services:
     restart: unless-stopped
     healthcheck:
       test: curl -f http://localhost:8080/healthz || exit 1
-      interval: 5s
-      timeout: 2s
+      interval: 10s
+      timeout: 10s
       retries: 15
     environment:
       HASURA_GRAPHQL_CORS_DOMAIN: "*"

--- a/backend/reef/hasura/metadata/databases/default/tables/auth_users.yaml
+++ b/backend/reef/hasura/metadata/databases/default/tables/auth_users.yaml
@@ -58,6 +58,7 @@ insert_permissions:
     permission:
       check: {}
       columns:
+        - id
         - invitation_id
         - referrer_id
         - username

--- a/yarn.lock
+++ b/yarn.lock
@@ -11795,7 +11795,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/chai@npm:*, @types/chai@npm:^4.3.3":
+"@types/chai-subset@npm:^1.3.3":
+  version: 1.3.3
+  resolution: "@types/chai-subset@npm:1.3.3"
+  dependencies:
+    "@types/chai": "*"
+  checksum: 4481da7345022995f5a105e6683744f7203d2c3d19cfe88d8e17274d045722948abf55e0adfd97709e0f043dade37a4d4e98cd4c660e2e8a14f23e6ecf79418f
+  languageName: node
+  linkType: hard
+
+"@types/chai@npm:*, @types/chai@npm:^4.3.3, @types/chai@npm:^4.3.4":
   version: 4.3.4
   resolution: "@types/chai@npm:4.3.4"
   checksum: 571184967beb03bf64c4392a13a7d44e72da9af5a1e83077ff81c39cf59c0fda2a5c78d2005084601cf8f3d11726608574d8b5b4a0e3e9736792807afd926cd0
@@ -13057,6 +13066,49 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@vitest/expect@npm:0.29.8":
+  version: 0.29.8
+  resolution: "@vitest/expect@npm:0.29.8"
+  dependencies:
+    "@vitest/spy": 0.29.8
+    "@vitest/utils": 0.29.8
+    chai: ^4.3.7
+  checksum: a80f9c352a979eb46690be2ea54b5ca391d3575b4053be80c1359325fb0cea913d6217f48d54e64ff5dda3b15bd7a6873a5f8128e8c098f7ebad1365d4065c5e
+  languageName: node
+  linkType: hard
+
+"@vitest/runner@npm:0.29.8":
+  version: 0.29.8
+  resolution: "@vitest/runner@npm:0.29.8"
+  dependencies:
+    "@vitest/utils": 0.29.8
+    p-limit: ^4.0.0
+    pathe: ^1.1.0
+  checksum: 8305370ff6c3fc6aea7189bd138ee4ff0e040a959c0fe6ab64bcb9e70ae5bf836b8dc058b1de288aa75c9d1cd648e5f112e7cd5691c03b7a1d32466d8bfc71a9
+  languageName: node
+  linkType: hard
+
+"@vitest/spy@npm:0.29.8":
+  version: 0.29.8
+  resolution: "@vitest/spy@npm:0.29.8"
+  dependencies:
+    tinyspy: ^1.0.2
+  checksum: 7b1607b696275bf94a497e92d7d10c466b9b3d08726bbedb3735bdf57f003763a9516e328af22746829526ce573f87eb6119ab64ce7db95794b2d220aa53b607
+  languageName: node
+  linkType: hard
+
+"@vitest/utils@npm:0.29.8":
+  version: 0.29.8
+  resolution: "@vitest/utils@npm:0.29.8"
+  dependencies:
+    cli-truncate: ^3.1.0
+    diff: ^5.1.0
+    loupe: ^2.3.6
+    pretty-format: ^27.5.1
+  checksum: fa18cccb6ab5295e43a1a43b9c022f070646a893adb0561c50b3e0c39f05ea74cbf379aef22ef485ea9acbf2bb8f0a224d457fd4f16b9e1bf509c13052c7f08b
+  languageName: node
+  linkType: hard
+
 "@wagmi/core@npm:^0.5.8":
   version: 0.5.8
   resolution: "@wagmi/core@npm:0.5.8"
@@ -13770,7 +13822,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"acorn-walk@npm:^8.0.0":
+"acorn-walk@npm:^8.0.0, acorn-walk@npm:^8.2.0":
   version: 8.2.0
   resolution: "acorn-walk@npm:8.2.0"
   checksum: 1715e76c01dd7b2d4ca472f9c58968516a4899378a63ad5b6c2d668bba8da21a71976c14ec5f5b75f887b6317c4ae0b897ab141c831d741dc76024d8745f1ad1
@@ -13786,7 +13838,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"acorn@npm:^8.0.4, acorn@npm:^8.2.4, acorn@npm:^8.5.0, acorn@npm:^8.7.1, acorn@npm:^8.8.0":
+"acorn@npm:^8.0.4, acorn@npm:^8.2.4, acorn@npm:^8.5.0, acorn@npm:^8.7.1, acorn@npm:^8.8.0, acorn@npm:^8.8.1, acorn@npm:^8.8.2":
   version: 8.8.2
   resolution: "acorn@npm:8.8.2"
   bin:
@@ -15278,6 +15330,7 @@ __metadata:
     tweetnacl: ^1.0.3
     urlsafe-base64: ^1.0.0
     uuid: ^9.0.0
+    vitest: ^0.29.8
     web-push: ^3.5.0
     zod: ^3.19.1
   languageName: unknown
@@ -16145,6 +16198,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"cac@npm:^6.7.14":
+  version: 6.7.14
+  resolution: "cac@npm:6.7.14"
+  checksum: 45a2496a9443abbe7f52a49b22fbe51b1905eff46e03fd5e6c98e3f85077be3f8949685a1849b1a9cd2bc3e5567dfebcf64f01ce01847baf918f1b37c839791a
+  languageName: node
+  linkType: hard
+
 "cacache@npm:^15.2.0, cacache@npm:^15.3.0":
   version: 15.3.0
   resolution: "cacache@npm:15.3.0"
@@ -16439,6 +16499,21 @@ __metadata:
     pathval: ^1.1.1
     type-detect: ^4.0.5
   checksum: 772c522b3bfe3fcf0e0e74edfe584cd886b0e85a73126dec750095300e023d4e1ec6d40e3c35a80d2bd8f33dca46c42767a36f5f50f32dca6fa31c88b5f49ab8
+  languageName: node
+  linkType: hard
+
+"chai@npm:^4.3.7":
+  version: 4.3.7
+  resolution: "chai@npm:4.3.7"
+  dependencies:
+    assertion-error: ^1.1.0
+    check-error: ^1.0.2
+    deep-eql: ^4.1.2
+    get-func-name: ^2.0.0
+    loupe: ^2.3.1
+    pathval: ^1.1.1
+    type-detect: ^4.0.5
+  checksum: 0bba7d267848015246a66995f044ce3f0ebc35e530da3cbdf171db744e14cbe301ab913a8d07caf7952b430257ccbb1a4a983c570a7c5748dc537897e5131f7c
   languageName: node
   linkType: hard
 
@@ -18307,6 +18382,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"deep-eql@npm:^4.1.2":
+  version: 4.1.3
+  resolution: "deep-eql@npm:4.1.3"
+  dependencies:
+    type-detect: ^4.0.0
+  checksum: 7f6d30cb41c713973dc07eaadded848b2ab0b835e518a88b91bea72f34e08c4c71d167a722a6f302d3a6108f05afd8e6d7650689a84d5d29ec7fe6220420397f
+  languageName: node
+  linkType: hard
+
 "deep-equal@npm:^2.0.5":
   version: 2.2.0
   resolution: "deep-equal@npm:2.2.0"
@@ -18690,6 +18774,13 @@ __metadata:
   version: 29.4.3
   resolution: "diff-sequences@npm:29.4.3"
   checksum: 28b265e04fdddcf7f9f814effe102cc95a9dec0564a579b5aed140edb24fc345c611ca52d76d725a3cab55d3888b915b5e8a4702e0f6058968a90fa5f41fcde7
+  languageName: node
+  linkType: hard
+
+"diff@npm:^5.1.0":
+  version: 5.1.0
+  resolution: "diff@npm:5.1.0"
+  checksum: c7bf0df7c9bfbe1cf8a678fd1b2137c4fb11be117a67bc18a0e03ae75105e8533dbfb1cda6b46beb3586ef5aed22143ef9d70713977d5fb1f9114e21455fba90
   languageName: node
   linkType: hard
 
@@ -26832,6 +26923,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"jsonc-parser@npm:^3.2.0":
+  version: 3.2.0
+  resolution: "jsonc-parser@npm:3.2.0"
+  checksum: 946dd9a5f326b745aa326d48a7257e3f4a4b62c5e98ec8e49fa2bdd8d96cef7e6febf1399f5c7016114fd1f68a1c62c6138826d5d90bc650448e3cf0951c53c7
+  languageName: node
+  linkType: hard
+
 "jsonfile@npm:^4.0.0":
   version: 4.0.0
   resolution: "jsonfile@npm:4.0.0"
@@ -27692,6 +27790,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"local-pkg@npm:^0.4.2":
+  version: 0.4.3
+  resolution: "local-pkg@npm:0.4.3"
+  checksum: 7825aca531dd6afa3a3712a0208697aa4a5cd009065f32e3fb732aafcc42ed11f277b5ac67229222e96f4def55197171cdf3d5522d0381b489d2e5547b407d55
+  languageName: node
+  linkType: hard
+
 "local-web-server@npm:^5.2.0":
   version: 5.3.0
   resolution: "local-web-server@npm:5.3.0"
@@ -27988,6 +28093,15 @@ __metadata:
   bin:
     loose-envify: cli.js
   checksum: 6517e24e0cad87ec9888f500c5b5947032cdfe6ef65e1c1936a0c48a524b81e65542c9c3edc91c97d5bddc806ee2a985dbc79be89215d613b1de5db6d1cfe6f4
+  languageName: node
+  linkType: hard
+
+"loupe@npm:^2.3.1, loupe@npm:^2.3.6":
+  version: 2.3.6
+  resolution: "loupe@npm:2.3.6"
+  dependencies:
+    get-func-name: ^2.0.0
+  checksum: cc83f1b124a1df7384601d72d8d1f5fe95fd7a8185469fec48bb2e4027e45243949e7a013e8d91051a138451ff0552310c32aa9786e60b6a30d1e801bdc2163f
   languageName: node
   linkType: hard
 
@@ -29346,6 +29460,18 @@ __metadata:
   languageName: node
   linkType: hard
 
+"mlly@npm:^1.1.0, mlly@npm:^1.1.1":
+  version: 1.2.0
+  resolution: "mlly@npm:1.2.0"
+  dependencies:
+    acorn: ^8.8.2
+    pathe: ^1.1.0
+    pkg-types: ^1.0.2
+    ufo: ^1.1.1
+  checksum: 640b019eb20e8e556bd623141b861d47e5c05f8af00210376ce1015912695dbd93a38cfe7ba18ca04f00e75645378f0f94a48a90bfa6e1b5dee1f0ec9c14eed1
+  languageName: node
+  linkType: hard
+
 "mnemonics@workspace:examples/xnft/mnemonics":
   version: 0.0.0-use.local
   resolution: "mnemonics@workspace:examples/xnft/mnemonics"
@@ -30674,6 +30800,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"p-limit@npm:^4.0.0":
+  version: 4.0.0
+  resolution: "p-limit@npm:4.0.0"
+  dependencies:
+    yocto-queue: ^1.0.0
+  checksum: 01d9d70695187788f984226e16c903475ec6a947ee7b21948d6f597bed788e3112cc7ec2e171c1d37125057a5f45f3da21d8653e04a3a793589e12e9e80e756b
+  languageName: node
+  linkType: hard
+
 "p-locate@npm:^3.0.0":
   version: 3.0.0
   resolution: "p-locate@npm:3.0.0"
@@ -31090,6 +31225,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"pathe@npm:^1.1.0":
+  version: 1.1.0
+  resolution: "pathe@npm:1.1.0"
+  checksum: 6b9be9968ea08a90c0824934799707a1c6a1ad22ac1f22080f377e3f75856d5e53a331b01d327329bfce538a14590587cfb250e8e7947f64408797c84c252056
+  languageName: node
+  linkType: hard
+
 "pathval@npm:^1.1.1":
   version: 1.1.1
   resolution: "pathval@npm:1.1.1"
@@ -31245,6 +31387,17 @@ __metadata:
   dependencies:
     find-up: ^5.0.0
   checksum: b167bb8dac7bbf22b1d5e30ec223e6b064b84b63010c9d49384619a36734caf95ed23ad23d4f9bd975e8e8082b60a83395f43a89bb192df53a7c25a38ecb57d9
+  languageName: node
+  linkType: hard
+
+"pkg-types@npm:^1.0.2":
+  version: 1.0.2
+  resolution: "pkg-types@npm:1.0.2"
+  dependencies:
+    jsonc-parser: ^3.2.0
+    mlly: ^1.1.1
+    pathe: ^1.1.0
+  checksum: 2d0a70c1721c2ebbe075b912531a4f43136e6658fdcc59dc76c39966201ab5ddf265868d1211943183406d4b70d373c17e3b176487bc2020ea737d030b0fd080
   languageName: node
   linkType: hard
 
@@ -31754,7 +31907,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"postcss@npm:^8.0.9, postcss@npm:^8.3.5, postcss@npm:^8.4.14, postcss@npm:^8.4.19":
+"postcss@npm:^8.0.9, postcss@npm:^8.3.5, postcss@npm:^8.4.14, postcss@npm:^8.4.19, postcss@npm:^8.4.21":
   version: 8.4.21
   resolution: "postcss@npm:8.4.21"
   dependencies:
@@ -33755,6 +33908,20 @@ __metadata:
   languageName: node
   linkType: hard
 
+"rollup@npm:^3.18.0":
+  version: 3.20.2
+  resolution: "rollup@npm:3.20.2"
+  dependencies:
+    fsevents: ~2.3.2
+  dependenciesMeta:
+    fsevents:
+      optional: true
+  bin:
+    rollup: dist/bin/rollup
+  checksum: 34b0932839b7c2a5d1742fb21ce95a47e0b49a0849f4abee2dccf25833187aa7babb898ca90d4fc761cffa4102b9ed0ac6ad7f6f6b96c8b8e2d67305abc5da65
+  languageName: node
+  linkType: hard
+
 "rpc-proxy@workspace:backend/workers/rpc-proxy":
   version: 0.0.0-use.local
   resolution: "rpc-proxy@workspace:backend/workers/rpc-proxy"
@@ -34402,6 +34569,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"siginfo@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "siginfo@npm:2.0.0"
+  checksum: 8aa5a98640ca09fe00d74416eca97551b3e42991614a3d1b824b115fc1401543650914f651ab1311518177e4d297e80b953f4cd4cd7ea1eabe824e8f2091de01
+  languageName: node
+  linkType: hard
+
 "signal-exit@npm:^3.0.0, signal-exit@npm:^3.0.2, signal-exit@npm:^3.0.3, signal-exit@npm:^3.0.7":
   version: 3.0.7
   resolution: "signal-exit@npm:3.0.7"
@@ -34989,6 +35163,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"stackback@npm:0.0.2":
+  version: 0.0.2
+  resolution: "stackback@npm:0.0.2"
+  checksum: 2d4dc4e64e2db796de4a3c856d5943daccdfa3dd092e452a1ce059c81e9a9c29e0b9badba91b43ef0d5ff5c04ee62feb3bcc559a804e16faf447bac2d883aa99
+  languageName: node
+  linkType: hard
+
 "stackframe@npm:^1.3.4":
   version: 1.3.4
   resolution: "stackframe@npm:1.3.4"
@@ -35067,6 +35248,13 @@ __metadata:
   version: 1.5.0
   resolution: "statuses@npm:1.5.0"
   checksum: c469b9519de16a4bb19600205cffb39ee471a5f17b82589757ca7bd40a8d92ebb6ed9f98b5a540c5d302ccbc78f15dc03cc0280dd6e00df1335568a5d5758a5c
+  languageName: node
+  linkType: hard
+
+"std-env@npm:^3.3.1":
+  version: 3.3.2
+  resolution: "std-env@npm:3.3.2"
+  checksum: c02256bb041ba1870d23f8360bc7e47a9cf1fabcd02c8b7c4246d48f2c6bb47b4f45c70964348844e6d36521df84c4a9d09d468654b51e0eb5c600e3392b4570
   languageName: node
   linkType: hard
 
@@ -35410,6 +35598,15 @@ __metadata:
   version: 2.0.1
   resolution: "strip-json-comments@npm:2.0.1"
   checksum: 1074ccb63270d32ca28edfb0a281c96b94dc679077828135141f27d52a5a398ef5e78bcf22809d23cadc2b81dfbe345eb5fd8699b385c8b1128907dec4a7d1e1
+  languageName: node
+  linkType: hard
+
+"strip-literal@npm:^1.0.0":
+  version: 1.0.1
+  resolution: "strip-literal@npm:1.0.1"
+  dependencies:
+    acorn: ^8.8.2
+  checksum: ab40496820f02220390d95cdd620a997168efb69d5bd7d180bc4ef83ca562a95447843d8c7c88b8284879a29cf4eedc89d8001d1e098c1a1e23d12a9c755dff4
   languageName: node
   linkType: hard
 
@@ -36165,6 +36362,27 @@ __metadata:
   languageName: node
   linkType: hard
 
+"tinybench@npm:^2.3.1":
+  version: 2.4.0
+  resolution: "tinybench@npm:2.4.0"
+  checksum: cfbe90f75755488653dde256019cc810f65e90f63fdd962e71e8b209b49598c5fc90c2227d2087eb807944895fafe7f12fe9ecae2b5e89db5adde66415e9b836
+  languageName: node
+  linkType: hard
+
+"tinypool@npm:^0.4.0":
+  version: 0.4.0
+  resolution: "tinypool@npm:0.4.0"
+  checksum: 8abcac9e784793499f1eeeace8290c026454b9d7338c74029ce6a821643bab8dcab7caeb4051e39006baf681d6a62d57c3319e9c0f6e2317a45ab0fdbd76ee26
+  languageName: node
+  linkType: hard
+
+"tinyspy@npm:^1.0.2":
+  version: 1.1.1
+  resolution: "tinyspy@npm:1.1.1"
+  checksum: 4ea908fdfddb92044c4454193ec543f5980ced0bd25c5b3d240a94c1511e47e765ad39cd13ae6d3370fb730f62038eedc357f55e4e239416e126bc418f0eee79
+  languageName: node
+  linkType: hard
+
 "tmp-promise@npm:^3.0.2":
   version: 3.0.3
   resolution: "tmp-promise@npm:3.0.3"
@@ -36826,6 +37044,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"ufo@npm:^1.1.1":
+  version: 1.1.1
+  resolution: "ufo@npm:1.1.1"
+  checksum: 6bd210ed93d8c0dedd76c456b1d1dfb0e3b08c2216ee6080e61f0f545de0bac24b3d3a5530cd6a403810855f8d8fc3922583965296142e04cfc287442635e6c7
+  languageName: node
+  linkType: hard
+
 "uglify-es@npm:^3.1.9":
   version: 3.3.10
   resolution: "uglify-es@npm:3.3.10"
@@ -37374,6 +37599,120 @@ __metadata:
     wrangler: ^2.1.6
   languageName: unknown
   linkType: soft
+
+"vite-node@npm:0.29.8":
+  version: 0.29.8
+  resolution: "vite-node@npm:0.29.8"
+  dependencies:
+    cac: ^6.7.14
+    debug: ^4.3.4
+    mlly: ^1.1.0
+    pathe: ^1.1.0
+    picocolors: ^1.0.0
+    vite: ^3.0.0 || ^4.0.0
+  bin:
+    vite-node: vite-node.mjs
+  checksum: b0981d4d63b1f373579eb9da69ca5af9123bf27c81ac246c541cdecf879ef4ef542e0b521cb6ceaafd5ead2cc3d243105d1fb8bf076953d42a6b2203607ce928
+  languageName: node
+  linkType: hard
+
+"vite@npm:^3.0.0 || ^4.0.0":
+  version: 4.2.1
+  resolution: "vite@npm:4.2.1"
+  dependencies:
+    esbuild: ^0.17.5
+    fsevents: ~2.3.2
+    postcss: ^8.4.21
+    resolve: ^1.22.1
+    rollup: ^3.18.0
+  peerDependencies:
+    "@types/node": ">= 14"
+    less: "*"
+    sass: "*"
+    stylus: "*"
+    sugarss: "*"
+    terser: ^5.4.0
+  dependenciesMeta:
+    fsevents:
+      optional: true
+  peerDependenciesMeta:
+    "@types/node":
+      optional: true
+    less:
+      optional: true
+    sass:
+      optional: true
+    stylus:
+      optional: true
+    sugarss:
+      optional: true
+    terser:
+      optional: true
+  bin:
+    vite: bin/vite.js
+  checksum: 70eb162ffc299017a3c310e3adc95e9661def6b17aafd1f8e5e02e516766060435590dbe3df1e4e95acc3583c728a76e91f07c546221d1e701f1b2b021293f45
+  languageName: node
+  linkType: hard
+
+"vitest@npm:^0.29.8":
+  version: 0.29.8
+  resolution: "vitest@npm:0.29.8"
+  dependencies:
+    "@types/chai": ^4.3.4
+    "@types/chai-subset": ^1.3.3
+    "@types/node": "*"
+    "@vitest/expect": 0.29.8
+    "@vitest/runner": 0.29.8
+    "@vitest/spy": 0.29.8
+    "@vitest/utils": 0.29.8
+    acorn: ^8.8.1
+    acorn-walk: ^8.2.0
+    cac: ^6.7.14
+    chai: ^4.3.7
+    debug: ^4.3.4
+    local-pkg: ^0.4.2
+    pathe: ^1.1.0
+    picocolors: ^1.0.0
+    source-map: ^0.6.1
+    std-env: ^3.3.1
+    strip-literal: ^1.0.0
+    tinybench: ^2.3.1
+    tinypool: ^0.4.0
+    tinyspy: ^1.0.2
+    vite: ^3.0.0 || ^4.0.0
+    vite-node: 0.29.8
+    why-is-node-running: ^2.2.2
+  peerDependencies:
+    "@edge-runtime/vm": "*"
+    "@vitest/browser": "*"
+    "@vitest/ui": "*"
+    happy-dom: "*"
+    jsdom: "*"
+    playwright: "*"
+    safaridriver: "*"
+    webdriverio: "*"
+  peerDependenciesMeta:
+    "@edge-runtime/vm":
+      optional: true
+    "@vitest/browser":
+      optional: true
+    "@vitest/ui":
+      optional: true
+    happy-dom:
+      optional: true
+    jsdom:
+      optional: true
+    playwright:
+      optional: true
+    safaridriver:
+      optional: true
+    webdriverio:
+      optional: true
+  bin:
+    vitest: vitest.mjs
+  checksum: 203e33bf093fdb99a6832c905a6c78175bb15313e06e1dcfbeb010a0e3efb8ff0aba4d317efedb4de76bd0086691bbd2c4bc7d6631f60fb1634b96832cba144f
+  languageName: node
+  linkType: hard
 
 "vlq@npm:^1.0.0":
   version: 1.0.1
@@ -38046,6 +38385,18 @@ __metadata:
   languageName: node
   linkType: hard
 
+"why-is-node-running@npm:^2.2.2":
+  version: 2.2.2
+  resolution: "why-is-node-running@npm:2.2.2"
+  dependencies:
+    siginfo: ^2.0.0
+    stackback: 0.0.2
+  bin:
+    why-is-node-running: cli.js
+  checksum: 50820428f6a82dfc3cbce661570bcae9b658723217359b6037b67e495255409b4c8bc7931745f5c175df71210450464517cab32b2f7458ac9c40b4925065200a
+  languageName: node
+  linkType: hard
+
 "wide-align@npm:^1.1.2, wide-align@npm:^1.1.5":
   version: 1.1.5
   resolution: "wide-align@npm:1.1.5"
@@ -38389,6 +38740,7 @@ __metadata:
     esbuild: ^0.15.13
     express: ^4.18.2
     uuid: ^9.0.0
+    vitest: ^0.29.8
     web-push: ^3.5.0
   languageName: unknown
   linkType: soft
@@ -38634,6 +38986,13 @@ __metadata:
   version: 0.1.0
   resolution: "yocto-queue@npm:0.1.0"
   checksum: f77b3d8d00310def622123df93d4ee654fc6a0096182af8bd60679ddcdfb3474c56c6c7190817c84a2785648cdee9d721c0154eb45698c62176c322fb46fc700
+  languageName: node
+  linkType: hard
+
+"yocto-queue@npm:^1.0.0":
+  version: 1.0.0
+  resolution: "yocto-queue@npm:1.0.0"
+  checksum: 2cac84540f65c64ccc1683c267edce396b26b1e931aa429660aefac8fbe0188167b7aee815a3c22fa59a28a58d898d1a2b1825048f834d8d629f4c2a5d443801
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
uses public_keys.is_primary to use the db indexes when checking if public keys are primary or not

added tests for all the endpoints it might affect, to try and ensure it doesn't introduce any regression bugs. These could probably be reduced or removed eventually if we added something like zod and trpc to our api endpoints for typing guarantees

also adds redis in docker-compose so that `xnft-api-server` can be run locally