### PR TITLE
use description and version from package.json

### DIFF
--- a/packages/app-extension/webpack.config.js
+++ b/packages/app-extension/webpack.config.js
@@ -6,6 +6,7 @@ const MiniCssExtractPlugin = require("mini-css-extract-plugin");
 const path = require("path");
 const ReactRefreshWebpackPlugin = require("@pmmmwh/react-refresh-webpack-plugin");
 const fs = require("fs");
+const { browserslist, description, version } = require("./package.json");
 
 const NODE_ENV = process.env.NODE_ENV || "development";
 const EXTENSION_NAME =
@@ -47,7 +48,7 @@ const swcLoaderConfiguration = {
     options: {
       // parseMap: true, // required when using with babel-loader
       env: {
-        targets: require("./package.json").browserslist,
+        targets: browserslist,
       },
       sourceMap: isDevelopment,
       jsc: {
@@ -250,8 +251,8 @@ const options = {
             return Buffer.from(
               JSON.stringify(
                 {
-                  description: process.env.npm_package_description,
-                  version: process.env.npm_package_version,
+                  description,
+                  version,
                   name: EXTENSION_NAME,
                   ...JSON.parse(content.toString()),
                 },


### PR DESCRIPTION
injects the description and version specified in app-extension/package.json into the manifest.json

it was using `process.env.npm_package_description` before but I don't think that works with monorepos

<img width="838" alt="Screenshot 2023-05-11 at 15 14 08" src="https://github.com/coral-xyz/backpack/assets/101902546/859a990a-7379-4853-ad22-c76c27ca582b">
