### PR TITLE
fix popout mode not locking

### DIFF
--- a/packages/background/src/frontend/server-ui.ts
+++ b/packages/background/src/frontend/server-ui.ts
@@ -143,9 +143,6 @@ async function handle<T = any>(
 ): Promise<RpcResponse<T>> {
   logger.debug(`handle rpc ${msg.method}`, msg);
 
-  // User did something so restart the auto-lock countdown
-  ctx.backend.keyringStoreAutoLockCountdownRestart();
-
   /**
    * Enables or disables Auto-lock functionality to ensure
    * the wallet stays unlocked when an xNFT is being used
@@ -156,6 +153,12 @@ async function handle<T = any>(
     );
 
   const { method, params } = msg;
+
+  if (method !== UI_RPC_METHOD_KEYRING_STORE_STATE) {
+    // User did something so restart the auto-lock countdown
+    ctx.backend.keyringStoreAutoLockCountdownRestart();
+  }
+
   switch (method) {
     //
     // Keyring.

--- a/packages/background/src/index.ts
+++ b/packages/background/src/index.ts
@@ -37,14 +37,9 @@ export function start(cfg: Config): Background {
     chrome.runtime.onInstalled.addListener(() => {
       chrome.alarms.get("keep-alive", (a) => {
         if (!a) {
-          console.log("registering keep alive alarm");
           chrome.alarms.create("keep-alive", { periodInMinutes: 0.5 });
         }
       });
-    });
-
-    chrome.alarms.onAlarm.addListener(() => {
-      console.log("keep alive alarm");
     });
   }
 


### PR DESCRIPTION
Querying the keyring store state was preventing the extension from locking in pop out mode. Querying the keyring store state is not a user action so it should not extend the timer.