### PR TITLE
prevent switching swap tokens if you don't own the output token

### DIFF
--- a/packages/app-extension/src/app/Router.tsx
+++ b/packages/app-extension/src/app/Router.tsx
@@ -54,7 +54,9 @@ export default function Router() {
     <WithSuspense>
       <>
         <ToastContainer
-          toastStyle={{ backgroundColor: theme.custom.colors.swapTokensButton }}
+          toastStyle={{
+            backgroundColor: theme.custom.colors.switchTokensButton,
+          }}
           theme={isDarkMode ? "dark" : "light"}
         />
         <_Router />

--- a/packages/recoil/src/context/Swap.tsx
+++ b/packages/recoil/src/context/Swap.tsx
@@ -15,7 +15,7 @@ import { getAssociatedTokenAddress } from "@solana/spl-token";
 import type { TokenInfo } from "@solana/spl-token-registry";
 import { PublicKey, Transaction } from "@solana/web3.js";
 import * as bs58 from "bs58";
-import { BigNumber, ethers,FixedNumber } from "ethers";
+import { BigNumber, ethers, FixedNumber } from "ethers";
 
 import { blockchainTokenData } from "../atoms/balance";
 import { jupiterInputTokens } from "../atoms/solana/jupiter";
@@ -100,6 +100,7 @@ export type SwapContext = {
   isLoadingTransactions: boolean;
   isJupiterError: boolean;
   canSwap: boolean;
+  canSwitch: boolean;
 };
 
 const _SwapContext = React.createContext<SwapContext | null>(null);
@@ -542,6 +543,11 @@ export function SwapProvider({
     return signature;
   };
 
+  // Only allow users to switch input and output tokens if they currently
+  // have a balance of the output token
+  const canSwitch =
+    toToken?.mint === WSOL_MINT || fromTokens.some((t) => t.mint === toMint);
+
   return (
     <_SwapContext.Provider
       value={{
@@ -570,6 +576,7 @@ export function SwapProvider({
         exceedsBalance,
         feeExceedsBalance,
         canSwap: !availableForSwap.isZero(),
+        canSwitch,
       }}
     >
       {children}

--- a/packages/themes/src/colors.ts
+++ b/packages/themes/src/colors.ts
@@ -92,7 +92,7 @@ export const DARK_COLORS: CustomColors = {
   textBackground: BACKGROUND_COLOR_1,
   textPlaceholder: FONT_COLOR_1,
   textBorder: BACKGROUND_COLOR_1,
-  swapTokensButton: BACKGROUND_COLOR_0,
+  switchTokensButton: BACKGROUND_COLOR_0,
   icon: "#787C89",
   approveTransactionTableBackground: BACKGROUND_COLOR_2,
   approveTransactionCloseBackground: BACKGROUND_COLOR_0,
@@ -164,7 +164,7 @@ export const LIGHT_COLORS: CustomColors = {
   textBorder: LIGHT_BORDER_COLOR,
   textPlaceholder: "#4E5768",
   textFieldTextColor: LIGHT_FONT_COLOR_2,
-  swapTokensButton: "#FFFFFF",
+  switchTokensButton: "#FFFFFF",
   icon: "#8F929E",
   approveTransactionTableBackground: LIGHT_BACKGROUND_COLOR_1,
   approveTransactionCloseBackground: "#C2C4CC",
@@ -333,7 +333,7 @@ export type CustomColors = {
   smallTextColor: string;
   subtext: string;
   successButton: string;
-  swapTokensButton: string;
+  switchTokensButton: string;
   tableBorder: string;
   text: string;
   textBackground: string;


### PR DESCRIPTION
fixes #3678


https://user-images.githubusercontent.com/101902546/231432944-904da5e1-3b56-411f-a642-eaf61ec63d4c.mov

----

- renames `SwapTokensButton` to `SwitchTokensButton` to differentiate from Swaps
- adds `canSwitch:Boolean` to `SwapProvider`
- sets `disabled={canSwitch}` on `SwitchTokensButton`

----

if the output token is... | `SwapProvider.canSwitch` is
---|---
wrapped Sol | `true`
a token already owned by the user | `true`
a token the user does not own | `false`

----

notes:

- uses terse `"Swich the Sending & Receiving token"` message due to horizontal space constraints, it could probably be a multiline string but it could take longer to implement