### PR TITLE
(expirement) adds parcel build to chat-xplat

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,6 +34,8 @@
   },
   "devDependencies": {
     "@manypkg/cli": "^0.19.1",
+    "@parcel/packager-ts": "2.8.3",
+    "@parcel/transformer-typescript-types": "2.8.3",
     "buffer": "^5.5.0",
     "check-dependency-version-consistency": "^3.0.3",
     "env-cmd": "^10.1.0",
@@ -43,6 +45,7 @@
     "lint-staged": "^12.4.1",
     "prettier": "^2.8.1",
     "turbo": "^1.8.3",
+    "typescript": "^4.9.5",
     "yarn-deduplicate": "^6.0.0"
   },
   "lint-staged": {

--- a/packages/chat-xplat/.parcelrc
+++ b/packages/chat-xplat/.parcelrc
@@ -1,0 +1,6 @@
+{
+  "extends": "@parcel/config-default",
+  "transformers": {
+    "*.{ts,tsx}": ["@parcel/transformer-typescript-tsc"]
+  }
+}

--- a/packages/chat-xplat/package.json
+++ b/packages/chat-xplat/package.json
@@ -23,6 +23,7 @@
     "recoil": "*"
   },
   "devDependencies": {
+    "@parcel/transformer-typescript-tsc": "^2.8.3",
     "eslint-config-custom": "*",
     "parcel": "latest",
     "typescript": "~4.9.3"

--- a/packages/chat-xplat/package.json
+++ b/packages/chat-xplat/package.json
@@ -3,14 +3,14 @@
   "version": "1.0.0",
   "description": "all the cross platform chat stuff that used to live in tamagui",
   "license": "ISC",
-  "author": "",
-  "module": "dist/esm/index.js",
   "source": "src/index.ts",
   "react-native": "src/index.ts",
-  "types": "dist/esm/index.d.ts",
+  "main": "dist/main.js",
+  "module": "dist/module.js",
+  "types": "dist/types.d.ts",
   "scripts": {
-    "build": "tsc -b",
-    "dev": "tsc --watch",
+    "build": "parcel build",
+    "watch": "parcel watch",
     "lint": "eslint ./src --ext .js,.jsx,.ts,.tsx --cache",
     "lint:fix": "yarn run lint --fix"
   },
@@ -18,11 +18,13 @@
     "@coral-xyz/common": "*",
     "@coral-xyz/db": "*",
     "@coral-xyz/recoil": "*",
+    "eventemitter3": "*",
     "react": "*",
     "recoil": "*"
   },
   "devDependencies": {
     "eslint-config-custom": "*",
+    "parcel": "latest",
     "typescript": "~4.9.3"
   }
 }

--- a/packages/chat-xplat/package.json
+++ b/packages/chat-xplat/package.json
@@ -8,11 +8,16 @@
   "main": "dist/main.js",
   "module": "dist/module.js",
   "types": "dist/types.d.ts",
+  "alias": {
+    "~src": "./src/"
+  },
   "scripts": {
     "build": "parcel build",
     "watch": "parcel watch",
     "lint": "eslint ./src --ext .js,.jsx,.ts,.tsx --cache",
-    "lint:fix": "yarn run lint --fix"
+    "check": "tsc --noEmit",
+    "lint:fix": "yarn run lint --fix",
+    "ci": "yarn build && yarn lint && yarn check"
   },
   "dependencies": {
     "@coral-xyz/common": "*",

--- a/packages/chat-xplat/tsconfig.json
+++ b/packages/chat-xplat/tsconfig.json
@@ -1,7 +1,11 @@
 {
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
+    "baseUrl": ".",
     "outDir": "dist/esm/",
-    "rootDir": "./src"
+    "rootDir": "./src",
+    "paths": {
+      "~*": ["./*"]
+    }
   }
 }

