### PR TITLE
refresh xnft jwt when active wallet changes

### DIFF
--- a/packages/recoil/src/atoms/preferences/index.tsx
+++ b/packages/recoil/src/atoms/preferences/index.tsx
@@ -1,8 +1,4 @@
-import type {
-  AutolockSettings,
-  Blockchain,
-  Preferences,
-} from "@coral-xyz/common";
+import type { AutolockSettings, Preferences } from "@coral-xyz/common";
 import {
   BACKEND_API_URL,
   DEFAULT_AUTO_LOCK_INTERVAL_SECS,
@@ -132,8 +128,12 @@ export const xnftJwt = atomFamily({
     key: "xnftJwtDefault",
     get:
       ({ xnftAddress }: { xnftAddress: string }) =>
-      async (): Promise<string> => {
+      async ({ get }): Promise<string> => {
         try {
+          // If a different user opens the same xNFT we want to force a new
+          // HTTP request that includes their authentication JWT.
+          get(authenticatedUser);
+          // get(activeWallet); // Uncomment if including the pubkey in the jwt
           const response = await fetch(
             `${BACKEND_API_URL}/users/jwt/xnft?xnftAddress=${xnftAddress}`
           );


### PR DESCRIPTION
fixes issue where the xnft jwt doesn't get updated when you open the same xnft with different users