### PR TITLE
hide token price change if no data is available

### DIFF
--- a/packages/app-extension/src/components/Unlocked/Balances/TokensWidget/Token.tsx
+++ b/packages/app-extension/src/components/Unlocked/Balances/TokensWidget/Token.tsx
@@ -128,11 +128,13 @@ function TokenHeader({
           amount={token.nativeBalance}
           displayLogo={false}
         />
-        <Typography className={classes.usdBalanceLabel}>
-          ${parseFloat(token.usdBalance.toFixed(2)).toLocaleString()}
-          &nbsp;&nbsp;&nbsp;
-          <span className={percentClass}>{token.recentPercentChange}%</span>
-        </Typography>
+        {token.priceData ? (
+          <Typography className={classes.usdBalanceLabel}>
+            ${parseFloat(token.usdBalance.toFixed(2)).toLocaleString()}
+            &nbsp;&nbsp;&nbsp;
+            <span className={percentClass}>{token.recentPercentChange}%</span>
+          </Typography>
+        ) : null}
       </div>
       <div className={classes.tokenHeaderButtonContainer}>
         <TransferWidget


### PR DESCRIPTION
hides the absolute USD value and 24hr percentage change value if there's no coingecko data available for that token

before | after
---|---
<img width="487" alt="Screenshot 2023-04-10 at 15 28 16" src="https://user-images.githubusercontent.com/101902546/230921914-b72afcd6-a28c-4596-bd30-d6fb2755d7f0.png">|<img width="487" alt="Screenshot 2023-04-10 at 15 27 55" src="https://user-images.githubusercontent.com/101902546/230921935-eb6f4325-b18e-48ff-b934-b3ec447dca47.png">
