### PR TITLE
auth fixes, graphql migration, navigator updates

### DIFF
--- a/packages/app-mobile/eas.json
+++ b/packages/app-mobile/eas.json
@@ -27,21 +27,24 @@
       "ios": {
         "simulator": true
       },
-      "channel": "development-simulator",
-      "env": {
-        "APP_ENV": "production"
-      }
+      "channel": "development-simulator"
     },
-    "preview": {
+    "staging": {
       "extends": "monorepo",
       "distribution": "internal",
-      "channel": "staging"
+      "channel": "staging",
+      "env": {
+        "APP_ENV": "staging"
+      }
     },
     "production": {
       "extends": "monorepo",
       "channel": "production",
       "distribution": "store",
-      "autoIncrement": true
+      "autoIncrement": true,
+      "env": {
+        "APP_ENV": "staging"
+      }
     }
   },
   "submit": {

--- a/packages/app-mobile/src/components/BottomSheetWalletPicker.tsx
+++ b/packages/app-mobile/src/components/BottomSheetWalletPicker.tsx
@@ -28,12 +28,19 @@ export function BottomSheetWalletPicker({ navigation }) {
   const handlePressSelect = useCallback(
     async (blockchain: Blockchain, publicKey: PublicKey) => {
       setLoadingId(publicKey);
+      navigation.replace("TopTabsWalletDetail", {
+        screen: "TokenList",
+        params: {
+          publicKey,
+          blockchain,
+        },
+      });
       selectActiveWallet({ blockchain, publicKey }, () => {
         setLoadingId(null);
         dismiss();
       });
     },
-    [dismiss, selectActiveWallet]
+    [dismiss, selectActiveWallet, navigation]
   );
 
   const handlePressEdit = useCallback(

--- a/packages/app-mobile/src/components/CollectionAttributesList.tsx
+++ b/packages/app-mobile/src/components/CollectionAttributesList.tsx
@@ -1,21 +1,37 @@
-import { Text, View } from "react-native";
+import { View } from "react-native";
 
 import { toTitleCase } from "@coral-xyz/common";
-import { StyledText } from "@coral-xyz/tamagui";
-
-import { useTheme } from "~hooks/useTheme";
+import { StyledText, Stack } from "@coral-xyz/tamagui";
 
 type Attribute = {
   trait: string;
   value: string;
 };
 
+function Pill({ trait, value }: Attribute): JSX.Element {
+  return (
+    <Stack
+      backgroundColor="$card"
+      px={8}
+      py={8}
+      borderRadius="$container"
+      space={2}
+    >
+      <StyledText fontSize="$xs" color="$secondary">
+        {toTitleCase(trait)}
+      </StyledText>
+      <StyledText fontSize="$sm" color="$fontColor">
+        {value}
+      </StyledText>
+    </Stack>
+  );
+}
+
 export function CollectionAttributes({
   attributes,
 }: {
   attributes: Attribute[];
 }): JSX.Element | null {
-  const theme = useTheme();
   if (!attributes || attributes?.length === 0) {
     return null;
   }
@@ -25,43 +41,18 @@ export function CollectionAttributes({
       <StyledText color="$secondary" size="$base">
         Attributes
       </StyledText>
-      <View style={{ flexDirection: "row", flexWrap: "wrap" }}>
+      <View
+        style={{
+          flexDirection: "row",
+          flexWrap: "wrap",
+          gap: 8,
+          marginTop: 12,
+          marginBottom: 18,
+        }}
+      >
         {attributes.map((attr: Attribute) => {
           return (
-            <View
-              key={attr.trait}
-              style={{
-                padding: 4,
-              }}
-            >
-              <View
-                style={{
-                  borderRadius: 8,
-                  backgroundColor: theme.custom.colors.nav,
-                  paddingTop: 4,
-                  paddingBottom: 4,
-                  paddingLeft: 8,
-                  paddingRight: 8,
-                }}
-              >
-                <Text
-                  style={{
-                    color: theme.custom.colors.secondary,
-                    fontSize: 14,
-                  }}
-                >
-                  {toTitleCase(attr.trait)}
-                </Text>
-                <Text
-                  style={{
-                    color: theme.custom.colors.fontColor,
-                    fontSize: 16,
-                  }}
-                >
-                  {attr.value}
-                </Text>
-              </View>
-            </View>
+            <Pill key={attr.trait} trait={attr.trait} value={attr.value} />
           );
         })}
       </View>

--- a/packages/app-mobile/src/components/CollectionListItem.tsx
+++ b/packages/app-mobile/src/components/CollectionListItem.tsx
@@ -1,0 +1,80 @@
+import { View, Pressable } from "react-native";
+
+import { UNKNOWN_NFT_ICON_SRC } from "@coral-xyz/common";
+import { ProxyImage, XStack, StyledText } from "@coral-xyz/tamagui";
+
+export function BaseListItem({ onPress, item }: any): JSX.Element {
+  return (
+    <Pressable style={{ flex: 1 }} onPress={() => onPress(item)}>
+      <CollectionImage images={item.images} />
+      <XStack mt={8}>
+        <StyledText
+          fontSize="$base"
+          numberOfLines={1}
+          ellipsizeMode="tail"
+          maxWidth="90%"
+        >
+          {item.name}
+        </StyledText>
+      </XStack>
+    </Pressable>
+  );
+}
+
+function ImageBox({ images }: { images: string[] }): JSX.Element {
+  return (
+    <View
+      style={{
+        height: 164,
+        borderRadius: 12,
+        backgroundColor: "white",
+        flexDirection: "row",
+        flexWrap: "wrap",
+        gap: 12,
+        padding: 12,
+        justifyContent: "space-evenly",
+        alignItems: "center",
+      }}
+    >
+      {images.map((uri: string, index: number) => {
+        return (
+          <ProxyNFTImage
+            key={`${index}${uri}`} // eslint-disable-line
+            src={uri}
+            size={64}
+            style={{ borderRadius: 8 }}
+          />
+        );
+      })}
+    </View>
+  );
+}
+
+function CollectionImage({ images }: { images: string[] }): JSX.Element {
+  if (images.length === 1) {
+    return (
+      <ProxyNFTImage size={164} src={images[0]} style={{ borderRadius: 12 }} />
+    );
+  }
+
+  return <ImageBox images={images.slice(0, 4)} />;
+}
+
+export function ProxyNFTImage({
+  size,
+  src,
+  style,
+}: {
+  size: number;
+  src: string;
+  style: any;
+}): JSX.Element {
+  const uri = src ?? UNKNOWN_NFT_ICON_SRC;
+  return (
+    <ProxyImage
+      size={size}
+      src={uri}
+      style={[style, { backgroundColor: "white" }]}
+    />
+  );
+}

--- a/packages/app-mobile/src/graphql/apollo.tsx
+++ b/packages/app-mobile/src/graphql/apollo.tsx
@@ -13,7 +13,9 @@ import AsyncStorage from "@react-native-async-storage/async-storage";
 // https://github.com/apollographql/apollo-cache-persist/tree/master/examples/react-native/src/hooks
 import { AsyncStorageWrapper, persistCache } from "apollo3-cache-persist";
 
-import { getTokenAsync, useSession } from "~lib/SessionProvider";
+import { useSession } from "~lib/SessionProvider";
+// consider using react-native-mmk when the time comes for the persisted cache
+// much faster than AsyncStorage
 
 const cache = new InMemoryCache();
 const API_URL = Constants.expoConfig?.extra?.graphqlApiUrl;
@@ -45,8 +47,7 @@ export const useApolloClient = () => {
   const [client, setClient] = useState<ApolloClient<NormalizedCacheObject>>();
 
   useEffect(() => {
-    async function init() {
-      const token = await getTokenAsync();
+    async function init(token: string | null) {
       await persistCache({
         cache,
         storage: new AsyncStorageWrapper(AsyncStorage),
@@ -56,7 +57,7 @@ export const useApolloClient = () => {
       setClient(apolloClient);
     }
 
-    init();
+    init(token);
   }, [token]);
 
   return {

--- a/packages/app-mobile/src/navigation/WalletsNavigator.tsx
+++ b/packages/app-mobile/src/navigation/WalletsNavigator.tsx
@@ -1,16 +1,14 @@
-import { Dimensions } from "react-native";
-
 import { Blockchain, toTitleCase } from "@coral-xyz/common";
+import { useTheme as useTamaguiTheme } from "@coral-xyz/tamagui";
 import { createMaterialTopTabNavigator } from "@react-navigation/material-top-tabs";
-import {
-  createStackNavigator,
-  StackScreenProps,
-} from "@react-navigation/stack";
+import { createNativeStackNavigator } from "@react-navigation/native-stack";
+import { StackScreenProps } from "@react-navigation/stack";
 
 import { WalletSwitcherButton } from "~components/WalletSwitcherButton";
 import { useTheme } from "~hooks/useTheme";
 import { WINDOW_WIDTH } from "~lib/index";
 import { HeaderButton } from "~navigation/components";
+import { TopTabsParamList } from "~navigation/types";
 import { CollectionDetailScreen } from "~screens/CollectionDetailScreen";
 import { CollectionItemDetailScreen } from "~screens/CollectionItemDetailScreen";
 import { CollectionListScreen } from "~screens/CollectionListScreen";
@@ -19,16 +17,7 @@ import { NotificationsScreen } from "~screens/NotificationsScreen";
 import { RecentActivityScreen } from "~screens/RecentActivityScreen";
 import { TokenDetailScreen } from "~screens/TokenDetailScreen";
 import { TokenListScreen } from "~screens/TokenListScreen";
-import { WalletDisplayStarterScreen } from "~screens/WalletDisplayStarterScreen";
 
-type TopTabsParamList = {
-  TokenList: {
-    blockchain: Blockchain;
-    publicKey: string;
-  };
-  Collectibles: undefined;
-  Activity: undefined;
-};
 const TopTabs = createMaterialTopTabNavigator<TopTabsParamList>();
 function TopTabsNavigator(): JSX.Element {
   const theme = useTheme();
@@ -95,16 +84,23 @@ export type TokenDetailScreenParams = StackScreenProps<
   "TokenDetail"
 >;
 
-const Stack = createStackNavigator<WalletStackParamList>();
+const Stack = createNativeStackNavigator<WalletStackParamList>();
 export function WalletsNavigator(): JSX.Element {
+  const theme = useTamaguiTheme();
   return (
-    <Stack.Navigator initialRouteName="HomeWalletList">
+    <Stack.Navigator
+      initialRouteName="HomeWalletList"
+      screenOptions={{
+        headerTintColor: theme.fontColor.val,
+      }}
+    >
       <Stack.Screen
         name="HomeWalletList"
         component={HomeWalletListScreen}
         options={({ navigation }) => {
           return {
             headerShown: true,
+            headerBackTitleVisible: false,
             title: "Balances",
             headerLeft: (props) => (
               <HeaderButton
@@ -163,6 +159,7 @@ export function WalletsNavigator(): JSX.Element {
           },
         }) => {
           return {
+            headerBackTitleVisible: false,
             title,
           };
         }}
@@ -176,6 +173,7 @@ export function WalletsNavigator(): JSX.Element {
           },
         }) => {
           return {
+            headerBackTitleVisible: false,
             title,
           };
         }}

--- a/packages/app-mobile/src/navigation/types.ts
+++ b/packages/app-mobile/src/navigation/types.ts
@@ -1,6 +1,7 @@
 import type { SubscriptionType, Blockchain, Nft } from "@coral-xyz/common";
 import type { Token } from "~types/types";
 
+import { MaterialTopTabsScreenProps } from "@react-navigation/material-top-tabs";
 import { NativeStackScreenProps } from "@react-navigation/native-stack";
 import { StackScreenProps } from "@react-navigation/stack";
 
@@ -100,4 +101,28 @@ export type ChatListScreenProps = NativeStackScreenProps<
 export type ChatDetailScreenProps = NativeStackScreenProps<
   ChatStackNavigatorParamList,
   "ChatDetail"
+>;
+
+export type TopTabsParamList = {
+  TokenList: {
+    blockchain: Blockchain;
+    publicKey: string;
+  };
+  Collectibles: undefined;
+  Activity: undefined;
+};
+
+export type TokenListScreenProps = MaterialTopTabsScreenProps<
+  TopTabsParamList,
+  "TokenList"
+>;
+
+export type CollectionListScreenProps = MaterialTopTabsScreenProps<
+  TopTabsParamList,
+  "Collectibles"
+>;
+
+export type RecentActivityScreenProps = MaterialTopTabsScreenProps<
+  TopTabsParamList,
+  "Activity"
 >;

--- a/packages/app-mobile/src/screens/CollectionDetailScreen.tsx
+++ b/packages/app-mobile/src/screens/CollectionDetailScreen.tsx
@@ -1,24 +1,16 @@
-import { Suspense, useCallback } from "react";
-import { FlatList, Pressable, Text } from "react-native";
+import { Suspense, useCallback, useMemo } from "react";
+import { FlatList, Text } from "react-native";
 
 import { useFragment_experimental } from "@apollo/client";
 import { useActiveWallet } from "@coral-xyz/recoil";
-import { ProxyImage, XStack, StyledText } from "@coral-xyz/tamagui";
 import { ErrorBoundary } from "react-error-boundary";
 
-import {
-  FullScreenLoading,
-  Screen,
-  RoundedContainerGroup,
-} from "~components/index";
-import { WINDOW_WIDTH } from "~lib/index";
+import { BaseListItem } from "~components/CollectionListItem";
+import { FullScreenLoading, Screen } from "~components/index";
 import { NftNodeFragment } from "~screens/CollectionListScreen";
 
-const blurhash =
-  "|rF?hV%2WCj[ayj[a|j[az_NaeWBj@ayfRayfQfQM{M|azj[azf6fQfQfQIpWXofj[ayj[j[fQayWCoeoeaya}j[ayfQa{oLj?j[WVj[ayayj[fQoff7azayj[ayj[j[ayofayayayj[fQj[ayayj[ayfjj[j[ayjuayj[";
-
 function ListItem({ id, onPress }: { id: string; onPress: any }): JSX.Element {
-  const { data: item } = useFragment_experimental({
+  const { data } = useFragment_experimental({
     fragment: NftNodeFragment,
     fragmentName: "NftNodeFragment",
     from: {
@@ -27,30 +19,17 @@ function ListItem({ id, onPress }: { id: string; onPress: any }): JSX.Element {
     },
   });
 
-  return (
-    <Pressable
-      style={{ flex: 1, marginBottom: 12, borderRadius: 16 }}
-      onPress={() => onPress(item)}
-    >
-      <ProxyImage
-        // placeholder={blurhash}
-        src={item.image}
-        size={WINDOW_WIDTH}
-        style={{ borderRadius: 12 }}
-        // transition={1000}
-      />
-      <XStack mt={8}>
-        <StyledText
-          fontSize="$base"
-          numberOfLines={1}
-          ellipsizeMode="tail"
-          maxWidth="90%"
-        >
-          {item.name}
-        </StyledText>
-      </XStack>
-    </Pressable>
+  const item = useMemo(
+    () => ({
+      id: data.id,
+      name: data.name,
+      images: [data.image],
+      type: data.type,
+    }),
+    [data]
   );
+
+  return <BaseListItem onPress={onPress} item={item} />;
 }
 
 function Container({ navigation, route }: any): JSX.Element {
@@ -76,21 +55,19 @@ function Container({ navigation, route }: any): JSX.Element {
     [handlePressItem]
   );
 
-  const numColumns = 2;
   const gap = 12;
 
   return (
     <Screen>
-      <RoundedContainerGroup style={{ padding: 12 }}>
-        <FlatList
-          data={nftIds}
-          numColumns={numColumns}
-          keyExtractor={keyExtractor}
-          renderItem={renderItem}
-          contentContainerStyle={{ gap }}
-          columnWrapperStyle={{ gap }}
-        />
-      </RoundedContainerGroup>
+      <FlatList
+        data={nftIds}
+        numColumns={2}
+        keyExtractor={keyExtractor}
+        renderItem={renderItem}
+        contentContainerStyle={{ gap }}
+        columnWrapperStyle={{ gap }}
+        showsVerticalScrollIndicator={false}
+      />
     </Screen>
   );
 }

--- a/packages/app-mobile/src/screens/CollectionItemDetailScreen.tsx
+++ b/packages/app-mobile/src/screens/CollectionItemDetailScreen.tsx
@@ -1,14 +1,10 @@
 import { Suspense } from "react";
-import { Alert, View, Text, ScrollView, Dimensions } from "react-native";
+import { Alert, View, Text, ScrollView } from "react-native";
 
 import * as Linking from "expo-linking";
 
 import { useFragment_experimental } from "@apollo/client";
-import {
-  Blockchain,
-  UNKNOWN_NFT_ICON_SRC,
-  explorerNftUrl,
-} from "@coral-xyz/common";
+import { Blockchain, explorerNftUrl } from "@coral-xyz/common";
 import {
   useEthereumExplorer,
   useSolanaExplorer,
@@ -19,9 +15,9 @@ import { useActionSheet } from "@expo/react-native-action-sheet";
 import { ErrorBoundary } from "react-error-boundary";
 
 import { CollectionAttributes } from "~components/CollectionAttributesList";
+import { ProxyNFTImage } from "~components/CollectionListItem";
 import {
   PrimaryButton,
-  ProxyImage,
   Screen,
   SecondaryButton,
   FullScreenLoading,
@@ -125,12 +121,12 @@ function Container({ navigation, route }): JSX.Element {
   });
 
   return (
-    <ScrollView>
+    <ScrollView showsVerticalScrollIndicator={false}>
       <Screen>
-        <ProxyImage
-          src={nft.image ?? UNKNOWN_NFT_ICON_SRC}
+        <ProxyNFTImage
+          src={nft.image}
           size={WINDOW_WIDTH}
-          style={{ borderRadius: 8 }}
+          style={{ borderRadius: 8, maxWidth: "100%" }}
         />
         <Description description={nft.description} />
         <Box marginVertical={12}>

--- a/packages/app-mobile/src/screens/CollectionListScreen.tsx
+++ b/packages/app-mobile/src/screens/CollectionListScreen.tsx
@@ -1,25 +1,21 @@
 import { Suspense, useMemo, useCallback } from "react";
-import { View, Pressable, Text, FlatList } from "react-native";
+import { View, Text, FlatList } from "react-native";
 
 import * as Linking from "expo-linking";
 
 import { gql, useSuspenseQuery_experimental } from "@apollo/client";
 import { useActiveWallet } from "@coral-xyz/recoil";
-import { XStack, StyledText, ProxyImage } from "@coral-xyz/tamagui";
 import { MaterialIcons } from "@expo/vector-icons";
 import { ErrorBoundary } from "react-error-boundary";
 
+import { BaseListItem } from "~components/CollectionListItem";
 import { ItemSeparator } from "~components/ListItem";
-import {
-  EmptyState,
-  Screen,
-  RoundedContainerGroup,
-  FullScreenLoading,
-} from "~components/index";
+import { EmptyState, Screen, FullScreenLoading } from "~components/index";
 import {
   convertNftDataToFlatlist,
   type ListItemProps,
 } from "~lib/CollectionUtils";
+import { CollectionListScreenProps } from "~navigation/types";
 
 function NoNFTsEmptyState() {
   return (
@@ -34,73 +30,6 @@ function NoNFTsEmptyState() {
         }}
       />
     </View>
-  );
-}
-
-function ImageBox({ images }: { images: string[] }): JSX.Element {
-  return (
-    <View
-      style={{
-        borderRadius: 12,
-        flexDirection: "row",
-        flexWrap: "wrap",
-        gap: 8,
-        padding: 8,
-        alignItems: "center",
-        backgroundColor: "#eee",
-        justifyContent: "space-evenly",
-      }}
-    >
-      {images.map((uri: string) => {
-        return (
-          <ProxyImage
-            key={uri}
-            src={uri}
-            size={64}
-            style={{ borderRadius: 8 }}
-          />
-        );
-      })}
-    </View>
-  );
-}
-
-function CollectionImage({ images }: { images: string[] }): JSX.Element {
-  if (images.length === 1) {
-    return (
-      <ProxyImage
-        size={164}
-        src={images[0]}
-        style={{ borderRadius: 12, padding: 12 }}
-      />
-    );
-  }
-
-  return <ImageBox images={images.slice(0, 4)} />;
-}
-
-function ListItem({
-  item,
-  handlePress,
-}: {
-  item: ListItemProps;
-  handlePress: (item: ListItemProps) => void;
-}): JSX.Element {
-  return (
-    <Pressable style={{ flex: 1 }} onPress={() => handlePress(item)}>
-      <CollectionImage images={item.images} />
-      <XStack mt={8}>
-        <StyledText
-          mr={4}
-          fontSize="$base"
-          numberOfLines={1}
-          maxWidth="80%"
-          ellipsizeMode="tail"
-        >
-          {item.name}
-        </StyledText>
-      </XStack>
-    </Pressable>
   );
 }
 
@@ -171,7 +100,7 @@ const GET_NFT_COLLECTIONS = gql`
   }
 `;
 
-function Container({ navigation }: any): JSX.Element {
+function Container({ navigation }: CollectionListScreenProps): JSX.Element {
   const { blockchain, publicKey } = useActiveWallet();
   const { data } = useSuspenseQuery_experimental(GET_NFT_COLLECTIONS, {
     variables: {
@@ -182,9 +111,7 @@ function Container({ navigation }: any): JSX.Element {
 
   const handlePressItem = useCallback(
     (item: ListItemProps) => {
-      // TODO item.nfts not item.images
       if (item.type === "collection" && item.images.length > 1) {
-        // navigate to collection detail
         navigation.push("CollectionDetail", {
           id: item.id,
           title: item.name,
@@ -192,7 +119,6 @@ function Container({ navigation }: any): JSX.Element {
         });
       } else {
         const nft = item.type === "collection" ? item.nfts[0] : item;
-        // navigation to nft detail
         navigation.push("CollectionItemDetail", {
           id: nft.id,
           title: nft.name,
@@ -207,33 +133,33 @@ function Container({ navigation }: any): JSX.Element {
   const keyExtractor = (item: ListItemProps) => item.id;
   const renderItem = useCallback(
     ({ item }: { item: ListItemProps }) => {
-      return <ListItem item={item} handlePress={handlePressItem} />;
+      return <BaseListItem onPress={handlePressItem} item={item} />;
     },
     [handlePressItem]
   );
 
-  const numColumns = 2;
   const gap = 12;
 
   return (
     <Screen>
-      <RoundedContainerGroup style={{ padding: 12 }}>
-        <FlatList
-          data={rows}
-          numColumns={numColumns}
-          ItemSeparatorComponent={ItemSeparator}
-          ListEmptyComponent={NoNFTsEmptyState}
-          keyExtractor={keyExtractor}
-          renderItem={renderItem}
-          contentContainerStyle={{ gap }}
-          columnWrapperStyle={{ gap }}
-        />
-      </RoundedContainerGroup>
+      <FlatList
+        data={rows}
+        numColumns={2}
+        ItemSeparatorComponent={ItemSeparator}
+        ListEmptyComponent={NoNFTsEmptyState}
+        keyExtractor={keyExtractor}
+        renderItem={renderItem}
+        contentContainerStyle={{ gap }}
+        columnWrapperStyle={{ gap }}
+        showsVerticalScrollIndicator={false}
+      />
     </Screen>
   );
 }
 
-export function CollectionListScreen({ navigation, route }: any): JSX.Element {
+export function CollectionListScreen({
+  navigation,
+}: CollectionListScreenProps): JSX.Element {
   return (
     <ErrorBoundary fallbackRender={({ error }) => <Text>{error.message}</Text>}>
       <Suspense fallback={<FullScreenLoading />}>

--- a/packages/app-mobile/src/screens/HomeWalletListScreen.tsx
+++ b/packages/app-mobile/src/screens/HomeWalletListScreen.tsx
@@ -2,28 +2,14 @@ import type { Blockchain } from "@coral-xyz/common";
 import type { Wallet, PublicKey } from "~types/types";
 
 import { Suspense, useCallback } from "react";
-import { FlatList, Pressable, View } from "react-native";
+import { FlatList, Pressable } from "react-native";
 
 import { gql, useSuspenseQuery_experimental } from "@apollo/client";
 import { formatUsd } from "@coral-xyz/common";
-import {
-  useTheme as useTamaguiTheme,
-  Box,
-  StyledText,
-  Stack,
-  XStack,
-  BlockchainLogo,
-} from "@coral-xyz/tamagui";
-import { useNavigation } from "@react-navigation/native";
+import { Box, StyledText, XStack, BlockchainLogo } from "@coral-xyz/tamagui";
 import { ErrorBoundary } from "react-error-boundary";
 
-import { ListHeader, ListItemWalletOverview } from "~components/ListItem";
-import {
-  RoundedContainerGroup,
-  Screen,
-  ScreenError,
-  ScreenLoading,
-} from "~components/index";
+import { Screen, ScreenError, ScreenLoading } from "~components/index";
 import { useWallets } from "~hooks/wallets";
 import { BalanceSummaryWidget } from "~screens/Unlocked/components/BalanceSummaryWidget";
 
@@ -151,8 +137,7 @@ function ListItem({
   );
 }
 
-function WalletList() {
-  const navigation = useNavigation();
+function WalletList({ navigation }) {
   const { allWallets, selectActiveWallet } = useWallets();
 
   const handlePressWallet = useCallback(
@@ -161,7 +146,7 @@ function WalletList() {
       navigation.push("TopTabsWalletDetail", {
         screen: "TokenList",
         params: {
-          publicKey: w.publicKey.toString(),
+          publicKey: w.publicKey,
           blockchain: w.blockchain,
         },
       });
@@ -173,12 +158,12 @@ function WalletList() {
   const renderItem = useCallback(
     ({ item: wallet, index }: { item: Wallet; index: number }) => {
       const isFirst = index === 0;
-      const isLast = index === allWallets.length - 1;
+      // const isLast = index === allWallets.length - 1;
       return (
         <ListItem isFirst={isFirst} item={wallet} onPress={handlePressWallet} />
       );
     },
-    [handlePressWallet, allWallets.length]
+    [handlePressWallet]
   );
 
   return (
@@ -192,24 +177,24 @@ function WalletList() {
   );
 }
 
-function Container() {
+function Container({ navigation }) {
   return (
     <Screen>
       <Box my={12}>
         <BalanceSummaryWidget />
       </Box>
-      <WalletList />
+      <WalletList navigation={navigation} />
     </Screen>
   );
 }
 
-export function HomeWalletListScreen(): JSX.Element {
+export function HomeWalletListScreen({ navigation }): JSX.Element {
   return (
     <ErrorBoundary
       fallbackRender={({ error }) => <ScreenError error={error.message} />}
     >
       <Suspense fallback={<ScreenLoading />}>
-        <Container />
+        <Container navigation={navigation} />
       </Suspense>
     </ErrorBoundary>
   );

--- a/packages/app-mobile/src/screens/RecentActivityScreen.tsx
+++ b/packages/app-mobile/src/screens/RecentActivityScreen.tsx
@@ -18,6 +18,7 @@ import {
   ScreenLoading,
 } from "~components/index";
 import { convertTransactionDataToSectionList } from "~lib/RecentActivityUtils";
+import { RecentActivityScreenProps } from "~navigation/types";
 
 const GET_RECENT_TRANSACTIONS = gql`
   query WalletTransactions($chainId: ChainID!, $address: String!) {
@@ -42,7 +43,7 @@ const GET_RECENT_TRANSACTIONS = gql`
   }
 `;
 
-function Container({ navigation }: any): JSX.Element {
+function Container({ navigation }: RecentActivityScreenProps): JSX.Element {
   const activeWallet = useActiveWallet();
   const { data } = useSuspenseQuery_experimental(GET_RECENT_TRANSACTIONS, {
     variables: {
@@ -102,7 +103,9 @@ function Container({ navigation }: any): JSX.Element {
   );
 }
 
-export function RecentActivityScreen({ navigation }: any): JSX.Element {
+export function RecentActivityScreen({
+  navigation,
+}: RecentActivityScreenProps): JSX.Element {
   return (
     <ErrorBoundary
       fallbackRender={({ error }) => <ScreenError error={error} />}

--- a/packages/app-mobile/src/screens/TokenListScreen.tsx
+++ b/packages/app-mobile/src/screens/TokenListScreen.tsx
@@ -16,10 +16,11 @@ import {
   ScreenLoading,
   ScreenError,
 } from "~components/index";
+import { TokenListScreenProps } from "~navigation/types";
 import { BalanceSummaryWidget } from "~screens/Unlocked/components/BalanceSummaryWidget";
 import { TokenRow } from "~screens/Unlocked/components/Balances";
 
-function Container({ navigation, route }): JSX.Element {
+function Container({ navigation, route }: TokenListScreenProps): JSX.Element {
   const { blockchain, publicKey } = route.params;
   const balances = useRecoilValue(
     blockchainBalancesSorted({
@@ -70,6 +71,7 @@ function Container({ navigation, route }): JSX.Element {
         data={balances}
         keyExtractor={(item) => item.address}
         renderItem={renderItem}
+        showsVerticalScrollIndicator={false}
         ListHeaderComponent={
           <>
             <BalanceSummaryWidget />
@@ -89,7 +91,10 @@ function Container({ navigation, route }): JSX.Element {
   );
 }
 
-export function TokenListScreen({ navigation, route }: any): JSX.Element {
+export function TokenListScreen({
+  navigation,
+  route,
+}: TokenListScreenProps): JSX.Element {
   return (
     <ErrorBoundary
       fallbackRender={({ error }) => <ScreenError error={error} />}

--- a/packages/app-mobile/src/screens/Unlocked/components/BalanceSummaryWidget.tsx
+++ b/packages/app-mobile/src/screens/Unlocked/components/BalanceSummaryWidget.tsx
@@ -67,32 +67,39 @@ function TextPercentChange({
   );
 }
 
-const GET_BALANCE_SUMMARY = gql`
-  query WalletBalanceSummary($chainId: ChainID!, $address: String!) {
-    wallet(chainId: $chainId, address: $address) {
+type QueryUserBalanceSummary = {
+  user: {
+    id: string;
+    wallet: {
+      id: string;
+      isPrimary: boolean;
+      chainId: string;
+      balances: {
+        aggregate: {
+          id: string;
+          percentChange: number;
+          value: number;
+          valueChange: number;
+        };
+      };
+    };
+  };
+};
+
+const GET_USER_BALANCE_SUMMARY = gql`
+  query UserWalletBalanceSummary($address: String!) {
+    user {
       id
-      balances {
+      wallet(address: $address) {
         id
-        aggregate {
-          id
-          percentChange
-          value
-          valueChange
-        }
-        native {
-          id
-          address
-          amount
-          decimals
-          displayAmount
-          marketData {
+        isPrimary
+        chainId
+        balances {
+          aggregate {
             id
-            usdChange
             percentChange
-            lastUpdatedAt
-            logo
-            price
             value
+            valueChange
           }
         }
       }
@@ -121,14 +128,15 @@ function ErrorFallback({ error }: { error: Error }) {
 
 function Container() {
   const activeWallet = useActiveWallet();
-  const { data } = useSuspenseQuery_experimental(GET_BALANCE_SUMMARY, {
+  const { data } = useSuspenseQuery_experimental(GET_USER_BALANCE_SUMMARY, {
     variables: {
-      chainId: activeWallet.blockchain.toUpperCase(),
       address: activeWallet.publicKey,
     },
   });
 
-  const { aggregate } = data.wallet.balances;
+  // TODO fix this, not great lol
+  const gqlData = data as QueryUserBalanceSummary;
+  const aggregate = gqlData.user.wallet.balances.aggregate;
   const totalBalance = aggregate.value ?? 0.0;
   const totalChange = aggregate.valueChange ?? 0.0;
   const percentChange = aggregate.percentChange ?? 0.0;
@@ -163,10 +171,6 @@ export function BalanceSummaryWidget() {
 }
 
 const styles = StyleSheet.create({
-  container: {
-    justifyContent: "center",
-    alignItems: "center",
-  },
   totalChangeText: {
     fontSize: 16,
   },

--- a/packages/recoil/src/context/OnboardingProvider.tsx
+++ b/packages/recoil/src/context/OnboardingProvider.tsx
@@ -397,7 +397,7 @@ export function OnboardingProvider({
         await createStore(id, jwt, data);
         return { ok: true, jwt };
       } catch (err) {
-        console.error("debug1:OnboardingProvider:maybeCreateUser", err);
+        console.error("OnboardingProvider:maybeCreateUser", err);
         return { ok: false, jwt: "" };
       }
     },

--- a/packages/recoil/src/context/OnboardingProvider.tsx
+++ b/packages/recoil/src/context/OnboardingProvider.tsx
@@ -241,7 +241,7 @@ export function OnboardingProvider({
         }
       }
     },
-    [data]
+    [data, background, setOnboardingData, signMessageForWallet]
   );
 
   const handlePrivateKeyInput = useCallback(
@@ -292,7 +292,7 @@ export function OnboardingProvider({
         };
       }
     },
-    [data]
+    []
   );
 
   //
@@ -329,9 +329,7 @@ export function OnboardingProvider({
           ? [data.privateKeyKeyringInit]
           : data.signedWalletDescriptors;
 
-      //
       // If we're down here, then we are creating a user for the first time.
-      //
       const body = JSON.stringify({
         username,
         inviteCode,
@@ -353,11 +351,11 @@ export function OnboardingProvider({
         }
         return await res.json();
       } catch (err) {
-        console.error("OnboardingProvider:createUser::error", err);
+        console.error("OnboardingProvider:createUser", err);
         throw new Error(`error creating user`);
       }
     },
-    [data]
+    [authenticate]
   );
 
   //
@@ -385,11 +383,11 @@ export function OnboardingProvider({
           });
         }
       } catch (err) {
-        console.error("OnboardingProvider:createStore::error", err);
+        console.error("OnboardingProvider:createStore", err);
         throw new Error(`error creating account`);
       }
     },
-    [data]
+    [background, getKeyringInit]
   );
 
   const maybeCreateUser = useCallback(
@@ -399,11 +397,11 @@ export function OnboardingProvider({
         await createStore(id, jwt, data);
         return { ok: true, jwt };
       } catch (err) {
-        console.error("OnboardingProvider:maybeCreateUser::error", err);
+        console.error("debug1:OnboardingProvider:maybeCreateUser", err);
         return { ok: false, jwt: "" };
       }
     },
-    [data]
+    [createStore, createUser]
   );
 
   const contextValue = useMemo(

--- a/packages/recoil/src/hooks/useRpcRequests.tsx
+++ b/packages/recoil/src/hooks/useRpcRequests.tsx
@@ -1,3 +1,4 @@
+import { useCallback } from "react";
 import type {
   Blockchain,
   LedgerKeyringInit,
@@ -12,25 +13,28 @@ import { useBackgroundClient } from "./";
 export const useRpcRequests = () => {
   const background = useBackgroundClient();
 
-  const signMessageForWallet = async (
-    blockchain: Blockchain,
-    publicKey: string,
-    message: string,
-    keyringInit?:
-      | LedgerKeyringInit
-      | MnemonicKeyringInit
-      | PrivateKeyKeyringInit
-  ) => {
-    return await background.request({
-      method: UI_RPC_METHOD_SIGN_MESSAGE_FOR_PUBLIC_KEY,
-      params: [
-        blockchain,
-        publicKey,
-        ethers.utils.base58.encode(Buffer.from(message, "utf-8")),
-        keyringInit,
-      ],
-    });
-  };
+  const signMessageForWallet = useCallback(
+    async (
+      blockchain: Blockchain,
+      publicKey: string,
+      message: string,
+      keyringInit?:
+        | LedgerKeyringInit
+        | MnemonicKeyringInit
+        | PrivateKeyKeyringInit
+    ) => {
+      return await background.request({
+        method: UI_RPC_METHOD_SIGN_MESSAGE_FOR_PUBLIC_KEY,
+        params: [
+          blockchain,
+          publicKey,
+          ethers.utils.base58.encode(Buffer.from(message, "utf-8")),
+          keyringInit,
+        ],
+      });
+    },
+    [background]
+  );
 
   return {
     signMessageForWallet,

--- a/packages/tamagui-core/package.json
+++ b/packages/tamagui-core/package.json
@@ -28,6 +28,7 @@
     "@tamagui/theme-base": "^1.28.1",
     "@tamagui/themes": "^1.28.1",
     "expo-image": "~1.2.3",
+    "react-error-boundary": "^4.0.9",
     "tamagui": "^1.28.1"
   },
   "scripts": {

--- a/packages/tamagui-core/src/components/ProxyImage.native.tsx
+++ b/packages/tamagui-core/src/components/ProxyImage.native.tsx
@@ -1,6 +1,9 @@
+import { ErrorBoundary } from "react-error-boundary";
 import { proxyImageUrl } from "@coral-xyz/common";
 import type { ImageProps, ImageStyle } from "expo-image";
 import { Image } from "expo-image";
+
+import { StyledText } from "../";
 
 export function ProxyImage({
   transition,
@@ -29,13 +32,19 @@ export function ProxyImage({
   const styles = { width: size, height: size, aspectRatio: 1 };
 
   return (
-    <Image
-      source={uri}
-      transition={transition}
-      contentFit={contentFit}
-      placeholder={placeholder}
-      // React Native apps need to specify a width and height for remote images
-      style={[styles, style as ImageStyle]}
-    />
+    <ErrorBoundary
+      fallbackRender={({ error }) => (
+        <StyledText color="red">{error}</StyledText>
+      )}
+    >
+      <Image
+        source={uri}
+        transition={transition}
+        contentFit={contentFit}
+        placeholder={placeholder}
+        // React Native apps need to specify a width and height for remote images
+        style={[styles, style as ImageStyle]}
+      />
+    </ErrorBoundary>
   );
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -4365,6 +4365,7 @@ __metadata:
     "@types/react-native": ~0.71.6
     eslint-config-custom: "*"
     expo-image: ~1.2.3
+    react-error-boundary: ^4.0.9
     tamagui: ^1.28.1
   languageName: unknown
   linkType: soft
@@ -35228,6 +35229,17 @@ __metadata:
   peerDependencies:
     react: ">=16.13.1"
   checksum: 02f04bdf8526f4b2474cb129ece32e5e32fbe81a72a71fdcf056c440aa9f4308b372383f5e817eea76220dcf0901459be2834d6ab8106cd9c36e8ec230df70f9
+  languageName: node
+  linkType: hard
+
+"react-error-boundary@npm:^4.0.9":
+  version: 4.0.9
+  resolution: "react-error-boundary@npm:4.0.9"
+  dependencies:
+    "@babel/runtime": ^7.12.5
+  peerDependencies:
+    react: ">=16.13.1"
+  checksum: c673c5f13b8647820cde0a219b0e415fd05896513adf176600f231b59d8075993dbbc8b93a9ad3824121fbbe2934d011cbcbbeefc1af300b22c204c73862e0f7
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
- loads the correct balances based on tapping the wallet picker button inside the bottom sheet
- fixes token auth for fetching data from onboarding
- adds private key import in onboarding
- points testflights build to latest service worker
- updates graphql query for balances queries
- set a consistent navigator color (fontColor right now, but this is old design system)
- consistently removes back title from wallets navigator (tokens / collections / activity)
- consistent NFT image loading
- removes vertical scroll indicator for a bunch of views
- adds useCallback to various hooks
- fixes collection detail screen styles (edited) 