### PR TITLE
Adds username to the stickers tooltip in chatrooms

### DIFF
--- a/packages/chat-sdk/src/components/Message.tsx
+++ b/packages/chat-sdk/src/components/Message.tsx
@@ -99,12 +99,6 @@ const useStyles = makeStyles((theme: any) =>
       width: "100%",
       color: theme.custom.colors.fontColor2,
     },
-    avatarNothing: {
-      color: "transparent",
-      backgroundColor: "transparent",
-      width: theme.spacing(4),
-      height: theme.spacing(4),
-    },
     displayName: {
       fontWeight: 600,
       marginLeft: "10px",
@@ -116,12 +110,6 @@ const useStyles = makeStyles((theme: any) =>
       padding: "2px 12px",
       borderRadius: 12,
       cursor: "pointer",
-    },
-    roundBtn: {
-      padding: "2px",
-      height: 26,
-      width: 26,
-      borderRadius: "13px",
     },
     messageLeftContainer: {
       display: "flex",
@@ -329,6 +317,7 @@ export const MessageLine = (props) => {
                         <NftStickerRender
                           uuid={props.uuid}
                           mint={props.metadata?.mint}
+                          displayName={displayName}
                         />
                       </div>
                     ) : (
@@ -503,6 +492,7 @@ export const MessageLine = (props) => {
                           <NftStickerRender
                             mint={props.metadata?.mint}
                             uuid={props.uuid}
+                            displayName={displayName}
                           />
                         </div>
                       ) : props.messageKind === "media" ? (

--- a/packages/chat-sdk/src/components/NftStickerRender.tsx
+++ b/packages/chat-sdk/src/components/NftStickerRender.tsx
@@ -21,9 +21,11 @@ export const useStyles = styles((theme) => ({
 export const NftStickerRender = ({
   mint,
   uuid,
+  displayName,
 }: {
   mint: string;
   uuid: string;
+  displayName: string;
 }) => {
   const classes = useStyles();
   const { isXs } = useBreakpoints();
@@ -115,7 +117,7 @@ export const NftStickerRender = ({
               >
                 <div style={{ fontWeight: 500, fontSize: 13 }}>
                   {" "}
-                  User owns this NFT{" "}
+                  @{displayName} owns this NFT{" "}
                 </div>
               </div>
             </div>


### PR DESCRIPTION
Fixed #3843

Screenshot before fix:

![image](https://user-images.githubusercontent.com/60383339/235375821-43a113f1-f11a-48af-ac22-ee548b23dfb6.png)

Screenshot after fix:

<img width="362" alt="Screenshot 2023-05-01 at 2 07 01 AM" src="https://user-images.githubusercontent.com/60383339/235375847-f685fe05-8e91-41c5-b0bb-386904c52bf7.png">

p.s. Had to remove two style classes that are not being used to pass the es-lint check


