### PR TITLE
fix: empty nft screen loads before nfts load

### DIFF
--- a/packages/recoil/src/atoms/solana/nft.tsx
+++ b/packages/recoil/src/atoms/solana/nft.tsx
@@ -16,6 +16,7 @@ import { PublicKey } from "@solana/web3.js";
 import { selectorFamily } from "recoil";
 
 import { equalSelectorFamily } from "../../equals";
+import { isPromise } from "../../utils";
 
 import { customSplTokenAccounts } from "./token";
 import { anchorContext } from "./wallet";
@@ -86,8 +87,13 @@ const solanaMetadataMap = selectorFamily<
           publicKey,
           metadata: nftMap,
         };
-      } catch (e) {
-        console.error(e);
+      } catch (errorOrPromise) {
+        if (isPromise(errorOrPromise)) {
+          const promise = errorOrPromise;
+          throw promise;
+        }
+        const error = errorOrPromise;
+        console.error(error);
         return null;
       }
     },

--- a/packages/recoil/src/utils.ts
+++ b/packages/recoil/src/utils.ts
@@ -1,0 +1,3 @@
+export function isPromise(p: any): p is Promise<any> {
+  return !!p && typeof p.then === "function";
+}


### PR DESCRIPTION
During the async data fetch for the `customSplTokenAccounts` atom, the selector `solanaMetadataMap` was not able to propagate the "loading" state when the request was still evaluated as pending. This is because the exception (thrown as an unfulfilled Promise) was caught and returned as a null value, causing recoil to set the loadable state of the selector as "hasValue" instead of "loading". As a result, the component displayed an empty state before recoil successfully retried the evaluation.

To address this, a solution is to throw the exception if it is a promise, so that it propagates up the state to the component as "loading". Open to suggestions on how to improve this as this is my first PR!


https://github.com/coral-xyz/backpack/assets/33209733/18e6c49d-9376-4ed2-b39d-36cbad3de760


Closes #3775 