### PR TITLE
token-2022: Pass in program id when deriving ATA

### DIFF
--- a/packages/common/src/solana/index.ts
+++ b/packages/common/src/solana/index.ts
@@ -194,7 +194,8 @@ export class Solana {
           walletPublicKey,
           destinationAta,
           destination,
-          mint
+          mint,
+          programId
         )
       );
     }
@@ -274,7 +275,8 @@ export class Solana {
           walletPublicKey,
           destinationAta,
           destination,
-          mint
+          mint,
+          programId
         )
       );
     }
@@ -632,7 +634,8 @@ export const generateWrapSolTx = async (
         walletPublicKey,
         destinationAta,
         destination,
-        NATIVE_MINT
+        NATIVE_MINT,
+        TOKEN_PROGRAM_ID
       )
     );
   }


### PR DESCRIPTION
#### Problem

Token-2022's great, but ATAs are even better, and the first pass wasn't passing in the program id when deriving the ATA, causing problems when creating someone else's ATA.

#### Solution

Pass in the program id too!