### PR TITLE
font on toasts and jump to bottom looks different

### DIFF
--- a/packages/chat-sdk/src/components/FullScreenChat.tsx
+++ b/packages/chat-sdk/src/components/FullScreenChat.tsx
@@ -236,7 +236,7 @@ export const FullScreenChat = ({
           <div
             style={{
               fontSize: 12,
-              fontWeight: 500,
+              fontWeight: 600,
               display: "inline-flex",
               cursor: "pointer",
               padding: "8px 12px 8px 16px",

--- a/packages/themes/src/colors.ts
+++ b/packages/themes/src/colors.ts
@@ -53,7 +53,7 @@ export const DARK_RED_BORDER_MED = "rgba(241,50,54,0.4)";
 
 // NOTE: Do not include anything but colors in here. No box shadows, borders, etc.
 export const DARK_COLORS: CustomColors = {
-  blue: "#3498db",
+  blue: "#4C94FF",
   smallTextColor: DARK_TEXT_SMALL_COLOR,
   brandColor: BRAND_COLOR,
   background: BACKGROUND_COLOR_0,
@@ -124,7 +124,7 @@ export const DARK_COLORS: CustomColors = {
 
 // NOTE: Do not include anything but colors in here. No box shadows, borders, etc.
 export const LIGHT_COLORS: CustomColors = {
-  blue: "blue",
+  blue: "#0057EB",
   smallTextColor: LIGHT_TEXT_SMALL_COLOR,
   brandColor: LIGHT_BRAND_COLOR,
   backgroundBackdrop: LIGHT_BACKGROUND_BACKDROP_COLOR,


### PR DESCRIPTION
This PR fixes the differentiation between font on toasts and jump to bottom 
fixes #2814 
Because of the `fontWeight` being `500` it looked a bit pixeletd thus it felt the different. Bumped the `fontWeight` to `600`.