### PR TITLE
fix: Ledger live EVM incorrect derivation path

### DIFF
--- a/packages/app-extension/src/components/common/Account/ImportWallets.tsx
+++ b/packages/app-extension/src/components/common/Account/ImportWallets.tsx
@@ -8,7 +8,7 @@ import {
   legacyBip44ChangeIndexed,
   legacyBip44Indexed,
   legacyLedgerIndexed,
-  legacyLedgerLiveIndexed,
+  legacyLedgerLiveAccount,
   legacySolletIndexed,
   LOAD_PUBLIC_KEY_AMOUNT,
   UI_RPC_METHOD_FIND_SERVER_PUBLIC_KEY_CONFLICTS,
@@ -132,8 +132,8 @@ export function ImportWallets({
       },
       **/
       {
-        path: (i: number) => legacyLedgerLiveIndexed(i),
-        label: "m/44/60/x - Ledger Live",
+        path: (i: number) => legacyLedgerLiveAccount(i),
+        label: "m/44'/60'/x'/0/0 - Ledger Live",
       },
       /**
       // Used in older versions of Backpack
@@ -144,16 +144,16 @@ export function ImportWallets({
       **/
       {
         path: (i: number) => legacyLedgerIndexed(i),
-        label: "m/44/60'/0'/x' - Ledger",
+        label: "m/44'/60'/0'/x' - Ledger",
       },
       {
         path: (i: number) => ethereumIndexed(i),
-        label: "m/44/60'/0'/0/x - Ethereum Standard",
+        label: "m/44'/60'/0'/0/x - Ethereum Standard",
       },
       {
         path: (i: number) =>
           legacyBip44ChangeIndexed(Blockchain.ETHEREUM, i) + "/0'",
-        label: "m/44/60'/x'/0'/0'",
+        label: "m/44'/60'/x'/0'/0'",
       },
     ],
   }[blockchain];

--- a/packages/common/src/crypto.ts
+++ b/packages/common/src/crypto.ts
@@ -54,11 +54,11 @@ export const legacyLedgerIndexed = (index: number) => {
 };
 
 /**
- * m/44'/60'
+ * m/44'/60'/x'/0/0
  */
-export const legacyLedgerLiveIndexed = (index: number) => {
+export const legacyLedgerLiveAccount = (accountIndex: number) => {
   const coinType = getCoinType(Blockchain.ETHEREUM);
-  const path = [44 + HARDENING, coinType, index];
+  const path = [44 + HARDENING, coinType, accountIndex + HARDENING, 0, 0];
   return new BIPPath.fromPathArray(path).toString();
 };
 
@@ -217,7 +217,7 @@ export const getRecoveryPaths = (blockchain: Blockchain, ledger = false) => {
       [...Array(LOAD_PUBLIC_KEY_AMOUNT).keys()].map(legacyLedgerIndexed)
     );
     paths = paths.concat(
-      [...Array(LOAD_PUBLIC_KEY_AMOUNT).keys()].map(legacyLedgerLiveIndexed)
+      [...Array(LOAD_PUBLIC_KEY_AMOUNT).keys()].map(legacyLedgerLiveAccount)
     );
   }
 


### PR DESCRIPTION
Easy to test, go to metamask, see some addresses for "Ledger live", go to backpack see some other addresses.

Also source https://github.com/MetaMask/metamask-extension/blob/6439551075e585c9ec27667e68df0cca9d4ef468/ui/pages/create-account/connect-hardware/index.js#L39