### PR TITLE
fix users missing in search results when sending tokens

### DIFF
--- a/backend/native/backpack-api/src/db/users.ts
+++ b/backend/native/backpack-api/src/db/users.ts
@@ -331,22 +331,24 @@ export const createUser = async (
 export async function getUsersByPrefix({
   usernamePrefix,
   uuid,
-  limit,
+  limit = 25,
 }: {
   usernamePrefix: string;
   uuid: string;
   limit?: number;
 }) {
-  const { auth_users } = await chain("query")(
+  const { auth_users_whose_username_matches: users } = await chain("query")(
     {
-      auth_users: [
+      auth_users_whose_username_matches: [
         {
+          args: {
+            prefix: usernamePrefix,
+          },
           where: {
-            username: { _like: `${usernamePrefix}%` },
             id: { _neq: uuid },
             public_keys: { is_primary: { _eq: true } },
           },
-          limit: limit || 25,
+          limit,
         },
         {
           id: true,
@@ -364,7 +366,7 @@ export async function getUsersByPrefix({
     { operationName: "getUsersByPrefix" }
   );
 
-  return auth_users;
+  return users;
 }
 
 /**

--- a/backend/native/backpack-api/src/db/users.ts
+++ b/backend/native/backpack-api/src/db/users.ts
@@ -483,12 +483,7 @@ export async function updateUserAvatar({
 export const getUserByPublicKeyAndChain = async (
   publicKey: string,
   blockchain: Blockchain
-): Promise<
-  {
-    id: string;
-    username: string;
-  }[]
-> => {
+) => {
   const response = await chain("query")(
     {
       auth_users: [

--- a/backend/native/backpack-api/src/routes/v1/__tests__/_constants.ts
+++ b/backend/native/backpack-api/src/routes/v1/__tests__/_constants.ts
@@ -34,10 +34,11 @@ export const users = {
       },
     },
   },
-  eth_only: {
+  ali: {
     id: "fb14ab0c-f20f-4b5d-a8d9-f9409eb69380",
     jwt: "eyJhbGciOiJSUzI1NiJ9.eyJzdWIiOiJmYjE0YWIwYy1mMjBmLTRiNWQtYThkOS1mOTQwOWViNjkzODAiLCJpc3MiOiJhdXRoLnhuZnRzLmRldiIsImF1ZCI6ImJhY2twYWNrIiwiaWF0IjoxNjgwNzAyMTAxfQ.ClllrJvRXQZzFKwmJJi_2Ek1JSad2VMugodEq9GEg0D40HNNak7iMLEOfYlaE7uZ6yq5nKIaHm6QUJ7mRbPrWBQq0Zr5GFnzt-16aL3reYAtt_o5ho-fijZ-TAZGL6dGCfJ05zzLMJGH7rjaEXAQkoOceWP6P8_FCdJds2XFraMTNUQzNvrNbsB6f3v2mAnIr1mWYykztWTW-EDzz3Bkpg0sOrccFOjI-rpO1GZ9OclOEuzYRb08WVQVbVsQc6VK0Z8FjE9xWNNPKj4swuNsXEnd3CZdVB4fniyHKVpXQg7QSb5LzBz60ywi9A64c1D7kfZX95zMQlRMoq1qYbD2eA",
     public_keys: {
+      // ali is an eth-only user
       ethereum: {
         primary: 0,
         keys: ["0x6Ecc980c2acB5aaCA12e3DBC2bdE2bC7dDc4d2D9"],

--- a/backend/native/backpack-api/src/routes/v1/__tests__/users.test.ts
+++ b/backend/native/backpack-api/src/routes/v1/__tests__/users.test.ts
@@ -44,5 +44,12 @@ test("an unregistered user cannot get information about themselves", async () =>
 test("getting users via prefix", async () => {
   const res = await bob.get(`users?usernamePrefix=ali`);
   expect(res.users.map((u) => u.username)).toStrictEqual(["ali", "alice"]);
-  expect(res.users[1].public_keys).toOnlyIncludePrimaryPublicKeysFor(alice);
+
+  const { public_keys } = res.users[1];
+  expect(public_keys).toOnlyIncludePrimaryPublicKeysFor(alice);
+
+  // Temporary, see https://github.com/coral-xyz/backpack/issues/3645
+  expect(public_keys.map((x) => x.public_key)).toStrictEqual(
+    public_keys.map((x) => x.publicKey)
+  );
 });

--- a/backend/native/backpack-api/src/routes/v1/__tests__/users.test.ts
+++ b/backend/native/backpack-api/src/routes/v1/__tests__/users.test.ts
@@ -1,17 +1,21 @@
-import { expect, test } from "vitest";
+import { describe, expect, test } from "vitest";
 
 import { alice, bob, unregistered_user } from "./_constants";
 
 test.todo("creating a user");
 
-test("getting the primary solana public key", async () => {
-  expect((await bob.get("users/primarySolPubkey/alice")).publicKey).toEqual(
-    alice.public_keys.solana.keys[alice.public_keys.solana.primary]
-  );
+describe("getting the primary solana public key", async () => {
+  test("for a user with a primary solana public key", async () => {
+    expect((await bob.get("users/primarySolPubkey/alice")).publicKey).toEqual(
+      alice.public_keys.solana.keys[alice.public_keys.solana.primary]
+    );
+  });
 
-  expect((await bob.get("users/primarySolPubkey/eth_only")).msg).toEqual(
-    "No active pubkey on SOL for this user"
-  );
+  test("for a user that doesn't have a primary solana public key", async () => {
+    expect((await bob.get("users/primarySolPubkey/ali")).msg).toEqual(
+      "No active pubkey on SOL for this user"
+    );
+  });
 });
 
 test("getting a user", async () => {
@@ -35,4 +39,10 @@ test("a registered user can get information about themselves", async () => {
 test("an unregistered user cannot get information about themselves", async () => {
   const res = await unregistered_user.get(`users/me`);
   expect(res.id).toBeFalsy();
+});
+
+test("getting users via prefix", async () => {
+  const res = await bob.get(`users?usernamePrefix=ali`);
+  expect(res.users.map((u) => u.username)).toStrictEqual(["ali", "alice"]);
+  expect(res.users[1].public_keys).toOnlyIncludePrimaryPublicKeysFor(alice);
 });

--- a/backend/native/backpack-api/src/routes/v1/users.ts
+++ b/backend/native/backpack-api/src/routes/v1/users.ts
@@ -89,7 +89,11 @@ router.get("/", extractUserId, async (req, res) => {
         areFriends: friendship?.areFriends || false,
         searchedSolPubKey: isSolPublicKey ? usernamePrefix : undefined,
         searchedEthPubKey: isEthPublicKey ? usernamePrefix : undefined,
-        public_keys,
+        // TODO: fix the disambiguation with snake_case and camelCase in API responses
+        public_keys: public_keys.map((pk) => ({
+          ...pk,
+          publicKey: pk.public_key,
+        })),
       };
     });
 

--- a/backend/native/zeus/src/zeus/const.ts
+++ b/backend/native/zeus/src/zeus/const.ts
@@ -829,6 +829,7 @@ export const AllTypesProps: Record<string, any> = {
     _set: "auth_users_set_input",
     where: "auth_users_bool_exp",
   },
+  auth_users_whose_username_matches_args: {},
   auth_xnft_preferences_bool_exp: {
     _and: "auth_xnft_preferences_bool_exp",
     _not: "auth_xnft_preferences_bool_exp",
@@ -1425,6 +1426,18 @@ export const AllTypesProps: Record<string, any> = {
     auth_users_by_pk: {
       id: "uuid",
     },
+    auth_users_whose_username_matches: {
+      args: "auth_users_whose_username_matches_args",
+      distinct_on: "auth_users_select_column",
+      order_by: "auth_users_order_by",
+      where: "auth_users_bool_exp",
+    },
+    auth_users_whose_username_matches_aggregate: {
+      args: "auth_users_whose_username_matches_args",
+      distinct_on: "auth_users_select_column",
+      order_by: "auth_users_order_by",
+      where: "auth_users_bool_exp",
+    },
     auth_xnft_preferences: {
       distinct_on: "auth_xnft_preferences_select_column",
       order_by: "auth_xnft_preferences_order_by",
@@ -1619,6 +1632,18 @@ export const AllTypesProps: Record<string, any> = {
     },
     auth_users_stream: {
       cursor: "auth_users_stream_cursor_input",
+      where: "auth_users_bool_exp",
+    },
+    auth_users_whose_username_matches: {
+      args: "auth_users_whose_username_matches_args",
+      distinct_on: "auth_users_select_column",
+      order_by: "auth_users_order_by",
+      where: "auth_users_bool_exp",
+    },
+    auth_users_whose_username_matches_aggregate: {
+      args: "auth_users_whose_username_matches_args",
+      distinct_on: "auth_users_select_column",
+      order_by: "auth_users_order_by",
       where: "auth_users_bool_exp",
     },
     auth_xnft_preferences: {
@@ -2294,6 +2319,8 @@ export const ReturnTypes: Record<string, any> = {
     auth_users: "auth_users",
     auth_users_aggregate: "auth_users_aggregate",
     auth_users_by_pk: "auth_users",
+    auth_users_whose_username_matches: "auth_users",
+    auth_users_whose_username_matches_aggregate: "auth_users_aggregate",
     auth_xnft_preferences: "auth_xnft_preferences",
     auth_xnft_preferences_by_pk: "auth_xnft_preferences",
     auth_xnft_secrets: "auth_xnft_secrets",
@@ -2351,6 +2378,8 @@ export const ReturnTypes: Record<string, any> = {
     auth_users_aggregate: "auth_users_aggregate",
     auth_users_by_pk: "auth_users",
     auth_users_stream: "auth_users",
+    auth_users_whose_username_matches: "auth_users",
+    auth_users_whose_username_matches_aggregate: "auth_users_aggregate",
     auth_xnft_preferences: "auth_xnft_preferences",
     auth_xnft_preferences_by_pk: "auth_xnft_preferences",
     auth_xnft_preferences_stream: "auth_xnft_preferences",

--- a/backend/native/zeus/src/zeus/index.ts
+++ b/backend/native/zeus/src/zeus/index.ts
@@ -4488,6 +4488,9 @@ export type ValueTypes = {
     /** filter the rows which have to be updated */
     where: ValueTypes["auth_users_bool_exp"] | Variable<any, string>;
   };
+  ["auth_users_whose_username_matches_args"]: {
+    prefix?: string | undefined | null | Variable<any, string>;
+  };
   /** columns and relationships of "auth.xnft_preferences" */
   ["auth_xnft_preferences"]: AliasType<{
     disabled?: boolean | `@${string}`;
@@ -6964,6 +6967,80 @@ export type ValueTypes = {
       { id: ValueTypes["uuid"] | Variable<any, string> },
       ValueTypes["auth_users"]
     ];
+    auth_users_whose_username_matches?: [
+      {
+        /** input parameters for function "auth_users_whose_username_matches" */
+        args:
+          | ValueTypes["auth_users_whose_username_matches_args"]
+          | Variable<any, string> /** distinct select on columns */;
+        distinct_on?:
+          | Array<ValueTypes["auth_users_select_column"]>
+          | undefined
+          | null
+          | Variable<any, string> /** limit the number of rows returned */;
+        limit?:
+          | number
+          | undefined
+          | null
+          | Variable<
+              any,
+              string
+            > /** skip the first n rows. Use only with order_by */;
+        offset?:
+          | number
+          | undefined
+          | null
+          | Variable<any, string> /** sort the rows by one or more columns */;
+        order_by?:
+          | Array<ValueTypes["auth_users_order_by"]>
+          | undefined
+          | null
+          | Variable<any, string> /** filter the rows returned */;
+        where?:
+          | ValueTypes["auth_users_bool_exp"]
+          | undefined
+          | null
+          | Variable<any, string>;
+      },
+      ValueTypes["auth_users"]
+    ];
+    auth_users_whose_username_matches_aggregate?: [
+      {
+        /** input parameters for function "auth_users_whose_username_matches_aggregate" */
+        args:
+          | ValueTypes["auth_users_whose_username_matches_args"]
+          | Variable<any, string> /** distinct select on columns */;
+        distinct_on?:
+          | Array<ValueTypes["auth_users_select_column"]>
+          | undefined
+          | null
+          | Variable<any, string> /** limit the number of rows returned */;
+        limit?:
+          | number
+          | undefined
+          | null
+          | Variable<
+              any,
+              string
+            > /** skip the first n rows. Use only with order_by */;
+        offset?:
+          | number
+          | undefined
+          | null
+          | Variable<any, string> /** sort the rows by one or more columns */;
+        order_by?:
+          | Array<ValueTypes["auth_users_order_by"]>
+          | undefined
+          | null
+          | Variable<any, string> /** filter the rows returned */;
+        where?:
+          | ValueTypes["auth_users_bool_exp"]
+          | undefined
+          | null
+          | Variable<any, string>;
+      },
+      ValueTypes["auth_users_aggregate"]
+    ];
     auth_xnft_preferences?: [
       {
         /** distinct select on columns */
@@ -8173,6 +8250,80 @@ export type ValueTypes = {
           | Variable<any, string>;
       },
       ValueTypes["auth_users"]
+    ];
+    auth_users_whose_username_matches?: [
+      {
+        /** input parameters for function "auth_users_whose_username_matches" */
+        args:
+          | ValueTypes["auth_users_whose_username_matches_args"]
+          | Variable<any, string> /** distinct select on columns */;
+        distinct_on?:
+          | Array<ValueTypes["auth_users_select_column"]>
+          | undefined
+          | null
+          | Variable<any, string> /** limit the number of rows returned */;
+        limit?:
+          | number
+          | undefined
+          | null
+          | Variable<
+              any,
+              string
+            > /** skip the first n rows. Use only with order_by */;
+        offset?:
+          | number
+          | undefined
+          | null
+          | Variable<any, string> /** sort the rows by one or more columns */;
+        order_by?:
+          | Array<ValueTypes["auth_users_order_by"]>
+          | undefined
+          | null
+          | Variable<any, string> /** filter the rows returned */;
+        where?:
+          | ValueTypes["auth_users_bool_exp"]
+          | undefined
+          | null
+          | Variable<any, string>;
+      },
+      ValueTypes["auth_users"]
+    ];
+    auth_users_whose_username_matches_aggregate?: [
+      {
+        /** input parameters for function "auth_users_whose_username_matches_aggregate" */
+        args:
+          | ValueTypes["auth_users_whose_username_matches_args"]
+          | Variable<any, string> /** distinct select on columns */;
+        distinct_on?:
+          | Array<ValueTypes["auth_users_select_column"]>
+          | undefined
+          | null
+          | Variable<any, string> /** limit the number of rows returned */;
+        limit?:
+          | number
+          | undefined
+          | null
+          | Variable<
+              any,
+              string
+            > /** skip the first n rows. Use only with order_by */;
+        offset?:
+          | number
+          | undefined
+          | null
+          | Variable<any, string> /** sort the rows by one or more columns */;
+        order_by?:
+          | Array<ValueTypes["auth_users_order_by"]>
+          | undefined
+          | null
+          | Variable<any, string> /** filter the rows returned */;
+        where?:
+          | ValueTypes["auth_users_bool_exp"]
+          | undefined
+          | null
+          | Variable<any, string>;
+      },
+      ValueTypes["auth_users_aggregate"]
     ];
     auth_xnft_preferences?: [
       {
@@ -11017,6 +11168,9 @@ export type ResolverInputTypes = {
     /** filter the rows which have to be updated */
     where: ResolverInputTypes["auth_users_bool_exp"];
   };
+  ["auth_users_whose_username_matches_args"]: {
+    prefix?: string | undefined | null;
+  };
   /** columns and relationships of "auth.xnft_preferences" */
   ["auth_xnft_preferences"]: AliasType<{
     disabled?: boolean | `@${string}`;
@@ -12886,6 +13040,54 @@ export type ResolverInputTypes = {
       { id: ResolverInputTypes["uuid"] },
       ResolverInputTypes["auth_users"]
     ];
+    auth_users_whose_username_matches?: [
+      {
+        /** input parameters for function "auth_users_whose_username_matches" */
+        args: ResolverInputTypes["auth_users_whose_username_matches_args"] /** distinct select on columns */;
+        distinct_on?:
+          | Array<ResolverInputTypes["auth_users_select_column"]>
+          | undefined
+          | null /** limit the number of rows returned */;
+        limit?:
+          | number
+          | undefined
+          | null /** skip the first n rows. Use only with order_by */;
+        offset?:
+          | number
+          | undefined
+          | null /** sort the rows by one or more columns */;
+        order_by?:
+          | Array<ResolverInputTypes["auth_users_order_by"]>
+          | undefined
+          | null /** filter the rows returned */;
+        where?: ResolverInputTypes["auth_users_bool_exp"] | undefined | null;
+      },
+      ResolverInputTypes["auth_users"]
+    ];
+    auth_users_whose_username_matches_aggregate?: [
+      {
+        /** input parameters for function "auth_users_whose_username_matches_aggregate" */
+        args: ResolverInputTypes["auth_users_whose_username_matches_args"] /** distinct select on columns */;
+        distinct_on?:
+          | Array<ResolverInputTypes["auth_users_select_column"]>
+          | undefined
+          | null /** limit the number of rows returned */;
+        limit?:
+          | number
+          | undefined
+          | null /** skip the first n rows. Use only with order_by */;
+        offset?:
+          | number
+          | undefined
+          | null /** sort the rows by one or more columns */;
+        order_by?:
+          | Array<ResolverInputTypes["auth_users_order_by"]>
+          | undefined
+          | null /** filter the rows returned */;
+        where?: ResolverInputTypes["auth_users_bool_exp"] | undefined | null;
+      },
+      ResolverInputTypes["auth_users_aggregate"]
+    ];
     auth_xnft_preferences?: [
       {
         /** distinct select on columns */
@@ -13777,6 +13979,54 @@ export type ResolverInputTypes = {
         where?: ResolverInputTypes["auth_users_bool_exp"] | undefined | null;
       },
       ResolverInputTypes["auth_users"]
+    ];
+    auth_users_whose_username_matches?: [
+      {
+        /** input parameters for function "auth_users_whose_username_matches" */
+        args: ResolverInputTypes["auth_users_whose_username_matches_args"] /** distinct select on columns */;
+        distinct_on?:
+          | Array<ResolverInputTypes["auth_users_select_column"]>
+          | undefined
+          | null /** limit the number of rows returned */;
+        limit?:
+          | number
+          | undefined
+          | null /** skip the first n rows. Use only with order_by */;
+        offset?:
+          | number
+          | undefined
+          | null /** sort the rows by one or more columns */;
+        order_by?:
+          | Array<ResolverInputTypes["auth_users_order_by"]>
+          | undefined
+          | null /** filter the rows returned */;
+        where?: ResolverInputTypes["auth_users_bool_exp"] | undefined | null;
+      },
+      ResolverInputTypes["auth_users"]
+    ];
+    auth_users_whose_username_matches_aggregate?: [
+      {
+        /** input parameters for function "auth_users_whose_username_matches_aggregate" */
+        args: ResolverInputTypes["auth_users_whose_username_matches_args"] /** distinct select on columns */;
+        distinct_on?:
+          | Array<ResolverInputTypes["auth_users_select_column"]>
+          | undefined
+          | null /** limit the number of rows returned */;
+        limit?:
+          | number
+          | undefined
+          | null /** skip the first n rows. Use only with order_by */;
+        offset?:
+          | number
+          | undefined
+          | null /** sort the rows by one or more columns */;
+        order_by?:
+          | Array<ResolverInputTypes["auth_users_order_by"]>
+          | undefined
+          | null /** filter the rows returned */;
+        where?: ResolverInputTypes["auth_users_bool_exp"] | undefined | null;
+      },
+      ResolverInputTypes["auth_users_aggregate"]
     ];
     auth_xnft_preferences?: [
       {
@@ -15833,6 +16083,9 @@ export type ModelTypes = {
     /** filter the rows which have to be updated */
     where: ModelTypes["auth_users_bool_exp"];
   };
+  ["auth_users_whose_username_matches_args"]: {
+    prefix?: string | undefined;
+  };
   /** columns and relationships of "auth.xnft_preferences" */
   ["auth_xnft_preferences"]: {
     disabled?: string | undefined;
@@ -16592,6 +16845,10 @@ export type ModelTypes = {
     auth_users_aggregate: ModelTypes["auth_users_aggregate"];
     /** fetch data from the table: "auth.users" using primary key columns */
     auth_users_by_pk?: ModelTypes["auth_users"] | undefined;
+    /** execute function "auth.users_whose_username_matches" which returns "auth.users" */
+    auth_users_whose_username_matches: Array<ModelTypes["auth_users"]>;
+    /** execute function "auth.users_whose_username_matches" and query aggregates on result of table type "auth.users" */
+    auth_users_whose_username_matches_aggregate: ModelTypes["auth_users_aggregate"];
     /** fetch data from the table: "auth.xnft_preferences" */
     auth_xnft_preferences: Array<ModelTypes["auth_xnft_preferences"]>;
     /** fetch data from the table: "auth.xnft_preferences" using primary key columns */
@@ -16724,6 +16981,10 @@ export type ModelTypes = {
     auth_users_by_pk?: ModelTypes["auth_users"] | undefined;
     /** fetch data from the table in a streaming manner: "auth.users" */
     auth_users_stream: Array<ModelTypes["auth_users"]>;
+    /** execute function "auth.users_whose_username_matches" which returns "auth.users" */
+    auth_users_whose_username_matches: Array<ModelTypes["auth_users"]>;
+    /** execute function "auth.users_whose_username_matches" and query aggregates on result of table type "auth.users" */
+    auth_users_whose_username_matches_aggregate: ModelTypes["auth_users_aggregate"];
     /** fetch data from the table: "auth.xnft_preferences" */
     auth_xnft_preferences: Array<ModelTypes["auth_xnft_preferences"]>;
     /** fetch data from the table: "auth.xnft_preferences" using primary key columns */
@@ -18724,6 +18985,9 @@ export type GraphQLTypes = {
     /** filter the rows which have to be updated */
     where: GraphQLTypes["auth_users_bool_exp"];
   };
+  ["auth_users_whose_username_matches_args"]: {
+    prefix?: string | undefined;
+  };
   /** columns and relationships of "auth.xnft_preferences" */
   ["auth_xnft_preferences"]: {
     __typename: "auth_xnft_preferences";
@@ -19532,6 +19796,10 @@ export type GraphQLTypes = {
     auth_users_aggregate: GraphQLTypes["auth_users_aggregate"];
     /** fetch data from the table: "auth.users" using primary key columns */
     auth_users_by_pk?: GraphQLTypes["auth_users"] | undefined;
+    /** execute function "auth.users_whose_username_matches" which returns "auth.users" */
+    auth_users_whose_username_matches: Array<GraphQLTypes["auth_users"]>;
+    /** execute function "auth.users_whose_username_matches" and query aggregates on result of table type "auth.users" */
+    auth_users_whose_username_matches_aggregate: GraphQLTypes["auth_users_aggregate"];
     /** fetch data from the table: "auth.xnft_preferences" */
     auth_xnft_preferences: Array<GraphQLTypes["auth_xnft_preferences"]>;
     /** fetch data from the table: "auth.xnft_preferences" using primary key columns */
@@ -19667,6 +19935,10 @@ export type GraphQLTypes = {
     auth_users_by_pk?: GraphQLTypes["auth_users"] | undefined;
     /** fetch data from the table in a streaming manner: "auth.users" */
     auth_users_stream: Array<GraphQLTypes["auth_users"]>;
+    /** execute function "auth.users_whose_username_matches" which returns "auth.users" */
+    auth_users_whose_username_matches: Array<GraphQLTypes["auth_users"]>;
+    /** execute function "auth.users_whose_username_matches" and query aggregates on result of table type "auth.users" */
+    auth_users_whose_username_matches_aggregate: GraphQLTypes["auth_users_aggregate"];
     /** fetch data from the table: "auth.xnft_preferences" */
     auth_xnft_preferences: Array<GraphQLTypes["auth_xnft_preferences"]>;
     /** fetch data from the table: "auth.xnft_preferences" using primary key columns */
@@ -20258,6 +20530,7 @@ type ZEUS_VARIABLES = {
   ["auth_users_stream_cursor_value_input"]: ValueTypes["auth_users_stream_cursor_value_input"];
   ["auth_users_update_column"]: ValueTypes["auth_users_update_column"];
   ["auth_users_updates"]: ValueTypes["auth_users_updates"];
+  ["auth_users_whose_username_matches_args"]: ValueTypes["auth_users_whose_username_matches_args"];
   ["auth_xnft_preferences_bool_exp"]: ValueTypes["auth_xnft_preferences_bool_exp"];
   ["auth_xnft_preferences_constraint"]: ValueTypes["auth_xnft_preferences_constraint"];
   ["auth_xnft_preferences_inc_input"]: ValueTypes["auth_xnft_preferences_inc_input"];

--- a/backend/reef/hasura/metadata/databases/databases.yaml
+++ b/backend/reef/hasura/metadata/databases/databases.yaml
@@ -16,3 +16,4 @@
   customization:
     naming_convention: hasura-default
   tables: "!include default/tables/tables.yaml"
+  functions: "!include default/functions/functions.yaml"

--- a/backend/reef/hasura/metadata/databases/default/functions/auth_users_whose_username_matches.yaml
+++ b/backend/reef/hasura/metadata/databases/default/functions/auth_users_whose_username_matches.yaml
@@ -1,0 +1,3 @@
+function:
+  name: users_whose_username_matches
+  schema: auth

--- a/backend/reef/hasura/metadata/databases/default/functions/dropzone_user_dropzone_public_key.yaml
+++ b/backend/reef/hasura/metadata/databases/default/functions/dropzone_user_dropzone_public_key.yaml
@@ -1,3 +1,0 @@
-function:
-  name: user_dropzone_public_key
-  schema: dropzone

--- a/backend/reef/hasura/metadata/databases/default/functions/functions.yaml
+++ b/backend/reef/hasura/metadata/databases/default/functions/functions.yaml
@@ -1,1 +1,1 @@
-- "!include dropzone_user_dropzone_public_key.yaml"
+- "!include auth_users_whose_username_matches.yaml"

--- a/backend/reef/hasura/migrations/default/1680874984983_add_users_whose_username_matches_function/down.sql
+++ b/backend/reef/hasura/migrations/default/1680874984983_add_users_whose_username_matches_function/down.sql
@@ -1,0 +1,1 @@
+DROP FUNCTION IF EXISTS auth.users_whose_username_matches;

--- a/backend/reef/hasura/migrations/default/1680874984983_add_users_whose_username_matches_function/up.sql
+++ b/backend/reef/hasura/migrations/default/1680874984983_add_users_whose_username_matches_function/up.sql
@@ -1,0 +1,11 @@
+CREATE OR REPLACE FUNCTION auth.users_whose_username_matches(prefix TEXT)
+RETURNS SETOF auth.users AS $$
+BEGIN
+  RETURN QUERY
+  SELECT *
+  FROM auth.users
+  WHERE username LIKE prefix || '%'
+  ORDER BY (username = prefix) DESC, username ASC;
+END;
+$$ LANGUAGE plpgsql STABLE;
+comment on function "auth"."users_whose_username_matches" is E'gets users whose username matches the supplied prefix, returning any exact match as the first result';

--- a/packages/app-extension/src/components/Unlocked/Balances/TokensWidget/AddressSelector.tsx
+++ b/packages/app-extension/src/components/Unlocked/Balances/TokensWidget/AddressSelector.tsx
@@ -48,14 +48,6 @@ export interface SendData {
 
 const useStyles = makeStyles((theme: any) =>
   createStyles({
-    hoverParent: {
-      "&:hover $hoverChild, & .Mui-focused $hoverChild": {
-        visibility: "visible",
-      },
-    },
-    hoverChild: {
-      visibility: "hidden",
-    },
     container: {
       display: "flex",
       flexDirection: "column",
@@ -64,17 +56,9 @@ const useStyles = makeStyles((theme: any) =>
     topHalf: {
       flex: 1,
     },
-    title: {
-      color: theme.custom.colors.fontColor,
-    },
     userText: {
       fontSize: 16,
       marginTop: 4,
-      color: theme.custom.colors.fontColor2,
-    },
-    address: {
-      fontWeight: 500,
-      fontSize: 14,
       color: theme.custom.colors.fontColor2,
     },
     buttonContainer: {
@@ -439,19 +423,23 @@ const Contacts = ({
         <div style={{ margin: "12px 12px" }}>
           <BubbleTopLabel text="Friends" />
           <AddressList
-            wallets={filteredContacts.map((c) => ({
-              username: c.remoteUsername,
-              addresses: c.public_keys
-                .filter(
-                  (x) =>
-                    x.blockchain === blockchain &&
-                    (x.publicKey.includes(searchFilter) ||
-                      c.remoteUsername.includes(searchFilter))
-                )
-                .map((x) => x.publicKey),
-              image: c.remoteUserImage,
-              uuid: c.remoteUserId,
-            })).sort((a: any, b: any) => a.username[0] < b.username[0] ? -1 : 1)}
+            wallets={filteredContacts
+              .map((c) => ({
+                username: c.remoteUsername,
+                addresses: c.public_keys
+                  .filter(
+                    (x) =>
+                      x.blockchain === blockchain &&
+                      (x.publicKey.includes(searchFilter) ||
+                        c.remoteUsername.includes(searchFilter))
+                  )
+                  .map((x) => x.publicKey),
+                image: c.remoteUserImage,
+                uuid: c.remoteUserId,
+              }))
+              .sort((a: any, b: any) =>
+                a.username[0] < b.username[0] ? -1 : 1
+              )}
           />
         </div>
       ) : null}
@@ -638,7 +626,7 @@ const SearchInput = ({
   const fetchUserDetails = async (address: string, blockchain: Blockchain) => {
     try {
       const response = await ParentCommunicationManager.getInstance().fetch(
-        `${BACKEND_API_URL}/users?usernamePrefix=${address}&blockchain=${blockchain}limit=6`
+        `${BACKEND_API_URL}/users?usernamePrefix=${address}&blockchain=${blockchain}&limit=6`
       );
       const json = await response.json();
       setSearchResults(

--- a/packages/app-mobile/src/screens/Unlocked/SendTokenScreen2.tsx
+++ b/packages/app-mobile/src/screens/Unlocked/SendTokenScreen2.tsx
@@ -1,8 +1,8 @@
 import type { Token } from "@@types/types";
-import type { RemoteUserData, SubscriptionType } from "@coral-xyz/common";
+import type { RemoteUserData } from "@coral-xyz/common";
 
 import { useEffect, useState } from "react";
-import { View, ScrollView, Alert } from "react-native";
+import { ScrollView, View } from "react-native";
 
 import { BACKEND_API_URL, Blockchain } from "@coral-xyz/common";
 import { useContacts } from "@coral-xyz/db";
@@ -14,12 +14,12 @@ import {
   useUser,
 } from "@coral-xyz/recoil";
 import {
-  PrimaryButton,
-  DangerButton,
   Box,
+  DangerButton,
+  ListItem,
+  PrimaryButton,
   Text,
   YGroup,
-  ListItem,
   YStack,
 } from "@coral-xyz/tamagui";
 import AsyncStorage from "@react-native-async-storage/async-storage";
@@ -143,7 +143,7 @@ export const SearchInput = ({
   const fetchUserDetails = async (address: string, blockchain: Blockchain) => {
     try {
       const jwt = await AsyncStorage.getItem("@bk-jwt");
-      const url = `${BACKEND_API_URL}/users?usernamePrefix=${address}&blockchain=${blockchain}limit=6`;
+      const url = `${BACKEND_API_URL}/users?usernamePrefix=${address}&blockchain=${blockchain}&limit=6`;
       const response = await fetch(url, {
         headers: {
           authorization: `Bearer ${jwt}`,


### PR DESCRIPTION
fixes #3645

- re-adds `public_keys.publicKey` and adds some tests to make refactoring possible if we choose to stick to a convention of snake case or camel case for data served from the API
- merges #3641 which returns the exact username match as the first result
- adds & before limit url search param so `blockchain=solanalimit=6` becomes `blockchain=solana&limit=6`