### PR TITLE
make send input validation stricter

### DIFF
--- a/packages/app-extension/src/components/Unlocked/Balances/TokensWidget/Send.tsx
+++ b/packages/app-extension/src/components/Unlocked/Balances/TokensWidget/Send.tsx
@@ -494,6 +494,10 @@ function SendV2({
 
                   setStrAmount(parsedVal);
 
+                  if (value.endsWith(".")) {
+                    throw "trailing ."; // can't throw new Error due to Error function
+                  }
+
                   const num = FixedNumber.fromString(
                     parsedVal === "" || parsedVal === "0." ? "0" : parsedVal
                   );

--- a/packages/app-extension/src/components/Unlocked/Balances/TokensWidget/Send.tsx
+++ b/packages/app-extension/src/components/Unlocked/Balances/TokensWidget/Send.tsx
@@ -478,10 +478,17 @@ function SendV2({
                 target: { value },
               }: ChangeEvent<HTMLInputElement>) => {
                 try {
+                  const maxDecimals = token.decimals ?? 9;
+
                   const parsedVal = value
-                    .replace(/[^0-9.]/g, "") // keep only 0-9 and .
-                    .replace(/^0+/, "") // remove leading zeros
-                    .replace(/^\.(.+)?$/, "0.$1"); // add leading 0 if only .
+                    .replace(/[^\d.]/g, "") // keep only 0-9 and .
+                    .replace(/^0+(\d+)/, "$1") // remove leading zeros
+                    .replace(/^\.(\d+)?$/, "0.$1") // use 0.\d if decimal is .\d
+                    .replace(
+                      // trim to the number of decimals allowed for the token
+                      new RegExp(`^(\\d+\\.\\d{${maxDecimals}}).+`),
+                      "$1"
+                    );
 
                   if (!Number.isFinite(Number(parsedVal))) return;
 
@@ -493,7 +500,7 @@ function SendV2({
 
                   const finalAmount = ethers.utils.parseUnits(
                     num.toString(),
-                    token.decimals
+                    maxDecimals
                   );
 
                   setAmount(finalAmount.isZero() ? null : finalAmount);

--- a/packages/app-extension/src/components/Unlocked/Balances/TokensWidget/Send.tsx
+++ b/packages/app-extension/src/components/Unlocked/Balances/TokensWidget/Send.tsx
@@ -481,13 +481,16 @@ function SendV2({
                   const maxDecimals = token.decimals ?? 9;
 
                   const parsedVal = value
-                    .replace(/[^\d.]/g, "") // keep only 0-9 and .
-                    .replace(/^0+(\d+)/, "$1") // remove leading zeros
-                    .replace(/^\.(\d+)?$/, "0.$1") // use 0.\d if decimal is .\d
+                    // remove all characters except for 0-9 and .
+                    .replace(/[^\d.]/g, "")
+                    // remove leading zeros
+                    .replace(/^0+(\d)/, "$1")
+                    // prepend a 0 if . is the first character
+                    .replace(/^\.(\d+)?$/, "0.$1")
                     // remove any periods after the first one
                     .replace(/^(\d+\.\d*?)\./, "$1")
+                    // trim to the number of decimals allowed for the token
                     .replace(
-                      // trim to the number of decimals allowed for the token
                       new RegExp(`^(\\d+\\.\\d{${maxDecimals}}).+`),
                       "$1"
                     );
@@ -497,7 +500,8 @@ function SendV2({
                   setStrAmount(parsedVal);
 
                   if (parsedVal.endsWith(".")) {
-                    throw "trailing ."; // can't throw new Error due to Error function
+                    // can't `throw new Error("trailing")` due to Error function
+                    throw "trailing .";
                   }
 
                   const finalAmount = ethers.utils.parseUnits(

--- a/packages/app-extension/src/components/Unlocked/Balances/TokensWidget/Send.tsx
+++ b/packages/app-extension/src/components/Unlocked/Balances/TokensWidget/Send.tsx
@@ -34,7 +34,7 @@ import {
 } from "@coral-xyz/recoil";
 import { styles as makeStyles, useCustomTheme } from "@coral-xyz/themes";
 import { Typography } from "@mui/material";
-import { BigNumber, ethers, FixedNumber } from "ethers";
+import { BigNumber, ethers } from "ethers";
 
 import { ApproveTransactionDrawer } from "../../../common/ApproveTransactionDrawer";
 import { CopyablePublicKey } from "../../../common/CopyablePublicKey";
@@ -498,12 +498,8 @@ function SendV2({
                     throw "trailing ."; // can't throw new Error due to Error function
                   }
 
-                  const num = FixedNumber.fromString(
-                    parsedVal === "" || parsedVal === "0." ? "0" : parsedVal
-                  );
-
                   const finalAmount = ethers.utils.parseUnits(
-                    num.toString(),
+                    parsedVal,
                     maxDecimals
                   );
 

--- a/packages/app-extension/src/components/Unlocked/Balances/TokensWidget/Send.tsx
+++ b/packages/app-extension/src/components/Unlocked/Balances/TokensWidget/Send.tsx
@@ -483,8 +483,6 @@ function SendV2({
                   const parsedVal = value
                     // remove all characters except for 0-9 and .
                     .replace(/[^\d.]/g, "")
-                    // remove leading zeros
-                    .replace(/^0+(\d)/, "$1")
                     // prepend a 0 if . is the first character
                     .replace(/^\.(\d+)?$/, "0.$1")
                     // remove any periods after the first one

--- a/packages/app-extension/src/components/Unlocked/Balances/TokensWidget/Send.tsx
+++ b/packages/app-extension/src/components/Unlocked/Balances/TokensWidget/Send.tsx
@@ -484,6 +484,8 @@ function SendV2({
                     .replace(/[^\d.]/g, "") // keep only 0-9 and .
                     .replace(/^0+(\d+)/, "$1") // remove leading zeros
                     .replace(/^\.(\d+)?$/, "0.$1") // use 0.\d if decimal is .\d
+                    // remove any periods after the first one
+                    .replace(/^(\d+\.\d*?)\./, "$1")
                     .replace(
                       // trim to the number of decimals allowed for the token
                       new RegExp(`^(\\d+\\.\\d{${maxDecimals}}).+`),
@@ -494,7 +496,7 @@ function SendV2({
 
                   setStrAmount(parsedVal);
 
-                  if (value.endsWith(".")) {
+                  if (parsedVal.endsWith(".")) {
                     throw "trailing ."; // can't throw new Error due to Error function
                   }
 


### PR DESCRIPTION
before vs after

https://github.com/coral-xyz/backpack/assets/101902546/f8acadeb-bb75-474f-90e4-213675bf8def



makes send input a lot stricter so it only accepts valid positive integers or decimals that are larger that the minimum possible fraction of a token