### PR TITLE
Specify source token account on transfer

### DIFF
--- a/packages/app-extension/src/components/Unlocked/Balances/TokensWidget/Solana/index.tsx
+++ b/packages/app-extension/src/components/Unlocked/Balances/TokensWidget/Solana/index.tsx
@@ -111,6 +111,7 @@ export function SendSolanaConfirmationCard({
           mint: new PublicKey(token.mint!),
           amount: amount.toNumber(),
           decimals: token.decimals,
+          source: new PublicKey(token.address),
         });
       }
       // Use an else here to avoid an extra request if we are transferring sol native mints.

--- a/packages/app-mobile/src/components/BottomDrawerSolanaConfirmation.tsx
+++ b/packages/app-mobile/src/components/BottomDrawerSolanaConfirmation.tsx
@@ -101,6 +101,7 @@ export function SendSolanaConfirmationCard({
           mint: new PublicKey(token.mint!),
           amount: amount.toNumber(),
           decimals: token.decimals,
+          source: new PublicKey(token.address),
         });
       } else {
         txSig = await Solana.transferToken(solanaCtx, {

--- a/packages/common/src/solana/index.ts
+++ b/packages/common/src/solana/index.ts
@@ -407,10 +407,10 @@ export class Solana {
     const { walletPublicKey, tokenClient, commitment } = solanaCtx;
     const { amount, mint, destination: destinationOwner } = req;
 
-    const sourceAta = associatedTokenAddress(mint, walletPublicKey);
+    const source = req.source ?? associatedTokenAddress(mint, walletPublicKey);
     const destinationAta = associatedTokenAddress(mint, destinationOwner);
 
-    const ownerTokenRecord = await tokenRecordAddress(mint, sourceAta);
+    const ownerTokenRecord = await tokenRecordAddress(mint, source);
 
     // we need to check whether the token is lock or listed
 
@@ -441,7 +441,7 @@ export class Solana {
     const transferAcccounts: TransferInstructionAccounts = {
       authority: walletPublicKey,
       tokenOwner: walletPublicKey,
-      token: sourceAta,
+      token: source,
       metadata: await metadataAddress(mint),
       mint,
       edition: await masterEditionAddress(mint),
@@ -726,6 +726,9 @@ export type TransferTokenRequest = {
   mint: PublicKey;
   amount: number;
   decimals?: number;
+  // Source token addess. If not provided, an ATA will
+  // be derived from the wallet.
+  source?: PublicKey;
 };
 
 export type TransferSolRequest = {


### PR DESCRIPTION
This PR enables the transfer of `pNFT`s from a token (non-ATA) account. It uses the token address as the source account.