### PR TITLE
Added spherepay.co to WhitelistedOrigins

### DIFF
--- a/packages/background/src/frontend/server-injected.ts
+++ b/packages/background/src/frontend/server-injected.ts
@@ -71,6 +71,7 @@ const whitelistedOrigins = [
   /^https:\/\/xnft\.wao\.gg$/,
   /^https:\/\/one\.xnfts\.dev$/,
   /^https:\/\/rafffle\.famousfoxes\.com$/,
+  /^https:\/\/spherepay\.co$/,
 ];
 
 export function start(cfg: Config, events: EventEmitter, b: Backend): Handle {


### PR DESCRIPTION
Some users using the chromium based **Arc** browser and **bagpack** are getting the following error: 

‘https://spherepay.co/ is not an approved origin’,

They get this despite clicking accept to connect to the wallet and adding the origin to the user's walletData. 

Issue does not exist in, "chrome", "firefox", and "brave". 