### PR TITLE
fix issue with storing xnftAddress object in recoil

### DIFF
--- a/packages/common/src/plugin.ts
+++ b/packages/common/src/plugin.ts
@@ -615,7 +615,7 @@ export class Plugin {
       this._requestTxApprovalFn!({
         kind,
         data: transaction,
-        xnftAddress: this.xnftAddress,
+        xnftAddress: this.xnftAddress.toString(),
         pluginUrl: this.iframeRootUrl,
         publicKey,
         resolve,


### PR DESCRIPTION
fixes `Cannot assign to read only property 'negative' of object` error which I believe is related to storing and retrieving PublicKey objects (rather than base58 strings) around in recoil

<img width="487" alt="Screenshot 2023-06-06 at 21 04 41" src="https://github.com/coral-xyz/backpack/assets/101902546/bed84865-c221-4ec5-aad3-ddd1fa05c2cf">

before | after
----|----
<img width="487" alt="Screenshot 2023-06-06 at 22 06 30" src="https://github.com/coral-xyz/backpack/assets/101902546/111bc4ef-7695-43ee-baef-717c0178b7fb">|<img width="487" alt="Screenshot 2023-06-06 at 21 57 29" src="https://github.com/coral-xyz/backpack/assets/101902546/a4e320a2-0b25-47b8-a4a4-953cc411b157">

it also restores a bit of metadata about the xnft in the top of the transaction signing drawer for production xNFTs

before | after
----|----
<img width="487" alt="Screenshot 2023-06-06 at 21 59 42" src="https://github.com/coral-xyz/backpack/assets/101902546/bc0a7d29-deba-4f0a-8db7-09dedab7c9fd">|<img width="487" alt="Screenshot 2023-06-06 at 21 59 21" src="https://github.com/coral-xyz/backpack/assets/101902546/9322414e-f035-430f-9531-f0ba17977f39">

There are some incorrect `PublicKey` vs `string` types in recoil and common which makes this a little tricky to debug but it'd be good to circle back and get them all sorted out soon