### PR TITLE
feat: support token-2022 accounts, transfers, and burns

### DIFF
--- a/packages/app-extension/src/components/Unlocked/Nfts/NftDetail.tsx
+++ b/packages/app-extension/src/components/Unlocked/Nfts/NftDetail.tsx
@@ -598,6 +598,7 @@ function BurnConfirmationCard({
       const _signature = await Solana.burnAndCloseNft(solanaCtx, {
         solDestination: solanaCtx.walletPublicKey,
         mint: new PublicKey(nft.mint.toString()),
+        programId: new PublicKey(nft.programId.toString()),
         amount,
       });
       setSignature(_signature);

--- a/packages/background/src/backend/solana-connection.ts
+++ b/packages/background/src/backend/solana-connection.ts
@@ -2,7 +2,7 @@ import type {
   CustomSplTokenAccountsResponse,
   EventEmitter,
   Notification,
-  SolanaTokenAccountWithKeyString,
+  SolanaTokenAccountWithKeyAndProgramIdString,
   SplNftMetadataString,
   TokenMetadataString,
 } from "@coral-xyz/common";
@@ -369,7 +369,7 @@ export class SolanaConnectionBackend {
   }
 
   async customSplMetadataUri(
-    tokens: Array<SolanaTokenAccountWithKeyString>,
+    tokens: Array<SolanaTokenAccountWithKeyAndProgramIdString>,
     tokenMetadata: Array<TokenMetadataString | null>
   ): Promise<Array<[string, SplNftMetadataString]>> {
     const key = JSON.stringify({

--- a/packages/background/src/frontend/solana-connection.ts
+++ b/packages/background/src/frontend/solana-connection.ts
@@ -5,7 +5,7 @@ import type {
   RpcRequest,
   RpcResponse,
   SerializedTokenAccountsFilter,
-  SolanaTokenAccountWithKeyString,
+  SolanaTokenAccountWithKeyAndProgramIdString,
   TokenMetadataString,
 } from "@coral-xyz/common";
 import {
@@ -339,7 +339,7 @@ async function handleCustomSplTokenAccounts(
 
 async function handleCustomSplMetadataUri(
   ctx: Context<SolanaConnectionBackend>,
-  nftTokens: Array<SolanaTokenAccountWithKeyString>,
+  nftTokens: Array<SolanaTokenAccountWithKeyAndProgramIdString>,
   nftTokenMetadata: Array<TokenMetadataString | null>
 ) {
   const resp = await ctx.backend.customSplMetadataUri(

--- a/packages/common/src/solana/background-connection.ts
+++ b/packages/common/src/solana/background-connection.ts
@@ -108,8 +108,8 @@ import type {
 } from "./programs/token";
 import { addressLookupTableAccountParser } from "./rpc-helpers";
 import type {
-  SolanaTokenAccountWithKey,
-  SolanaTokenAccountWithKeyString,
+  SolanaTokenAccountWithKeyAndProgramId,
+  SolanaTokenAccountWithKeyAndProgramIdString,
   SplNftMetadataString,
   TokenMetadata,
   TokenMetadataString,
@@ -133,7 +133,7 @@ export class BackgroundSolanaConnection extends Connection {
   }
 
   async customSplMetadataUri(
-    tokens: Array<SolanaTokenAccountWithKeyString>,
+    tokens: Array<SolanaTokenAccountWithKeyAndProgramIdString>,
     tokenMetadata: Array<TokenMetadataString | null>
   ): Promise<Array<[string, SplNftMetadataString]>> {
     return await this._backgroundClient.request({
@@ -223,12 +223,13 @@ export class BackgroundSolanaConnection extends Connection {
   }
 
   static solanaTokenAccountWithKeyToJson(
-    t: SolanaTokenAccountWithKey
-  ) /* : SolanaTokenAccountWithKeyString */ {
+    t: SolanaTokenAccountWithKeyAndProgramId
+  ) /* : SolanaTokenAccountWithKeyAndProgramIdString */ {
     return {
       ...t,
       mint: t.mint.toString(),
       key: t.key.toString(),
+      programId: t.programId.toString(),
       amount: t.amount.toString(),
       delegate: t.delegate?.toString(),
       delegatedAmount: t.delegatedAmount.toString(),

--- a/packages/common/src/solana/index.ts
+++ b/packages/common/src/solana/index.ts
@@ -95,7 +95,7 @@ export class Solana {
     ctx: SolanaContext,
     req: BurnNftRequest
   ): Promise<string> {
-    const { solDestination, mint } = req;
+    const { solDestination, mint, programId } = req;
     const { walletPublicKey, tokenInterface, commitment } = ctx;
 
     const provider = tokenInterface.provider;
@@ -104,7 +104,7 @@ export class Solana {
     const tx = new Transaction();
     tx.add(
       await tokenInterface
-        .withProgramId(TOKEN_PROGRAM_ID)
+        .withProgramId(programId)
         .methods.burn(new BN(req.amount ?? 1))
         .accounts({
           source: associatedToken,
@@ -115,7 +115,7 @@ export class Solana {
     );
     tx.add(
       await tokenInterface
-        .withProgramId(TOKEN_PROGRAM_ID)
+        .withProgramId(programId)
         .methods.closeAccount()
         .accounts({
           account: associatedToken,
@@ -142,7 +142,7 @@ export class Solana {
     req: TransferTokenRequest
   ): Promise<string> {
     const { walletPublicKey, registry, tokenInterface, commitment } = ctx;
-    const { mint, destination, amount } = req;
+    const { mint, programId, destination, amount } = req;
 
     const decimals = (() => {
       if (req.decimals !== undefined) {
@@ -199,7 +199,7 @@ export class Solana {
     }
 
     const tx = await tokenInterface
-      .withProgramId(TOKEN_PROGRAM_ID)
+      .withProgramId(programId)
       .methods.transferChecked(nativeAmount, decimals)
       .accounts({
         source: sourceAta,
@@ -228,7 +228,7 @@ export class Solana {
     req: TransferTokenRequest
   ): Promise<string> {
     const { walletPublicKey, tokenInterface, commitment } = ctx;
-    const { mint, destination } = req;
+    const { mint, programId, destination } = req;
 
     const destinationAta = associatedTokenAddress(mint, destination);
     const sourceAta = associatedTokenAddress(mint, walletPublicKey);
@@ -409,7 +409,7 @@ export class Solana {
     req: TransferTokenRequest
   ): Promise<string> {
     const { walletPublicKey, tokenInterface, commitment } = solanaCtx;
-    const { amount, mint, destination: destinationOwner } = req;
+    const { amount, mint, programId, destination: destinationOwner } = req;
 
     const source = req.source ?? associatedTokenAddress(mint, walletPublicKey);
     const destinationAta = associatedTokenAddress(mint, destinationOwner);
@@ -740,6 +740,7 @@ export type TransferTokenRequest = {
   // SOL address.
   destination: PublicKey;
   mint: PublicKey;
+  programId: PublicKey;
   amount: number;
   decimals?: number;
   // Source token addess. If not provided, an ATA will
@@ -774,5 +775,6 @@ export type DeleteInstallRequest = {
 export type BurnNftRequest = {
   solDestination: PublicKey;
   mint: PublicKey;
+  programId: PublicKey;
   amount?: number;
 };

--- a/packages/common/src/solana/programs/token.ts
+++ b/packages/common/src/solana/programs/token.ts
@@ -124,11 +124,11 @@ export async function customSplTokenAccounts(
     fetchTokens(publicKey, tokenInterface.withProgramId(TOKEN_PROGRAM_ID)),
     fetchTokens(publicKey, tokenInterface.withProgramId(TOKEN_2022_PROGRAM_ID)),
   ]);
-  const chain = function* (...iters) {
+  const chainIter = function* (...iters) {
     for (let it of iters) yield* it;
   };
   const tokenAccountsArray = Array.from(
-    chain(tokenAccounts.values(), token2022Accounts.values())
+    chainIter(tokenAccounts.values(), token2022Accounts.values())
   );
 
   //

--- a/packages/common/src/solana/programs/token.ts
+++ b/packages/common/src/solana/programs/token.ts
@@ -93,10 +93,11 @@ export class TokenInterface {
 
 export function associatedTokenAddress(
   mint: PublicKey,
-  wallet: PublicKey
+  wallet: PublicKey,
+  programId: PublicKey
 ): PublicKey {
   return anchor.utils.publicKey.findProgramAddressSync(
-    [wallet.toBuffer(), TOKEN_PROGRAM_ID.toBuffer(), mint.toBuffer()],
+    [wallet.toBuffer(), programId.toBuffer(), mint.toBuffer()],
     ASSOCIATED_TOKEN_PROGRAM_ID
   )[0];
 }

--- a/packages/common/src/solana/send-helpers.ts
+++ b/packages/common/src/solana/send-helpers.ts
@@ -16,12 +16,12 @@ import type { AccountInfo, Connection } from "@solana/web3.js";
 import { PublicKey } from "@solana/web3.js";
 
 import { metadataAddress } from "./programs/token";
-import type { RawMintString } from "./types";
+import type { RawMintWithProgramIdString } from "./types";
 
 export const isCardinalWrappedToken = async (
   connection: Connection,
   mintId: PublicKey,
-  mintInfo: RawMintString
+  mintInfo: RawMintWithProgramIdString
 ) => {
   const mintManagerId = (
     await programs.tokenManager.pda.findMintManagerId(mintId)
@@ -58,7 +58,7 @@ export const isCardinalWrappedToken = async (
 
 export const isCreatorStandardToken = (
   mintId: PublicKey,
-  mintInfo: RawMintString
+  mintInfo: RawMintWithProgramIdString
 ) => {
   const mintManagerId = findMintManagerId(mintId);
   // not network calls involved we can assume this token was created properly if the mint and freeze authority match
@@ -73,7 +73,7 @@ export const isCreatorStandardToken = (
 export async function isOpenCreatorProtocol(
   connection: Connection,
   mintId: PublicKey,
-  mintInfo: RawMintString
+  mintInfo: RawMintWithProgramIdString
 ): Promise<MintState | null> {
   const mintStatePk = findMintStatePk(mintId);
   const accountInfo = (await connection.getAccountInfo(

--- a/packages/common/src/solana/types.ts
+++ b/packages/common/src/solana/types.ts
@@ -6,12 +6,14 @@ import { PublicKey } from "@solana/web3.js";
 
 export type SolanaTokenAccount = IdlAccounts<SplToken>["token"];
 
-export interface SolanaTokenAccountWithKey extends SolanaTokenAccount {
+export interface SolanaTokenAccountWithKeyAndProgramId
+  extends SolanaTokenAccount {
   key: PublicKey;
+  programId: PublicKey;
 }
 
-export type SolanaTokenAccountWithKeySerializable = Omit<
-  SolanaTokenAccountWithKey,
+export type SolanaTokenAccountWithKeyandProgramIdSerializable = Omit<
+  SolanaTokenAccountWithKeyAndProgramId,
   "amount"
 > & {
   amount: string;
@@ -40,10 +42,18 @@ export type ReplaceTypes<ObjType extends object, FromType, ToType> = {
   [KeyType in keyof ObjType]: ReplaceType<ObjType[KeyType], FromType, ToType>;
 };
 
-export type RawMintString = ReplaceTypes<RawMint, PublicKey, string>;
+export interface RawMintWithProgramId extends RawMint {
+  programId: PublicKey;
+}
 
-export type SolanaTokenAccountWithKeyString = ReplaceTypes<
-  SolanaTokenAccountWithKey,
+export type RawMintWithProgramIdString = ReplaceTypes<
+  RawMintWithProgramId,
+  PublicKey,
+  string
+>;
+
+export type SolanaTokenAccountWithKeyAndProgramIdString = ReplaceTypes<
+  SolanaTokenAccountWithKeyAndProgramId,
   PublicKey,
   string
 >;

--- a/packages/recoil/src/atoms/solana/nft.tsx
+++ b/packages/recoil/src/atoms/solana/nft.tsx
@@ -1,7 +1,7 @@
 import type {
   Nft,
   NftCollection,
-  SolanaTokenAccountWithKeyString,
+  SolanaTokenAccountWithKeyAndProgramIdString,
   TokenMetadataString,
 } from "@coral-xyz/common";
 import {
@@ -266,7 +266,7 @@ type MetadataMap = {
   metadata: {
     [metadataPublicKey: string]: {
       metadataPublicKey: string;
-      nftToken: SolanaTokenAccountWithKeyString;
+      nftToken: SolanaTokenAccountWithKeyAndProgramIdString;
       nftTokenMetadata: TokenMetadataString | null;
     };
   };

--- a/packages/recoil/src/atoms/solana/token.tsx
+++ b/packages/recoil/src/atoms/solana/token.tsx
@@ -1,6 +1,6 @@
 import type {
-  RawMintString,
-  SolanaTokenAccountWithKeyString,
+  RawMintWithProgramIdString,
+  SolanaTokenAccountWithKeyAndProgramIdString,
   SplNftMetadataString,
   TokenMetadataString,
 } from "@coral-xyz/common";
@@ -41,13 +41,13 @@ export const customSplTokenAccounts = atomFamily({
         get,
       }): Promise<{
         publicKey: string;
-        splTokenMints: Map<string, RawMintString | null>;
+        splTokenMints: Map<string, RawMintWithProgramIdString | null>;
         nfts: {
-          nftTokens: Array<SolanaTokenAccountWithKeyString>;
+          nftTokens: Array<SolanaTokenAccountWithKeyAndProgramIdString>;
           nftTokenMetadata: Array<TokenMetadataString | null>;
         };
         fts: {
-          fungibleTokens: Array<SolanaTokenAccountWithKeyString>;
+          fungibleTokens: Array<SolanaTokenAccountWithKeyAndProgramIdString>;
           fungibleTokenMetadata: Array<TokenMetadataString | null>;
         };
       }> => {
@@ -87,7 +87,7 @@ export const customSplTokenAccounts = atomFamily({
  * Loads all the token accounts for fungible tokens for the given public key.
  */
 export const solanaFungibleTokenAccounts = selectorFamily<
-  Map<string, SolanaTokenAccountWithKeyString>,
+  Map<string, SolanaTokenAccountWithKeyAndProgramIdString>,
   {
     connectionUrl: string;
     publicKey: string;
@@ -107,7 +107,7 @@ export const solanaFungibleTokenAccounts = selectorFamily<
  * key.
  */
 export const solanaNftTokenAccounts = selectorFamily<
-  Map<string, SolanaTokenAccountWithKeyString>,
+  Map<string, SolanaTokenAccountWithKeyAndProgramIdString>,
   {
     connectionUrl: string;
     publicKey: string;
@@ -194,7 +194,7 @@ export const solanaFungibleTokenUriData = selectorFamily<
  * Store the info from the SPL Token Account owned by the connected wallet.
  */
 export const solanaTokenAccountsMap = selectorFamily<
-  SolanaTokenAccountWithKeyString | undefined,
+  SolanaTokenAccountWithKeyAndProgramIdString | undefined,
   {
     tokenAddress: string;
     publicKey: string;
@@ -327,7 +327,7 @@ export const solanaFungibleTokenNativeBalance = selectorFamily<
  * Returns all mints--fungible and non-fungible.
  */
 export const solanaTokenMint = selectorFamily<
-  /*RawMintString | null*/ any,
+  /*RawMintWithProgramIdString | null*/ any,
   { tokenAddress: string; publicKey: string }
 >({
   key: "solanaTokenMint",

--- a/packages/recoil/src/atoms/solana/wallet.tsx
+++ b/packages/recoil/src/atoms/solana/wallet.tsx
@@ -1,5 +1,5 @@
-import { BackgroundSolanaConnection } from "@coral-xyz/common";
-import { AnchorProvider, Spl } from "@project-serum/anchor";
+import { BackgroundSolanaConnection, TokenInterface } from "@coral-xyz/common";
+import { AnchorProvider } from "@project-serum/anchor";
 import { Keypair } from "@solana/web3.js";
 import { selector } from "recoil";
 
@@ -27,12 +27,12 @@ export const anchorContext = selector({
       commitment: _commitment,
       preflightCommitment: _commitment,
     });
-    const tokenClient = Spl.token(provider);
+    const tokenInterface = new TokenInterface(provider);
     return {
       connection,
       connectionUrl: _connectionUrl,
       provider,
-      tokenClient,
+      tokenInterface,
     };
   },
 });

--- a/packages/recoil/src/hooks/solana/index.tsx
+++ b/packages/recoil/src/hooks/solana/index.tsx
@@ -1,4 +1,4 @@
-import type { RawMintString } from "@coral-xyz/common";
+import type { RawMintWithProgramIdString } from "@coral-xyz/common";
 import { useRecoilValue } from "recoil";
 
 import * as atoms from "../../atoms";
@@ -20,6 +20,6 @@ export function useSolanaTokenMint({
 }: {
   publicKey: string;
   tokenAddress: string;
-}): RawMintString {
+}): RawMintWithProgramIdString {
   return useRecoilValue(atoms.solanaTokenMint({ tokenAddress, publicKey }));
 }

--- a/packages/recoil/src/hooks/solana/useSolanaConnection.tsx
+++ b/packages/recoil/src/hooks/solana/useSolanaConnection.tsx
@@ -25,13 +25,13 @@ export function useAnchorContextLoadable(): Loadable<any> {
 
 export function useSolanaCtx(): SolanaContext {
   const { publicKey } = useActiveSolanaWallet();
-  const { tokenClient, provider } = useAnchorContext();
+  const { tokenInterface, provider } = useAnchorContext();
   const registry = useSplTokenRegistry();
   const commitment = useSolanaCommitment();
   const backgroundClient = useBackgroundClient();
   return {
     walletPublicKey: new PublicKey(publicKey),
-    tokenClient,
+    tokenInterface,
     registry,
     commitment,
     backgroundClient,

--- a/packages/recoil/src/hooks/solana/useSolanaTransaction.tsx
+++ b/packages/recoil/src/hooks/solana/useSolanaTransaction.tsx
@@ -71,6 +71,7 @@ export function useSolanaTransaction({
         txSig = await Solana.transferProgrammableNft(solanaCtx, {
           destination: new PublicKey(destinationAddress),
           mint: new PublicKey(token.mint!),
+          programId: new PublicKey(token.programId!),
           amount: amount.toNumber(),
           decimals: token.decimals,
           source: new PublicKey(token.address),
@@ -90,6 +91,7 @@ export function useSolanaTransaction({
               destination: new PublicKey(destinationAddress),
               amount: amount.toNumber(),
               mint: new PublicKey(token.mint!),
+              programId: new PublicKey(token.programId!),
             },
             ocpMintState
           );
@@ -97,6 +99,7 @@ export function useSolanaTransaction({
           txSig = await Solana.transferCreatorStandardToken(solanaCtx, {
             destination: new PublicKey(destinationAddress),
             mint: new PublicKey(token.mint!),
+            programId: new PublicKey(token.programId!),
             amount: amount.toNumber(),
             decimals: token.decimals,
           });
@@ -106,6 +109,7 @@ export function useSolanaTransaction({
           txSig = await Solana.transferCardinalManagedToken(solanaCtx, {
             destination: new PublicKey(destinationAddress),
             mint: new PublicKey(token.mint!),
+            programId: new PublicKey(token.programId!),
             amount: amount.toNumber(),
             decimals: token.decimals,
           });
@@ -113,6 +117,7 @@ export function useSolanaTransaction({
           txSig = await Solana.transferToken(solanaCtx, {
             destination: new PublicKey(destinationAddress),
             mint: new PublicKey(token.mint!),
+            programId: new PublicKey(token.programId!),
             amount: amount.toNumber(),
             decimals: token.decimals,
           });

--- a/packages/recoil/src/hooks/solana/useSolanaTransaction.tsx
+++ b/packages/recoil/src/hooks/solana/useSolanaTransaction.tsx
@@ -71,7 +71,7 @@ export function useSolanaTransaction({
         txSig = await Solana.transferProgrammableNft(solanaCtx, {
           destination: new PublicKey(destinationAddress),
           mint: new PublicKey(token.mint!),
-          programId: new PublicKey(token.programId!),
+          programId: new PublicKey(mintInfo.programId!),
           amount: amount.toNumber(),
           decimals: token.decimals,
           source: new PublicKey(token.address),
@@ -91,7 +91,7 @@ export function useSolanaTransaction({
               destination: new PublicKey(destinationAddress),
               amount: amount.toNumber(),
               mint: new PublicKey(token.mint!),
-              programId: new PublicKey(token.programId!),
+              programId: new PublicKey(mintInfo.programId!),
             },
             ocpMintState
           );
@@ -99,7 +99,7 @@ export function useSolanaTransaction({
           txSig = await Solana.transferCreatorStandardToken(solanaCtx, {
             destination: new PublicKey(destinationAddress),
             mint: new PublicKey(token.mint!),
-            programId: new PublicKey(token.programId!),
+            programId: new PublicKey(mintInfo.programId!),
             amount: amount.toNumber(),
             decimals: token.decimals,
           });
@@ -109,7 +109,7 @@ export function useSolanaTransaction({
           txSig = await Solana.transferCardinalManagedToken(solanaCtx, {
             destination: new PublicKey(destinationAddress),
             mint: new PublicKey(token.mint!),
-            programId: new PublicKey(token.programId!),
+            programId: new PublicKey(mintInfo.programId!),
             amount: amount.toNumber(),
             decimals: token.decimals,
           });
@@ -117,7 +117,7 @@ export function useSolanaTransaction({
           txSig = await Solana.transferToken(solanaCtx, {
             destination: new PublicKey(destinationAddress),
             mint: new PublicKey(token.mint!),
-            programId: new PublicKey(token.programId!),
+            programId: new PublicKey(mintInfo.programId!),
             amount: amount.toNumber(),
             decimals: token.decimals,
           });


### PR DESCRIPTION
#### Problem

Token-2022 has been out for some time, but backpack doesn't support it.

#### Solution

Add basic support for Token-2022! This PR boils down to a few things:

* fetch accounts for token-2022
* store the program id on accounts and mints after they're fetched
* use the program id for ATA derivation, transfers, and burns

Since the `Program` type from Anchor doesn't allow modifying the program id, I've gone with a `TokenInterface` intermediate type, which contains a `withProgramId` function, to expose a `Program<SplToken>` with the correct program id. This may be a little heavy, so let me know if you prefer something else. You could also modify instructions as they're created, but going through the `TokenInterface` makes it hard to get wrong, which I wanted to prioritize.

Note that this PR doesn't touch wrapped SOL at all. There is a wrapped SOL mint on token-2022, but this keeps all wrapped SOL on the old token program for now.

Also, I noticed a bug with burning NFTs. My test account wasn't an ATA and failed because the burn function assumed that the source was an ATA, so I added the `source` parameter in the burn request. If you prefer to have that work done separately, let me know.

Edit: I've also written a little guide at https://github.com/solana-labs/solana-program-library/pull/4325 if you need more info