### PR TITLE
allow popups sandbox permission

### DIFF
--- a/packages/common/src/plugin.ts
+++ b/packages/common/src/plugin.ts
@@ -181,6 +181,7 @@ export class Plugin {
     this.iframeRoot.sandbox.add("allow-same-origin");
     this.iframeRoot.sandbox.add("allow-scripts");
     this.iframeRoot.sandbox.add("allow-forms");
+    this.iframeRoot.sandbox.add("allow-popups");
 
     this.iframeRoot.onload = () => this.handleRootIframeOnLoad();
   }

--- a/packages/provider-core/src/root-provider-xnft.ts
+++ b/packages/provider-core/src/root-provider-xnft.ts
@@ -68,16 +68,6 @@ export class ProviderRootXnftInjection extends PrivateEventEmitter {
     this.#setupChannels();
   }
 
-  public async openWindow(_url: string) {
-    const url = new URL(_url);
-
-    if (!url.protocol.startsWith("http")) {
-      throw "Invalid url.";
-    }
-
-    window.open(url, "_blank");
-  }
-
   public async openPlugin(xnftAddress: string) {
     await this.#requestManager.request({
       method: PLUGIN_RPC_METHOD_PLUGIN_OPEN,


### PR DESCRIPTION
- add `allow-popups` permission to the plugin sandbox
- remove the `window.xnft.openWindow` wrapper since standard `window.open` will now work