### PR TITLE
add another lazy import in options.js to reduce bundle size

### DIFF
--- a/packages/app-extension/src/options/index.tsx
+++ b/packages/app-extension/src/options/index.tsx
@@ -1,17 +1,21 @@
-import React, { lazy, Suspense } from "react";
+import { lazy, Suspense } from "react";
 import { createRoot } from "react-dom/client";
 
-import Options from "./Options";
-
+// Code-splitting keeps the options.js bundle under 4MB which is
+// a requirement for Firefox extensions
+const Options = lazy(() => import("./Options"));
 const LedgerIframe = lazy(() => import("../components/LedgerIframe"));
 
 // Render the UI.
 // TOOD(react) createRoot is required: https://reactjs.org/blog/2022/03/08/react-18-upgrade-guide.html#updates-to-client-rendering-apis
 const container = document.getElementById("options");
 const root = createRoot(container!);
+
 root.render(
   <>
-    <Options />
+    <Suspense fallback={null}>
+      <Options />
+    </Suspense>
     <Suspense fallback={null}>
       <LedgerIframe />
     </Suspense>


### PR DESCRIPTION
related #1496 

Firefox will not accept any source files > 4MB

This shrinks options.js from 6.2MB to 143KB and doesn't create any new chunk files that are over 4MB