### PR TITLE
fix USD formatting on token detail screen

### DIFF
--- a/packages/app-extension/src/components/Unlocked/Balances/TokensWidget/Token.tsx
+++ b/packages/app-extension/src/components/Unlocked/Balances/TokensWidget/Token.tsx
@@ -1,6 +1,6 @@
 import { Suspense, useState } from "react";
 import type { SearchParamsFor } from "@coral-xyz/common";
-import { Blockchain } from "@coral-xyz/common";
+import { Blockchain, formatUSD } from "@coral-xyz/common";
 import {
   blockchainTokenData,
   useActiveEthereumWallet,
@@ -132,7 +132,7 @@ function TokenHeader({
         />
         {token.priceData ? (
           <Typography className={classes.usdBalanceLabel}>
-            ${parseFloat(token.usdBalance.toFixed(2)).toLocaleString()}
+            {formatUSD(token.usdBalance)}
             &nbsp;&nbsp;&nbsp;
             <span className={percentClass}>{token.recentPercentChange}%</span>
           </Typography>


### PR DESCRIPTION
before | after
----|-----
<img width="452" alt="Screenshot 2023-05-31 at 18 08 22" src="https://github.com/coral-xyz/backpack/assets/101902546/f17b6836-0440-4b0b-bc7b-01b27c5031df">|<img width="424" alt="Screenshot 2023-05-31 at 18 22 30" src="https://github.com/coral-xyz/backpack/assets/101902546/0f8968cd-c481-49ca-a083-fa13d277a671">
