### PR TITLE
Fix/item details page click if xnft

### DIFF
--- a/packages/app-extension/src/components/Unlocked/Nfts/Cards.tsx
+++ b/packages/app-extension/src/components/Unlocked/Nfts/Cards.tsx
@@ -188,7 +188,7 @@ export function NFTCard({
           <>
             <Button
               className={classes.button}
-              onClick={xnft ? onOpenXnft : openDetails}
+              onClick={openDetails}
               disableRipple
               style={{
                 textTransform: "none",
@@ -234,7 +234,13 @@ export function NFTCard({
                 }}
               >
                 {xnft ? (
-                  <div className={`${classes.xnftIcon} xnftIcon`}>
+                  <div
+                    className={`${classes.xnftIcon} xnftIcon`}
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      onOpenXnft(e);
+                    }}
+                  >
                     <AppsColorIcon
                       className="appIcon"
                       style={{
@@ -255,11 +261,6 @@ export function NFTCard({
                   </div>
                 ) : null}
               </div>
-              {/* {xnft ? (
-          <div className={`${classes.openXnft} openXnft`}>
-            <Typography>Open xNFT</Typography>
-          </div>
-        ) : null} */}
             </Button>
             <div
               style={{

--- a/packages/app-extension/src/components/Unlocked/Nfts/Cards.tsx
+++ b/packages/app-extension/src/components/Unlocked/Nfts/Cards.tsx
@@ -272,7 +272,7 @@ export function NFTCard({
               }}
             >
               <Typography
-                onClick={xnft ? onOpenXnft : openDetails}
+                onClick={openDetails}
                 component="div"
                 style={{
                   display: "flex",


### PR DESCRIPTION
Summary

Addresses this: https://github.com/coral-xyz/backpack/issues/3777

Attempting after making the NFT viewer experience be consistent across xNFTs and non xNFTs when clicking on them. Here's the current behavior:
- If xNFT, it will redirect you to the xNFT app if you click on the image or the nft name
- If not xNFT, it will redirect you to the item details page if you click on the image or nft name

New behavior is that it will never redirect you to the xNFT page anymore if you click on the image or nft name, making it consistent with non xNFT experience (redirecting you to the item details page).

**Users can still click on "Open xNFT" to open the xNFT application.**

Justification: If the experience is not consistent, user only choice to go to item details page become right clicking (which is not exactly intuitive, I only noticed because I read the code hahaha). And thus, experience gets actually degraded if the NFT is linked to a xNFT, as you can see item details page easily and/or set as PFP.

Test Plan

Loom showcasing the feature/new behavior: https://www.loom.com/share/a1b33a6d62594d15a0c5b22fada53203

All tests passing.
<img width="570" alt="Screenshot 2023-04-25 at 18 05 35" src="https://user-images.githubusercontent.com/18222497/234336736-db01ff13-d712-4d72-acf3-929486fe6999.png">
