### PR TITLE
Fixes friend request notification not updating

### DIFF
--- a/packages/message-sdk/src/components/ChatScreen.tsx
+++ b/packages/message-sdk/src/components/ChatScreen.tsx
@@ -1,4 +1,5 @@
 import { ChatRoom } from "@coral-xyz/chat-sdk";
+import { updateFriendshipIfExists } from "@coral-xyz/db";
 import { useFriendship, useUpdateFriendships } from "@coral-xyz/recoil";
 
 export const ChatScreen = ({
@@ -17,7 +18,7 @@ export const ChatScreen = ({
 
   if (!friendshipValue || !friendshipValue.id) {
     console.error(`Friendship not found with user ${userId} or jwt not found`);
-    return <div></div>;
+    return <div />;
   }
 
   return (
@@ -27,9 +28,9 @@ export const ChatScreen = ({
       }}
     >
       <ChatRoom
-        type={"individual"}
+        type="individual"
         remoteUsername={username}
-        username={""}
+        username=""
         roomId={friendshipValue.id?.toString()}
         userId={uuid}
         areFriends={friendshipValue.areFriends}
@@ -38,14 +39,30 @@ export const ChatScreen = ({
         blocked={friendshipValue.blocked}
         remoteRequested={friendshipValue.remoteRequested}
         spam={friendshipValue.spam}
-        setRequested={(updatedValue: boolean) =>
-          setFriendshipValue({
-            userId: userId,
-            friendshipValue: {
-              requested: updatedValue,
-            },
-          })
-        }
+        setRequested={(updatedValue: boolean) => {
+          if (!friendshipValue.remoteRequested && !friendshipValue.areFriends)
+            setFriendshipValue({
+              userId: userId,
+              friendshipValue: {
+                requested: updatedValue,
+              },
+            });
+          else if (!friendshipValue.areFriends) {
+            updateFriendshipIfExists(uuid, userId, {
+              requested: 0,
+              areFriends: 1,
+            });
+
+            setFriendshipValue({
+              userId: userId,
+              friendshipValue: {
+                areFriends: updatedValue,
+                remoteRequested: false,
+                requested: false,
+              },
+            });
+          }
+        }}
         setSpam={(updatedValue: boolean) =>
           setFriendshipValue({
             userId: userId,


### PR DESCRIPTION
# Description 

The friend request notifications weren't updating when the friend request was accepted through the chat. This was primarily because when sending or accepting a request through the chat window, only `requested` was being updated in the recoil state.

## Proposed Fix
Check if `friendshipValue.remoteRequested` is set to true for the `ChatScreen`, in that case, update state to set `areFriends` to true. If `remoteRequested` is false, then update `requested` to true.

https://user-images.githubusercontent.com/20705464/234343554-2ef92cba-679e-46f2-8915-41615f9dbf62.mov

Fixes #3710 

