### PR TITLE
fix: streched image dimensions

### DIFF
--- a/packages/app-extension/src/components/Unlocked/Nfts/Detail.tsx
+++ b/packages/app-extension/src/components/Unlocked/Nfts/Detail.tsx
@@ -233,12 +233,13 @@ function Image({ nft, style }: { nft: any; style?: any }) {
         display: "flex",
         position: "relative",
         alignItems: "center",
+        justifyContent: "center",
         ...(style || {}),
       }}
     >
       <ProxyImage
         style={{
-          width: "100%",
+          maxWidth: "100%",
           borderRadius: "8px",
         }}
         loadingStyles={{


### PR DESCRIPTION
### Summary
This PR attempts at improving, mainly, the desktop experience of using Backpack, that is currently like this: https://github.com/coral-xyz/backpack/issues/3778

It stretches small images as width: 100% is always enforced

This PR changes width: 100% to maxWidth: 100%; and center the item (which is useful if the NFT image is small, like SMB). Mobile version remains unaffected by the changes as it is a really small window, so continue to prob just use 100%.

### Implementation
https://www.loom.com/share/0364a5513b44446caad0e7c085f43050 (non-popup mode didnt record lol, i guess i need to record entire desktop for it to show).