### PR TITLE
Eliminate race condition in `useIsAddressValid`

### DIFF
--- a/packages/eslint-config-custom/shared/react.js
+++ b/packages/eslint-config-custom/shared/react.js
@@ -60,7 +60,7 @@ module.exports = {
     "react-hooks/exhaustive-deps": [
       "warn",
       {
-        additionalHooks: "(useRecoilCallback|useRecoilTransaction_UNSTABLE)",
+        additionalHooks: "(useAsyncEffect|useRecoilCallback|useRecoilTransaction_UNSTABLE)",
       },
     ],
   },

--- a/packages/recoil/package.json
+++ b/packages/recoil/package.json
@@ -29,7 +29,8 @@
     "ethers": "^5.7.0",
     "react": "18.2.0",
     "react-router-dom": "^6.3.0",
-    "recoil": "^0.7.5"
+    "recoil": "^0.7.5",
+    "use-async-effect": "^2.2.7"
   },
   "devDependencies": {
     "eslint-config-custom": "*",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4345,6 +4345,7 @@ __metadata:
     react-router-dom: ^6.3.0
     recoil: ^0.7.5
     typescript: ~4.9.3
+    use-async-effect: ^2.2.7
   peerDependencies:
     "@solana/web3.js": ^1.63.1
   languageName: unknown
@@ -40400,6 +40401,15 @@ __metadata:
   version: 1.0.0
   resolution: "urlsafe-base64@npm:1.0.0"
   checksum: 41d28a337044e5ad287174e928227b025d03424c5cd316956fdcbd916fccdc70981fa9a67e77325c5250c8150ba90bca0de65e783aa6235567b7f820e1146cb6
+  languageName: node
+  linkType: hard
+
+"use-async-effect@npm:^2.2.7":
+  version: 2.2.7
+  resolution: "use-async-effect@npm:2.2.7"
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0 || ^18.0.0
+  checksum: 81fe96df0e9db68fcf5b63a88307ba09896ddbdb6ea952fb00340d5f9d1393d06f2af4d8aa547b062cac2edaaf4bc383fc30f039054ce93bc9e61298ee52e938
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Eliminate race condition in `useIsAddressValid`
## Summary:

In general, async code in React effects is unsafe. To be precise, _setting state_ after an awaitable is unsafe unless you track whether the effect that triggered you is still ‘relevant’ (ie. its dependencies haven't changed _and_ the component in which it lives has not unmounted).

```ts
useEffect(() => {
  (async () => {
    const result = await somethingThatTakesTime(foo);
    setResult(result); // `foo` might have changed by now!
  })();
}, [foo]);

// 1. `foo` gets set to `bar`
// 2. `somethingThatTakesTime` gets called for `bar`
// 3. `foo` changes to `baz`
// 4. `somethingThatTakesTime` gets called for `baz`
// 5. `somethingThatTakesTime` returns a result for `baz` and `setResult` gets called
// 6. `somethingThatTakesTime` returns a result for `bar` and `setResult` gets called
//
// Now `foo` is `baz`, but you're displaying the _result_ for `bar`. UI: corrupt.
```

In this PR we implement the tracking necessary to prevent this; we cancel in progress work whenever `address` changes. This will prevent a situation where the result from a _previous_ address ends up overwriting the result for the _current_ address.

## Test Plan:

Years of watching this bite developers in the ass.
