### PR TITLE
Fix deprecated imports

### DIFF
--- a/packages/wallet-standard/package.json
+++ b/packages/wallet-standard/package.json
@@ -26,16 +26,16 @@
         "bs58": "^4.0.1"
     },
     "devDependencies": {
-        "@solana/wallet-standard-features": "^1.0.0",
+        "@solana/wallet-standard-features": "^1.0.1",
         "@types/bs58": "^4.0.1",
         "@types/node": "^18.6.4",
         "@typescript-eslint/eslint-plugin": "^5.32.0",
         "@typescript-eslint/parser": "^5.32.0",
-        "@wallet-standard/base": "^1.0.0",
-        "@wallet-standard/features": "^1.0.0",
+        "@wallet-standard/base": "^1.0.1",
+        "@wallet-standard/features": "^1.0.3",
         "eslint": "8.22.0",
         "eslint-config-prettier": "^8.5.0",
-        "eslint-plugin-require-extensions": "^0.1.1",
+        "eslint-plugin-require-extensions": "^0.1.3",
         "prettier": "^2.7.1",
         "shx": "^0.3.4",
         "typescript": "~4.9.3"

--- a/packages/wallet-standard/src/wallet.ts
+++ b/packages/wallet-standard/src/wallet.ts
@@ -13,14 +13,14 @@ import type {
 import { Connection, PublicKey, VersionedTransaction } from '@solana/web3.js';
 import type { Wallet, WalletAccount } from '@wallet-standard/base';
 import type {
-    ConnectFeature,
-    ConnectMethod,
-    DisconnectFeature,
-    DisconnectMethod,
-    EventsFeature,
-    EventsListeners,
-    EventsNames,
-    EventsOnMethod,
+    StandardConnectFeature,
+    StandardConnectMethod,
+    StandardDisconnectFeature,
+    StandardDisconnectMethod,
+    StandardEventsFeature,
+    StandardEventsListeners,
+    StandardEventsNames,
+    StandardEventsOnMethod,
 } from '@wallet-standard/features';
 import bs58 from 'bs58';
 import { BackpackWalletAccount } from './account.js';
@@ -36,7 +36,7 @@ export type BackpackFeature = {
 };
 
 export class BackpackWallet implements Wallet {
-    readonly #listeners: { [E in EventsNames]?: EventsListeners[E][] } = {};
+    readonly #listeners: { [E in StandardEventsNames]?: StandardEventsListeners[E][] } = {};
     readonly #version = '1.0.0' as const;
     readonly #name = 'Backpack' as const;
     readonly #icon = icon;
@@ -59,9 +59,9 @@ export class BackpackWallet implements Wallet {
         return SOLANA_CHAINS.slice();
     }
 
-    get features(): ConnectFeature &
-        DisconnectFeature &
-        EventsFeature &
+    get features(): StandardConnectFeature &
+        StandardDisconnectFeature &
+        StandardEventsFeature &
         SolanaSignAndSendTransactionFeature &
         SolanaSignTransactionFeature &
         SolanaSignMessageFeature &
@@ -146,7 +146,7 @@ export class BackpackWallet implements Wallet {
         }
     };
 
-    #connect: ConnectMethod = async ({ silent } = {}) => {
+    #connect: StandardConnectMethod = async ({ silent } = {}) => {
         if (!silent && !this.#backpack.publicKey) {
             await this.#backpack.connect();
         }
@@ -156,21 +156,21 @@ export class BackpackWallet implements Wallet {
         return { accounts: this.accounts };
     };
 
-    #disconnect: DisconnectMethod = async () => {
+    #disconnect: StandardDisconnectMethod = async () => {
         await this.#backpack.disconnect();
     };
 
-    #on: EventsOnMethod = (event, listener) => {
+    #on: StandardEventsOnMethod = (event, listener) => {
         this.#listeners[event]?.push(listener) || (this.#listeners[event] = [listener]);
         return (): void => this.#off(event, listener);
     };
 
-    #emit<E extends EventsNames>(event: E, ...args: Parameters<EventsListeners[E]>): void {
+    #emit<E extends StandardEventsNames>(event: E, ...args: Parameters<StandardEventsListeners[E]>): void {
         // eslint-disable-next-line prefer-spread
         this.#listeners[event]?.forEach((listener) => listener.apply(null, args));
     }
 
-    #off<E extends EventsNames>(event: E, listener: EventsListeners[E]): void {
+    #off<E extends StandardEventsNames>(event: E, listener: StandardEventsListeners[E]): void {
         this.#listeners[event] = this.#listeners[event]?.filter((existingListener) => listener !== existingListener);
     }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -4144,18 +4144,18 @@ __metadata:
   resolution: "@coral-xyz/wallet-standard@workspace:packages/wallet-standard"
   dependencies:
     "@coral-xyz/provider-core": "*"
-    "@solana/wallet-standard-features": ^1.0.0
+    "@solana/wallet-standard-features": ^1.0.1
     "@solana/web3.js": ^1.63.1
     "@types/bs58": ^4.0.1
     "@types/node": ^18.6.4
     "@typescript-eslint/eslint-plugin": ^5.32.0
     "@typescript-eslint/parser": ^5.32.0
-    "@wallet-standard/base": ^1.0.0
-    "@wallet-standard/features": ^1.0.0
+    "@wallet-standard/base": ^1.0.1
+    "@wallet-standard/features": ^1.0.3
     bs58: ^4.0.1
     eslint: 8.22.0
     eslint-config-prettier: ^8.5.0
-    eslint-plugin-require-extensions: ^0.1.1
+    eslint-plugin-require-extensions: ^0.1.3
     prettier: ^2.7.1
     shx: ^0.3.4
     typescript: ~4.9.3
@@ -14371,7 +14371,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@wallet-standard/features@npm:^1.0.0, @wallet-standard/features@npm:^1.0.3":
+"@wallet-standard/features@npm:^1.0.3":
   version: 1.0.3
   resolution: "@wallet-standard/features@npm:1.0.3"
   dependencies:
@@ -22122,12 +22122,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"eslint-plugin-require-extensions@npm:^0.1.1":
-  version: 0.1.2
-  resolution: "eslint-plugin-require-extensions@npm:0.1.2"
+"eslint-plugin-require-extensions@npm:^0.1.3":
+  version: 0.1.3
+  resolution: "eslint-plugin-require-extensions@npm:0.1.3"
   peerDependencies:
     eslint: "*"
-  checksum: 68616c4e7ed3588f5ee1306c40b6e88a9947a5bcfea41a8287a0087ce801615bcc00525d828d0800834bd77d66b56c55507623bf5ba92fb77ff88fbd30bed4d2
+  checksum: 698c2e92b0309b8646f734f9c4b95d6cd9ff06a408187fe9ef79b3415c4a444b7e818a1cbb8ae820795961d9de54d2af42c77cb298450518c206f89513305932
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Some Wallet Standard feature types were renamed. This updates to the latest versions and uses the non-deprecated imports. There are no functional or runtime changes.