### PR TITLE
update cors settings for some workers

### DIFF
--- a/backend/workers/feature-gates/package.json
+++ b/backend/workers/feature-gates/package.json
@@ -13,6 +13,6 @@
     "deploy": "wrangler publish"
   },
   "dependencies": {
-    "hono": "^2.2.1"
+    "hono": "^3.1.5"
   }
 }

--- a/backend/workers/feature-gates/src/index.ts
+++ b/backend/workers/feature-gates/src/index.ts
@@ -1,8 +1,16 @@
 import { Hono } from "hono";
+import { cors } from "hono/cors";
+
 import { FEATURE_GATES } from "./FEATURES";
 import { getStripeEnabledGate } from "./stripe";
 
-const app = new Hono();
+type Env = {
+  STRIPE_SECRET: string;
+};
+
+const app = new Hono<{ Bindings: Env }>();
+
+app.use("*", cors());
 
 app.get("/", (c) => {
   return c.json("ok", 200);

--- a/backend/workers/jupiter-proxy/package.json
+++ b/backend/workers/jupiter-proxy/package.json
@@ -15,7 +15,7 @@
     "@jup-ag/api": "^4.0.1-alpha.0",
     "@solana/web3.js": "^1.73.0",
     "@supabase/supabase-js": "^2.4.1",
-    "hono": "^2.7.2",
+    "hono": "^3.1.5",
     "jose": "^4.11.2"
   }
 }

--- a/backend/workers/jupiter-proxy/src/index.ts
+++ b/backend/workers/jupiter-proxy/src/index.ts
@@ -2,6 +2,7 @@ import type { V4SwapPostRequest } from "@jup-ag/api";
 import { Connection } from "@solana/web3.js";
 import { createClient } from "@supabase/supabase-js";
 import { Hono } from "hono";
+import { cors } from "hono/cors";
 import { importSPKI, jwtVerify } from "jose";
 
 import ACCOUNTS from "./feeAccounts.json";
@@ -9,6 +10,8 @@ import ACCOUNTS from "./feeAccounts.json";
 type MintAddress = keyof typeof ACCOUNTS | undefined;
 
 const app = new Hono();
+
+app.use("*", cors());
 
 // start routes ----------------------------------------
 

--- a/backend/workers/version/.eslintrc.js
+++ b/backend/workers/version/.eslintrc.js
@@ -1,0 +1,8 @@
+module.exports = {
+  root: true,
+  extends: ["custom"],
+  parserOptions: {
+    tsconfigRootDir: __dirname,
+    project: ["./tsconfig.json"],
+  },
+};

--- a/backend/workers/version/package.json
+++ b/backend/workers/version/package.json
@@ -12,6 +12,6 @@
     "deploy": "wrangler publish"
   },
   "dependencies": {
-    "hono": "^2.2.1"
+    "hono": "^3.1.5"
   }
 }

--- a/backend/workers/version/src/index.ts
+++ b/backend/workers/version/src/index.ts
@@ -1,6 +1,9 @@
 import { Hono } from "hono";
+import { cors } from "hono/cors";
 
 const app = new Hono();
+
+app.use("*", cors());
 
 app.get("/", (c) => {
   return c.json(

--- a/backend/workers/version/wrangler.toml
+++ b/backend/workers/version/wrangler.toml
@@ -1,7 +1,3 @@
 name = "version"
 main = "src/index.ts"
 compatibility_date = "2022-09-22"
-node_compat = true
-
-[env.development.vars]
-STRIPE_SECRET = ""

--- a/yarn.lock
+++ b/yarn.lock
@@ -21966,7 +21966,7 @@ __metadata:
   dependencies:
     "@cloudflare/workers-types": ^3.16.0
     "@coral-xyz/common": "*"
-    hono: ^2.2.1
+    hono: ^3.1.5
     typescript: ^4.9.5
     wrangler: ^2.1.6
   languageName: unknown
@@ -23533,10 +23533,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"hono@npm:^2.2.1, hono@npm:^2.2.3, hono@npm:^2.5.8, hono@npm:^2.7.2":
+"hono@npm:^2.2.1, hono@npm:^2.2.3, hono@npm:^2.5.8":
   version: 2.7.8
   resolution: "hono@npm:2.7.8"
   checksum: 3ac38c8fbdcdd48cd9dbf70a1869fde4251a43c40b1419cda66028b6605f3856d5c92b9891e84cd010e18dbb76cc6e5cab03c4e51f9d0cc2b5bd3f924c4e88d3
+  languageName: node
+  linkType: hard
+
+"hono@npm:^3.1.5":
+  version: 3.1.5
+  resolution: "hono@npm:3.1.5"
+  checksum: f37c7953edc31bcdfbec450ef23bf401b16204860f5e7f044ef2123ea344f2a8d27a6eab8aa53122697bd8dccfae168539267df48a13f3a0cb950052c318a1f9
   languageName: node
   linkType: hard
 
@@ -27124,7 +27131,7 @@ __metadata:
     "@solana/web3.js": ^1.73.0
     "@supabase/supabase-js": ^2.4.1
     eslint-config-custom: "*"
-    hono: ^2.7.2
+    hono: ^3.1.5
     jose: ^4.11.2
     wrangler: ^2.7.1
   languageName: unknown
@@ -37602,7 +37609,7 @@ __metadata:
   resolution: "version@workspace:backend/workers/version"
   dependencies:
     "@cloudflare/workers-types": ^3.16.0
-    hono: ^2.2.1
+    hono: ^3.1.5
     typescript: ~4.9.3
     wrangler: ^2.1.6
   languageName: unknown


### PR DESCRIPTION
while debugging some issues that some windows users seem to be facing, this updates cors settings for the following workers -

- feature-gates
- jupiter-proxy
- version

for now it ignores the following workers

- avatars
- invites
- nft-data