### PR TITLE
fix - allow notifications screen doesn't display on account recovery #3619

### DIFF
--- a/packages/app-extension/src/components/Onboarding/pages/RecoverAccount.tsx
+++ b/packages/app-extension/src/components/Onboarding/pages/RecoverAccount.tsx
@@ -19,6 +19,7 @@ import { AlreadyOnboarded } from "./AlreadyOnboarded";
 import { Finish } from "./Finish";
 import { KeyringTypeSelector } from "./KeyringTypeSelector";
 import { MnemonicSearch } from "./MnemonicSearch";
+import { NotificationsPermission } from "./NotificationsPermission";
 import { RecoverAccountUsernameForm } from "./RecoverAccountUsernameForm";
 import { TwitterConnect } from "./TwitterConnect";
 
@@ -151,6 +152,7 @@ export const RecoverAccount = ({
           />,
         ]
       : []),
+    <NotificationsPermission key="NotificationsPermission" onNext={nextStep} />,
     <Finish key="Finish" isAddingAccount={isAddingAccount} />,
   ];
 


### PR DESCRIPTION
[Backpack.webm](https://user-images.githubusercontent.com/128965067/230313527-04552f2e-bf9a-4452-8999-5a941908490b.webm)