--- a/packages/chat-xplat/tsconfig.json
+++ b/packages/chat-xplat/tsconfig.json
@@ -1,11 +1,11 @@
 {
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
-    "baseUrl": ".",
+    "baseUrl": "./",
     "outDir": "dist/esm/",
     "rootDir": "./src",
     "paths": {
-      "~*": ["./*"]
+      "~src": ["./src/"]
     }
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3889,6 +3889,7 @@ __metadata:
     "@coral-xyz/common": "*"
     "@coral-xyz/db": "*"
     "@coral-xyz/recoil": "*"
+    "@parcel/transformer-typescript-tsc": ^2.8.3
     eslint-config-custom: "*"
     eventemitter3: "*"
     parcel: latest
@@ -10159,6 +10160,19 @@ __metadata:
     posthtml-render: ^3.0.0
     semver: ^5.7.1
   checksum: 1f3db309e47d07849a2b4ffe11b508fd7ae792c0c0ce7b03e442fffb25f5e7425c5027428729bf2b587309265bba0be6da635d62c51ae8ab7e54483eff3f575e
+  languageName: node
+  linkType: hard
+
+"@parcel/transformer-typescript-tsc@npm:^2.8.3":
+  version: 2.8.3
+  resolution: "@parcel/transformer-typescript-tsc@npm:2.8.3"
+  dependencies:
+    "@parcel/plugin": 2.8.3
+    "@parcel/source-map": ^2.1.1
+    "@parcel/ts-utils": 2.8.3
+  peerDependencies:
+    typescript: ">=3.0.0"
+  checksum: 3195fccf16d0ceccaab32b649546440d0fb8d103371953c260b3ebf7960c24b1b15ffb1d33f9278927ddf4ec8581105e3a1ffcc811c30a0f315d4560d0e0e8ba
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -3890,6 +3890,8 @@ __metadata:
     "@coral-xyz/db": "*"
     "@coral-xyz/recoil": "*"
     eslint-config-custom: "*"
+    eventemitter3: "*"
+    parcel: latest
     react: "*"
     recoil: "*"
     typescript: ~4.9.3
@@ -9896,6 +9898,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@parcel/packager-ts@npm:2.8.3":
+  version: 2.8.3
+  resolution: "@parcel/packager-ts@npm:2.8.3"
+  dependencies:
+    "@parcel/plugin": 2.8.3
+  checksum: 9c000d7cfe558cf0b88e277c857ce1d446662ab22798f2e271d409df563d7137793e1348a62bf3cd0cb69e5bc5a9c5de68f1708c0029e37a71d15652809cd37d
+  languageName: node
+  linkType: hard
+
 "@parcel/plugin@npm:2.8.3":
   version: 2.8.3
   resolution: "@parcel/plugin@npm:2.8.3"
@@ -10148,6 +10159,33 @@ __metadata:
     posthtml-render: ^3.0.0
     semver: ^5.7.1
   checksum: 1f3db309e47d07849a2b4ffe11b508fd7ae792c0c0ce7b03e442fffb25f5e7425c5027428729bf2b587309265bba0be6da635d62c51ae8ab7e54483eff3f575e
+  languageName: node
+  linkType: hard
+
+"@parcel/transformer-typescript-types@npm:2.8.3":
+  version: 2.8.3
+  resolution: "@parcel/transformer-typescript-types@npm:2.8.3"
+  dependencies:
+    "@parcel/diagnostic": 2.8.3
+    "@parcel/plugin": 2.8.3
+    "@parcel/source-map": ^2.1.1
+    "@parcel/ts-utils": 2.8.3
+    "@parcel/utils": 2.8.3
+    nullthrows: ^1.1.1
+  peerDependencies:
+    typescript: ">=3.0.0"
+  checksum: 60d879b25481d22f8588e4b5e499193164393db39f1a4d41a9779b12fd1115b053658370268374b56bc855c2214930a4466cdf845d9d4cd76e54ed1ee1bb6317
+  languageName: node
+  linkType: hard
+
+"@parcel/ts-utils@npm:2.8.3":
+  version: 2.8.3
+  resolution: "@parcel/ts-utils@npm:2.8.3"
+  dependencies:
+    nullthrows: ^1.1.1
+  peerDependencies:
+    typescript: ">=3.0.0"
+  checksum: 002665a6e890420f15cc257afab814355a84e01a554d184e309c483e5c4fc7d2fda3edf9e8fc138a9f50792e9d3c95b705bc683f582bbc3f8e770f96ed305f24
   languageName: node
   linkType: hard
 
@@ -16999,6 +17037,8 @@ __metadata:
   resolution: "backpack@workspace:."
   dependencies:
     "@manypkg/cli": ^0.19.1
+    "@parcel/packager-ts": 2.8.3
+    "@parcel/transformer-typescript-types": 2.8.3
     buffer: ^5.5.0
     check-dependency-version-consistency: ^3.0.3
     env-cmd: ^10.1.0
@@ -17009,6 +17049,7 @@ __metadata:
     patch-package: ^6.5.0
     prettier: ^2.8.1
     turbo: ^1.8.3
+    typescript: ^4.9.5
     yarn-deduplicate: ^6.0.0
   languageName: unknown
   linkType: soft
@@ -22949,6 +22990,13 @@ __metadata:
   version: 5.0.1
   resolution: "event-target-shim@npm:5.0.1"
   checksum: 1ffe3bb22a6d51bdeb6bf6f7cf97d2ff4a74b017ad12284cc9e6a279e727dc30a5de6bb613e5596ff4dc3e517841339ad09a7eec44266eccb1aa201a30448166
+  languageName: node
+  linkType: hard
+
+"eventemitter3@npm:*":
+  version: 5.0.1
+  resolution: "eventemitter3@npm:5.0.1"
+  checksum: 543d6c858ab699303c3c32e0f0f47fc64d360bf73c3daf0ac0b5079710e340d6fe9f15487f94e66c629f5f82cd1a8678d692f3dbb6f6fcd1190e1b97fcad36f8
   languageName: node
   linkType: hard
 
@@ -33299,7 +33347,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"parcel@npm:^2.8.3":
+"parcel@npm:^2.8.3, parcel@npm:latest":
   version: 2.8.3
   resolution: "parcel@npm:2.8.3"
   dependencies:


### PR DESCRIPTION
if it's gonna build, it should build

my requirements were:
- types and autocomplete still works with path alises import { A } from '~src/A'
- proper build targets for react-native/the extension with ESM support for the latter
- speed (since its built as a lbrary, less work for the extension)