### PR TITLE
fix checking versioned transaction status

### DIFF
--- a/packages/app-extension/src/components/Unlocked/Nfts/NftDetail.tsx
+++ b/packages/app-extension/src/components/Unlocked/Nfts/NftDetail.tsx
@@ -621,10 +621,7 @@ function BurnConfirmationCard({
         await confirmTransaction(
           solanaCtx.connection,
           _signature,
-          solanaCtx.commitment !== "confirmed" &&
-            solanaCtx.commitment !== "finalized"
-            ? "confirmed"
-            : solanaCtx.commitment
+          solanaCtx.commitment === "finalized" ? "finalized" : "confirmed"
         );
         setState("confirmed");
         if (onComplete) onComplete();

--- a/packages/app-extension/src/components/Unlocked/Settings/Xnfts/Detail.tsx
+++ b/packages/app-extension/src/components/Unlocked/Settings/Xnfts/Detail.tsx
@@ -187,16 +187,18 @@ export const XnftDetail: React.FC<{ xnft: any }> = ({ xnft }) => {
             marginBottom: "15px",
           }}
         />
-        {xnft.metadata?.xnft ? <Typography
-          sx={{
+        {xnft.metadata?.xnft ? (
+          <Typography
+            sx={{
               color: theme.custom.colors.fontColor,
               fontSize: "12px",
               marginBottom: "15px",
               textAlign: "center",
             }}
           >
-          v{xnft.metadata.xnft.version}
-        </Typography> : null}
+            v{xnft.metadata.xnft.version}
+          </Typography>
+        ) : null}
         <Button
           disabled={isDisabled}
           disableRipple
@@ -304,9 +306,7 @@ const UninstallConfirmationCard = ({ xnft }: { xnft: any }) => {
       await confirmTransaction(
         ctx.connection,
         txSig,
-        ctx.commitment !== "confirmed" && ctx.commitment !== "finalized"
-          ? "confirmed"
-          : ctx.commitment
+        ctx.commitment === "finalized" ? "finalized" : "confirmed"
       );
 
       setCardType("complete");

--- a/packages/background/src/frontend/solana-connection.ts
+++ b/packages/background/src/frontend/solana-connection.ts
@@ -1,6 +1,5 @@
 import type {
   Context,
-  CustomSplTokenAccountsResponse,
   EventEmitter,
   RpcRequest,
   RpcResponse,
@@ -54,12 +53,11 @@ import type {
   GetAccountInfoConfig,
   GetParsedProgramAccountsConfig,
   GetProgramAccountsConfig,
-  MessageArgs,
+  GetVersionedTransactionConfig,
   SendOptions,
   TransactionSignature,
 } from "@solana/web3.js";
-import { Message, PublicKey, VersionedMessage } from "@solana/web3.js";
-import * as bs58 from "bs58";
+import { PublicKey, VersionedMessage } from "@solana/web3.js";
 import { decode } from "bs58";
 
 import type { SolanaConnectionBackend } from "../backend/solana-connection";
@@ -269,7 +267,7 @@ async function handleConfirmTransaction(
   signature:
     | BlockheightBasedTransactionConfirmationStrategy
     | TransactionSignature,
-  commitment?: Commitment
+  commitmentOrConfig?: GetVersionedTransactionConfig | Finality
 ) {
   if (typeof signature === "string") {
     const { blockhash, lastValidBlockHeight } =
@@ -281,7 +279,10 @@ async function handleConfirmTransaction(
     };
   }
 
-  const resp = await ctx.backend.confirmTransaction(signature, commitment);
+  const resp = await ctx.backend.confirmTransaction(
+    signature,
+    commitmentOrConfig
+  );
   return [resp];
 }
 
@@ -314,18 +315,24 @@ async function handleGetConfirmedSignaturesForAddress2(
 async function handleGetParsedTransaction(
   ctx: Context<SolanaConnectionBackend>,
   signature: TransactionSignature,
-  commitment?: Finality
+  commitmentOrConfig?: GetVersionedTransactionConfig | Finality
 ) {
-  const resp = await ctx.backend.getParsedTransaction(signature, commitment);
+  const resp = await ctx.backend.getParsedTransaction(
+    signature,
+    commitmentOrConfig
+  );
   return [resp];
 }
 
 async function handleGetParsedTransactions(
   ctx: Context<SolanaConnectionBackend>,
   signatures: TransactionSignature[],
-  commitment?: Finality
+  commitmentOrConfig?: GetVersionedTransactionConfig | Finality
 ) {
-  const resp = await ctx.backend.getParsedTransactions(signatures, commitment);
+  const resp = await ctx.backend.getParsedTransactions(
+    signatures,
+    commitmentOrConfig
+  );
   return [resp];
 }
 

--- a/packages/chat-sdk/src/components/SimpleTransaction.tsx
+++ b/packages/chat-sdk/src/components/SimpleTransaction.tsx
@@ -1,4 +1,4 @@
-import React, { Suspense, useEffect, useState } from "react";
+import { Suspense, useEffect, useState } from "react";
 import { Blockchain } from "@coral-xyz/common";
 import {
   SOL_LOGO_URI,
@@ -105,21 +105,21 @@ export const SimpleTransaction = ({
             ? "You Received"
             : `You sent @${remoteUsername}`}
         </div>
-        {!loading && (
+        {!loading ? (
           <>
-            {tokenAddress && (
+            {tokenAddress ? (
               <ParsedTransactionWithSuspense
                 message={message}
                 tokenAddress={tokenAddress}
                 amount={amount}
               />
-            )}
-            {!tokenAddress && (
+            ) : null}
+            {!tokenAddress ? (
               <ParsedSolTransaction message={message} amount={amount} />
-            )}
+            ) : null}
           </>
-        )}
-        {loading && <TxSkeleton />}
+        ) : null}
+        {loading ? <TxSkeleton /> : null}
         <div
           style={{
             display: "flex",
@@ -231,11 +231,11 @@ function ParsedTransaction({ tokenAddress, amount, message }) {
         <div style={{ fontSize: 30, display: "flex" }}>
           <div>{amount.toFixed(2)}</div>
         </div>
-        {message && (
+        {message ? (
           <div style={{ marginBottom: 10, color: theme.custom.colors.icon }}>
             {message}
           </div>
-        )}
+        ) : null}
         <div
           style={{
             display: "flex",
@@ -269,11 +269,11 @@ function ParsedSolTransaction({ amount, message }) {
         <div style={{ fontSize: 30, display: "flex" }}>
           <div>{amount.toFixed(2)}</div>
         </div>
-        {message && (
+        {message ? (
           <div style={{ marginBottom: 10, color: theme.custom.colors.icon }}>
             {message}
           </div>
-        )}
+        ) : null}
         <div
           style={{
             display: "flex",

--- a/packages/common/src/solana/background-connection.ts
+++ b/packages/common/src/solana/background-connection.ts
@@ -28,6 +28,7 @@ import type {
   GetProgramAccountsConfig,
   GetProgramAccountsFilter,
   GetSupplyConfig,
+  GetVersionedTransactionConfig,
   InflationGovernor,
   InflationReward,
   LeaderSchedule,
@@ -424,11 +425,11 @@ export class BackgroundSolanaConnection extends Connection {
 
   async getParsedTransactions(
     signatures: TransactionSignature[],
-    commitment?: Finality
+    commitmentOrConfig?: GetVersionedTransactionConfig | Finality
   ): Promise<(ParsedConfirmedTransaction | null)[]> {
     return await this._backgroundClient.request({
       method: SOLANA_CONNECTION_RPC_GET_PARSED_TRANSACTIONS,
-      params: [signatures, commitment],
+      params: [signatures, commitmentOrConfig],
     });
   }
 
@@ -445,11 +446,11 @@ export class BackgroundSolanaConnection extends Connection {
 
   async getParsedTransaction(
     signature: TransactionSignature,
-    commitment?: Finality
+    commitmentOrConfig?: GetVersionedTransactionConfig | Finality
   ): Promise<ParsedConfirmedTransaction | null> {
     return await this._backgroundClient.request({
       method: SOLANA_CONNECTION_RPC_GET_PARSED_TRANSACTION,
-      params: [signature, commitment],
+      params: [signature, commitmentOrConfig],
     });
   }
 
@@ -1010,8 +1011,8 @@ export class BackgroundSolanaConnection extends Connection {
 export async function confirmTransaction(
   c: Connection,
   txSig: string,
-  commitment: Finality
-): Promise<ParsedConfirmedTransaction> {
+  commitmentOrConfig?: GetVersionedTransactionConfig | Finality
+): Promise<ReturnType<(typeof c)["getParsedTransaction"]>> {
   return new Promise(async (resolve, reject) => {
     setTimeout(
       () =>
@@ -1019,9 +1020,9 @@ export async function confirmTransaction(
       30000
     );
     await new Promise((resolve) => setTimeout(resolve, 5000));
-    let tx = await c.getParsedTransaction(txSig, commitment);
+    let tx = await c.getParsedTransaction(txSig, commitmentOrConfig);
     while (tx === null) {
-      tx = await c.getParsedTransaction(txSig, commitment);
+      tx = await c.getParsedTransaction(txSig, commitmentOrConfig);
       await new Promise((resolve) => setTimeout(resolve, 1000));
     }
     resolve(tx);

--- a/packages/recoil/src/hooks/solana/useSolanaTransaction.tsx
+++ b/packages/recoil/src/hooks/solana/useSolanaTransaction.tsx
@@ -139,10 +139,7 @@ export function useSolanaTransaction({
       await confirmTransaction(
         solanaCtx.connection,
         txSig,
-        solanaCtx.commitment !== "confirmed" &&
-          solanaCtx.commitment !== "finalized"
-          ? "confirmed"
-          : solanaCtx.commitment
+        solanaCtx.commitment === "finalized" ? "finalized" : "confirmed"
       );
       setCardType("complete");
       if (onComplete) onComplete(txSig);


### PR DESCRIPTION
fixes #3978 

`window.xnft.solana.sendAndConfirm` fails at the confirmation stage because versioned transactions aren't supported in the getParsedTransaction config, this adds support by adding `maxSupportedTransactionVersion: 0`