### PR TITLE
set a user's referrer if wasn't set when the user was created

### DIFF
--- a/backend/native/backpack-api/src/config.ts
+++ b/backend/native/backpack-api/src/config.ts
@@ -1,8 +1,18 @@
 import * as dotenv from "dotenv";
 
 dotenv.config();
-export const HASURA_URL =
-  process.env.HASURA_URL || "http://localhost:8112/v1/graphql";
+
+const DEFAULT_LOCAL_HASURA_URL = "http://localhost:8112/v1/graphql";
+
+export const HASURA_URL = process.env.HASURA_URL || DEFAULT_LOCAL_HASURA_URL;
+
+if (
+  process.env.NODE_ENV === "test" &&
+  HASURA_URL !== DEFAULT_LOCAL_HASURA_URL
+) {
+  console.error("You should only be running tests in a test environment");
+  process.exit(1);
+}
 
 export const JWT =
   process.env.AUTH_JWT ||

--- a/backend/native/backpack-api/src/routes/v1/__tests__/_setup.ts
+++ b/backend/native/backpack-api/src/routes/v1/__tests__/_setup.ts
@@ -5,11 +5,6 @@ import { HASURA_URL, JWT } from "../../../config";
 
 import { users } from "./_constants";
 
-if (process.env.NODE_ENV !== "test" || !HASURA_URL.includes("localhost:")) {
-  console.error("This is not a test environment");
-  process.exit(1);
-}
-
 expect.extend({
   toOnlyIncludePrimaryPublicKeysFor(
     keys,
@@ -66,12 +61,11 @@ expect.extend({
 });
 
 beforeAll(async () => {
-  const LOCAL_ADMIN_PASSWORD = "myadminsecretkey";
   await fetch(HASURA_URL, {
     method: "POST",
     headers: {
       "Content-Type": "application/json",
-      "x-hasura-admin-secret": LOCAL_ADMIN_PASSWORD,
+      "x-hasura-admin-secret": "myadminsecretkey",
     },
     body: JSON.stringify({
       // TODO: add DELETE cascades to remove all associated data with users

--- a/backend/native/backpack-api/src/routes/v1/__tests__/users.test.ts
+++ b/backend/native/backpack-api/src/routes/v1/__tests__/users.test.ts
@@ -1,8 +1,17 @@
-import { describe, expect, test } from "vitest";
+import { v4 } from "uuid";
+import { afterEach, describe, expect, test } from "vitest";
 
-import { alice, bob, unregistered_user } from "./_constants";
+import { Chain } from "../../../../../zeus/dist/esm";
+import { HASURA_URL } from "../../../config";
 
-test.todo("creating a user");
+import { ali, alice, bob, get } from "./_constants";
+
+describe.todo("creating a user", () => {
+  test.todo("with valid credentials");
+  test.todo("with invalid credentials");
+  test.todo("with a referrer cookie");
+  test.todo("sets the authenticated user as the referrer if there's no cookie");
+});
 
 describe("getting the primary solana public key", async () => {
   test("for a user with a primary solana public key", async () => {
@@ -19,7 +28,7 @@ describe("getting the primary solana public key", async () => {
 });
 
 test("getting a user", async () => {
-  const res = await unregistered_user.get("users/alice");
+  const res = await get("users/alice");
   expect(res.id).toEqual(alice.id);
   expect(res.publicKeys).toOnlyIncludePrimaryPublicKeysFor(alice);
 });
@@ -37,8 +46,69 @@ test("a registered user can get information about themselves", async () => {
 });
 
 test("an unregistered user cannot get information about themselves", async () => {
-  const res = await unregistered_user.get(`users/me`);
+  const res = await get(`users/me`);
   expect(res.id).toBeFalsy();
+});
+
+describe("updating the referrer", async () => {
+  const chain = await Chain(HASURA_URL, {
+    headers: { "x-hasura-admin-secret": "myadminsecretkey" },
+  });
+
+  test("a user's referrer is set if they have a valid referrer cookie", async () => {
+    let res = await get(`users/me`, undefined, {
+      Cookie: `jwt=${alice.jwt};referrer=${bob.id};`,
+    });
+    expect(await getReferrersUsername(alice)).toBe("bob");
+    expect(res.id).toEqual(alice.id);
+
+    // ... and it won't be changed once it's set
+
+    res = await get(`users/me`, undefined, {
+      Cookie: `jwt=${alice.jwt};referrer=${ali.id};`,
+    });
+    expect(await getReferrersUsername(alice)).toBe("bob");
+    expect(res.id).toEqual(alice.id);
+  });
+
+  test("a user doesn't get a referrer if there's no referrer cookie set", async () => {
+    expect(await getReferrersUsername(alice)).toBeUndefined();
+    const res = await alice.get(`users/me`);
+    expect(await getReferrersUsername(alice)).toBeUndefined();
+    expect(res.id).toEqual(alice.id);
+  });
+
+  for (const referrer of [v4(), "invalid", "", alice.id]) {
+    test(`invalid referrer ('${referrer}') is ignored`, async () => {
+      const res = await get(`users/me`, undefined, {
+        Cookie: `jwt=${alice.jwt};referrer=${referrer};`,
+      });
+      expect(await getReferrersUsername(alice)).toBeUndefined();
+      expect(res.id).toEqual(alice.id);
+    });
+  }
+
+  afterEach(async () => {
+    await chain("mutation")(
+      {
+        update_auth_users_many: [
+          { updates: [{ where: {}, _set: { referrer_id: null } }] },
+          { affected_rows: true },
+        ],
+      },
+      { operationName: "clearReferrers" }
+    );
+  });
+
+  async function getReferrersUsername(user: any) {
+    const { auth_users_by_pk } = await chain("query")(
+      {
+        auth_users_by_pk: [{ id: user.id }, { referrer: { username: true } }],
+      },
+      { operationName: "getReferrer" }
+    );
+    return auth_users_by_pk?.referrer?.username;
+  }
 });
 
 test("getting users via prefix", async () => {

--- a/backend/native/backpack-api/src/utils/hasura.ts
+++ b/backend/native/backpack-api/src/utils/hasura.ts
@@ -1,0 +1,7 @@
+import { Chain } from "@coral-xyz/zeus";
+
+import { HASURA_URL, JWT } from "../config";
+
+export const chain = Chain(HASURA_URL, {
+  headers: { Authorization: `Bearer ${JWT}` },
+});

--- a/backend/native/zeus/src/zeus/const.ts
+++ b/backend/native/zeus/src/zeus/const.ts
@@ -766,6 +766,7 @@ export const AllTypesProps: Record<string, any> = {
     referred_users: "auth_users_bool_exp",
     referred_users_aggregate: "auth_users_aggregate_bool_exp",
     referrer: "auth_users_bool_exp",
+    referrer_id: "uuid_comparison_exp",
     username: "citext_comparison_exp",
   },
   auth_users_constraint: "enum" as const,
@@ -782,11 +783,13 @@ export const AllTypesProps: Record<string, any> = {
   auth_users_max_order_by: {
     created_at: "order_by",
     id: "order_by",
+    referrer_id: "order_by",
     username: "order_by",
   },
   auth_users_min_order_by: {
     created_at: "order_by",
     id: "order_by",
+    referrer_id: "order_by",
     username: "order_by",
   },
   auth_users_obj_rel_insert_input: {
@@ -805,6 +808,7 @@ export const AllTypesProps: Record<string, any> = {
     public_keys_aggregate: "auth_public_keys_aggregate_order_by",
     referred_users_aggregate: "auth_users_aggregate_order_by",
     referrer: "auth_users_order_by",
+    referrer_id: "order_by",
     username: "order_by",
   },
   auth_users_pk_columns_input: {
@@ -813,6 +817,7 @@ export const AllTypesProps: Record<string, any> = {
   auth_users_select_column: "enum" as const,
   auth_users_set_input: {
     avatar_nft: "citext",
+    referrer_id: "uuid",
     updated_at: "timestamptz",
   },
   auth_users_stream_cursor_input: {
@@ -822,6 +827,7 @@ export const AllTypesProps: Record<string, any> = {
   auth_users_stream_cursor_value_input: {
     created_at: "timestamptz",
     id: "uuid",
+    referrer_id: "uuid",
     username: "citext",
   },
   auth_users_update_column: "enum" as const,
@@ -2084,6 +2090,7 @@ export const ReturnTypes: Record<string, any> = {
     referred_users: "auth_users",
     referred_users_aggregate: "auth_users_aggregate",
     referrer: "auth_users",
+    referrer_id: "uuid",
     username: "citext",
   },
   auth_users_aggregate: {
@@ -2098,11 +2105,13 @@ export const ReturnTypes: Record<string, any> = {
   auth_users_max_fields: {
     created_at: "timestamptz",
     id: "uuid",
+    referrer_id: "uuid",
     username: "citext",
   },
   auth_users_min_fields: {
     created_at: "timestamptz",
     id: "uuid",
+    referrer_id: "uuid",
     username: "citext",
   },
   auth_users_mutation_response: {

--- a/backend/native/zeus/src/zeus/index.ts
+++ b/backend/native/zeus/src/zeus/index.ts
@@ -4160,6 +4160,7 @@ export type ValueTypes = {
     ];
     /** An object relationship */
     referrer?: ValueTypes["auth_users"];
+    referrer_id?: boolean | `@${string}`;
     username?: boolean | `@${string}`;
     __typename?: boolean | `@${string}`;
   }>;
@@ -4288,6 +4289,11 @@ export type ValueTypes = {
       | undefined
       | null
       | Variable<any, string>;
+    referrer_id?:
+      | ValueTypes["uuid_comparison_exp"]
+      | undefined
+      | null
+      | Variable<any, string>;
     username?:
       | ValueTypes["citext_comparison_exp"]
       | undefined
@@ -4332,6 +4338,7 @@ export type ValueTypes = {
   ["auth_users_max_fields"]: AliasType<{
     created_at?: boolean | `@${string}`;
     id?: boolean | `@${string}`;
+    referrer_id?: boolean | `@${string}`;
     username?: boolean | `@${string}`;
     __typename?: boolean | `@${string}`;
   }>;
@@ -4343,6 +4350,11 @@ export type ValueTypes = {
       | null
       | Variable<any, string>;
     id?: ValueTypes["order_by"] | undefined | null | Variable<any, string>;
+    referrer_id?:
+      | ValueTypes["order_by"]
+      | undefined
+      | null
+      | Variable<any, string>;
     username?:
       | ValueTypes["order_by"]
       | undefined
@@ -4353,6 +4365,7 @@ export type ValueTypes = {
   ["auth_users_min_fields"]: AliasType<{
     created_at?: boolean | `@${string}`;
     id?: boolean | `@${string}`;
+    referrer_id?: boolean | `@${string}`;
     username?: boolean | `@${string}`;
     __typename?: boolean | `@${string}`;
   }>;
@@ -4364,6 +4377,11 @@ export type ValueTypes = {
       | null
       | Variable<any, string>;
     id?: ValueTypes["order_by"] | undefined | null | Variable<any, string>;
+    referrer_id?:
+      | ValueTypes["order_by"]
+      | undefined
+      | null
+      | Variable<any, string>;
     username?:
       | ValueTypes["order_by"]
       | undefined
@@ -4428,6 +4446,11 @@ export type ValueTypes = {
       | undefined
       | null
       | Variable<any, string>;
+    referrer_id?:
+      | ValueTypes["order_by"]
+      | undefined
+      | null
+      | Variable<any, string>;
     username?:
       | ValueTypes["order_by"]
       | undefined
@@ -4447,6 +4470,7 @@ export type ValueTypes = {
       | undefined
       | null
       | Variable<any, string>;
+    referrer_id?: ValueTypes["uuid"] | undefined | null | Variable<any, string>;
     updated_at?:
       | ValueTypes["timestamptz"]
       | undefined
@@ -4474,6 +4498,7 @@ export type ValueTypes = {
       | null
       | Variable<any, string>;
     id?: ValueTypes["uuid"] | undefined | null | Variable<any, string>;
+    referrer_id?: ValueTypes["uuid"] | undefined | null | Variable<any, string>;
     username?: ValueTypes["citext"] | undefined | null | Variable<any, string>;
   };
   /** update columns of table "auth.users" */
@@ -10954,6 +10979,7 @@ export type ResolverInputTypes = {
     ];
     /** An object relationship */
     referrer?: ResolverInputTypes["auth_users"];
+    referrer_id?: boolean | `@${string}`;
     username?: boolean | `@${string}`;
     __typename?: boolean | `@${string}`;
   }>;
@@ -11040,6 +11066,7 @@ export type ResolverInputTypes = {
       | undefined
       | null;
     referrer?: ResolverInputTypes["auth_users_bool_exp"] | undefined | null;
+    referrer_id?: ResolverInputTypes["uuid_comparison_exp"] | undefined | null;
     username?: ResolverInputTypes["citext_comparison_exp"] | undefined | null;
   };
   /** unique or primary key constraints on table "auth.users" */
@@ -11072,6 +11099,7 @@ export type ResolverInputTypes = {
   ["auth_users_max_fields"]: AliasType<{
     created_at?: boolean | `@${string}`;
     id?: boolean | `@${string}`;
+    referrer_id?: boolean | `@${string}`;
     username?: boolean | `@${string}`;
     __typename?: boolean | `@${string}`;
   }>;
@@ -11079,12 +11107,14 @@ export type ResolverInputTypes = {
   ["auth_users_max_order_by"]: {
     created_at?: ResolverInputTypes["order_by"] | undefined | null;
     id?: ResolverInputTypes["order_by"] | undefined | null;
+    referrer_id?: ResolverInputTypes["order_by"] | undefined | null;
     username?: ResolverInputTypes["order_by"] | undefined | null;
   };
   /** aggregate min on columns */
   ["auth_users_min_fields"]: AliasType<{
     created_at?: boolean | `@${string}`;
     id?: boolean | `@${string}`;
+    referrer_id?: boolean | `@${string}`;
     username?: boolean | `@${string}`;
     __typename?: boolean | `@${string}`;
   }>;
@@ -11092,6 +11122,7 @@ export type ResolverInputTypes = {
   ["auth_users_min_order_by"]: {
     created_at?: ResolverInputTypes["order_by"] | undefined | null;
     id?: ResolverInputTypes["order_by"] | undefined | null;
+    referrer_id?: ResolverInputTypes["order_by"] | undefined | null;
     username?: ResolverInputTypes["order_by"] | undefined | null;
   };
   /** response of any mutation on the table "auth.users" */
@@ -11134,6 +11165,7 @@ export type ResolverInputTypes = {
       | undefined
       | null;
     referrer?: ResolverInputTypes["auth_users_order_by"] | undefined | null;
+    referrer_id?: ResolverInputTypes["order_by"] | undefined | null;
     username?: ResolverInputTypes["order_by"] | undefined | null;
   };
   /** primary key columns input for table: auth.users */
@@ -11145,6 +11177,7 @@ export type ResolverInputTypes = {
   /** input type for updating data in table "auth.users" */
   ["auth_users_set_input"]: {
     avatar_nft?: ResolverInputTypes["citext"] | undefined | null;
+    referrer_id?: ResolverInputTypes["uuid"] | undefined | null;
     updated_at?: ResolverInputTypes["timestamptz"] | undefined | null;
   };
   /** Streaming cursor of the table "auth_users" */
@@ -11158,6 +11191,7 @@ export type ResolverInputTypes = {
   ["auth_users_stream_cursor_value_input"]: {
     created_at?: ResolverInputTypes["timestamptz"] | undefined | null;
     id?: ResolverInputTypes["uuid"] | undefined | null;
+    referrer_id?: ResolverInputTypes["uuid"] | undefined | null;
     username?: ResolverInputTypes["citext"] | undefined | null;
   };
   /** update columns of table "auth.users" */
@@ -15926,6 +15960,7 @@ export type ModelTypes = {
     referred_users_aggregate: ModelTypes["auth_users_aggregate"];
     /** An object relationship */
     referrer?: ModelTypes["auth_users"] | undefined;
+    referrer_id?: ModelTypes["uuid"] | undefined;
     username: ModelTypes["citext"];
   };
   /** aggregated selection of "auth.users" */
@@ -15977,6 +16012,7 @@ export type ModelTypes = {
       | ModelTypes["auth_users_aggregate_bool_exp"]
       | undefined;
     referrer?: ModelTypes["auth_users_bool_exp"] | undefined;
+    referrer_id?: ModelTypes["uuid_comparison_exp"] | undefined;
     username?: ModelTypes["citext_comparison_exp"] | undefined;
   };
   ["auth_users_constraint"]: auth_users_constraint;
@@ -16000,24 +16036,28 @@ export type ModelTypes = {
   ["auth_users_max_fields"]: {
     created_at?: ModelTypes["timestamptz"] | undefined;
     id?: ModelTypes["uuid"] | undefined;
+    referrer_id?: ModelTypes["uuid"] | undefined;
     username?: ModelTypes["citext"] | undefined;
   };
   /** order by max() on columns of table "auth.users" */
   ["auth_users_max_order_by"]: {
     created_at?: ModelTypes["order_by"] | undefined;
     id?: ModelTypes["order_by"] | undefined;
+    referrer_id?: ModelTypes["order_by"] | undefined;
     username?: ModelTypes["order_by"] | undefined;
   };
   /** aggregate min on columns */
   ["auth_users_min_fields"]: {
     created_at?: ModelTypes["timestamptz"] | undefined;
     id?: ModelTypes["uuid"] | undefined;
+    referrer_id?: ModelTypes["uuid"] | undefined;
     username?: ModelTypes["citext"] | undefined;
   };
   /** order by min() on columns of table "auth.users" */
   ["auth_users_min_order_by"]: {
     created_at?: ModelTypes["order_by"] | undefined;
     id?: ModelTypes["order_by"] | undefined;
+    referrer_id?: ModelTypes["order_by"] | undefined;
     username?: ModelTypes["order_by"] | undefined;
   };
   /** response of any mutation on the table "auth.users" */
@@ -16051,6 +16091,7 @@ export type ModelTypes = {
       | ModelTypes["auth_users_aggregate_order_by"]
       | undefined;
     referrer?: ModelTypes["auth_users_order_by"] | undefined;
+    referrer_id?: ModelTypes["order_by"] | undefined;
     username?: ModelTypes["order_by"] | undefined;
   };
   /** primary key columns input for table: auth.users */
@@ -16061,6 +16102,7 @@ export type ModelTypes = {
   /** input type for updating data in table "auth.users" */
   ["auth_users_set_input"]: {
     avatar_nft?: ModelTypes["citext"] | undefined;
+    referrer_id?: ModelTypes["uuid"] | undefined;
     updated_at?: ModelTypes["timestamptz"] | undefined;
   };
   /** Streaming cursor of the table "auth_users" */
@@ -16074,6 +16116,7 @@ export type ModelTypes = {
   ["auth_users_stream_cursor_value_input"]: {
     created_at?: ModelTypes["timestamptz"] | undefined;
     id?: ModelTypes["uuid"] | undefined;
+    referrer_id?: ModelTypes["uuid"] | undefined;
     username?: ModelTypes["citext"] | undefined;
   };
   ["auth_users_update_column"]: auth_users_update_column;
@@ -18818,6 +18861,7 @@ export type GraphQLTypes = {
     referred_users_aggregate: GraphQLTypes["auth_users_aggregate"];
     /** An object relationship */
     referrer?: GraphQLTypes["auth_users"] | undefined;
+    referrer_id?: GraphQLTypes["uuid"] | undefined;
     username: GraphQLTypes["citext"];
   };
   /** aggregated selection of "auth.users" */
@@ -18871,6 +18915,7 @@ export type GraphQLTypes = {
       | GraphQLTypes["auth_users_aggregate_bool_exp"]
       | undefined;
     referrer?: GraphQLTypes["auth_users_bool_exp"] | undefined;
+    referrer_id?: GraphQLTypes["uuid_comparison_exp"] | undefined;
     username?: GraphQLTypes["citext_comparison_exp"] | undefined;
   };
   /** unique or primary key constraints on table "auth.users" */
@@ -18898,12 +18943,14 @@ export type GraphQLTypes = {
     __typename: "auth_users_max_fields";
     created_at?: GraphQLTypes["timestamptz"] | undefined;
     id?: GraphQLTypes["uuid"] | undefined;
+    referrer_id?: GraphQLTypes["uuid"] | undefined;
     username?: GraphQLTypes["citext"] | undefined;
   };
   /** order by max() on columns of table "auth.users" */
   ["auth_users_max_order_by"]: {
     created_at?: GraphQLTypes["order_by"] | undefined;
     id?: GraphQLTypes["order_by"] | undefined;
+    referrer_id?: GraphQLTypes["order_by"] | undefined;
     username?: GraphQLTypes["order_by"] | undefined;
   };
   /** aggregate min on columns */
@@ -18911,12 +18958,14 @@ export type GraphQLTypes = {
     __typename: "auth_users_min_fields";
     created_at?: GraphQLTypes["timestamptz"] | undefined;
     id?: GraphQLTypes["uuid"] | undefined;
+    referrer_id?: GraphQLTypes["uuid"] | undefined;
     username?: GraphQLTypes["citext"] | undefined;
   };
   /** order by min() on columns of table "auth.users" */
   ["auth_users_min_order_by"]: {
     created_at?: GraphQLTypes["order_by"] | undefined;
     id?: GraphQLTypes["order_by"] | undefined;
+    referrer_id?: GraphQLTypes["order_by"] | undefined;
     username?: GraphQLTypes["order_by"] | undefined;
   };
   /** response of any mutation on the table "auth.users" */
@@ -18951,6 +19000,7 @@ export type GraphQLTypes = {
       | GraphQLTypes["auth_users_aggregate_order_by"]
       | undefined;
     referrer?: GraphQLTypes["auth_users_order_by"] | undefined;
+    referrer_id?: GraphQLTypes["order_by"] | undefined;
     username?: GraphQLTypes["order_by"] | undefined;
   };
   /** primary key columns input for table: auth.users */
@@ -18962,6 +19012,7 @@ export type GraphQLTypes = {
   /** input type for updating data in table "auth.users" */
   ["auth_users_set_input"]: {
     avatar_nft?: GraphQLTypes["citext"] | undefined;
+    referrer_id?: GraphQLTypes["uuid"] | undefined;
     updated_at?: GraphQLTypes["timestamptz"] | undefined;
   };
   /** Streaming cursor of the table "auth_users" */
@@ -18975,6 +19026,7 @@ export type GraphQLTypes = {
   ["auth_users_stream_cursor_value_input"]: {
     created_at?: GraphQLTypes["timestamptz"] | undefined;
     id?: GraphQLTypes["uuid"] | undefined;
+    referrer_id?: GraphQLTypes["uuid"] | undefined;
     username?: GraphQLTypes["citext"] | undefined;
   };
   /** update columns of table "auth.users" */
@@ -20252,11 +20304,13 @@ export const enum auth_users_constraint {
 export const enum auth_users_select_column {
   created_at = "created_at",
   id = "id",
+  referrer_id = "referrer_id",
   username = "username",
 }
 /** update columns of table "auth.users" */
 export const enum auth_users_update_column {
   avatar_nft = "avatar_nft",
+  referrer_id = "referrer_id",
   updated_at = "updated_at",
 }
 /** unique or primary key constraints on table "auth.xnft_preferences" */

--- a/backend/reef/hasura/metadata/databases/default/tables/auth_users.yaml
+++ b/backend/reef/hasura/metadata/databases/default/tables/auth_users.yaml
@@ -77,6 +77,7 @@ select_permissions:
       columns:
         - created_at
         - id
+        - referrer_id
         - username
       filter: {}
       allow_aggregations: true
@@ -105,6 +106,7 @@ update_permissions:
     permission:
       columns:
         - avatar_nft
+        - referrer_id
         - updated_at
       filter: {}
       check: null

--- a/backend/reef/hasura/migrations/default/1681739214181_create_trigger_that_would_prevent_overwriting_referrer_id/down.sql
+++ b/backend/reef/hasura/migrations/default/1681739214181_create_trigger_that_would_prevent_overwriting_referrer_id/down.sql
@@ -1,0 +1,2 @@
+DROP TRIGGER check_referrer_id_update_trigger ON auth.users;
+DROP FUNCTION auth.check_referrer_id_update();

--- a/backend/reef/hasura/migrations/default/1681739214181_create_trigger_that_would_prevent_overwriting_referrer_id/up.sql
+++ b/backend/reef/hasura/migrations/default/1681739214181_create_trigger_that_would_prevent_overwriting_referrer_id/up.sql
@@ -1,0 +1,15 @@
+CREATE OR REPLACE FUNCTION auth.check_referrer_id_update() RETURNS TRIGGER AS $$
+BEGIN
+  IF (NEW.referrer_id IS NOT NULL AND OLD.referrer_id IS NOT NULL) OR (NEW.referrer_id = NEW.id) THEN
+    RAISE EXCEPTION 'referrer_id cannot be updated when it is already set or equal to user id';
+  END IF;
+
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER check_referrer_id_update_trigger
+  BEFORE UPDATE ON auth.users
+  FOR EACH ROW
+  WHEN (OLD.referrer_id IS DISTINCT FROM NEW.referrer_id)
+  EXECUTE FUNCTION auth.check_referrer_id_update();


### PR DESCRIPTION
when loading user data in backpack the `/me` endpoint is fetched

during that request, this will update the current user's referrer field IF

- they don't already have a referrer set
- it's not themselves
- it's a valid user

TODO:

- consider removing the referrer cookie once the referral is set
- (related) check 'sub-users' are still referred by the original referrer