### PR TITLE
fix tamagui/lucide icons for mobile

### DIFF
--- a/packages/data-components/package.json
+++ b/packages/data-components/package.json
@@ -17,6 +17,7 @@
     "@coral-xyz/recoil": "*",
     "@coral-xyz/tamagui": "*",
     "@coral-xyz/themes": "*",
+    "@tamagui/lucide-icons": "^1.28.1",
     "expo-linking": "^4.0.1",
     "expo-modules-core": "^1.2.7",
     "helius-sdk": "^1.0.6",

--- a/packages/data-components/package.json
+++ b/packages/data-components/package.json
@@ -22,7 +22,8 @@
     "expo-modules-core": "^1.2.7",
     "helius-sdk": "^1.0.6",
     "react": "^18.2.0",
-    "react-error-boundary": "^4.0.4"
+    "react-error-boundary": "^4.0.4",
+    "react-native-svg": "^13.9.0"
   },
   "devDependencies": {
     "@graphql-codegen/cli": "^3.3.1",

--- a/packages/data-components/src/components/TransactionHistory/TransactionDetails/TransactionDetailsTable.tsx
+++ b/packages/data-components/src/components/TransactionHistory/TransactionDetails/TransactionDetailsTable.tsx
@@ -14,9 +14,9 @@ import {
   StyledText,
   TableCore,
   TableRowCore,
-  TamaguiIcons,
   XStack,
 } from "@coral-xyz/tamagui";
+import * as TamaguiIcons from "@tamagui/lucide-icons";
 import * as Linking from "expo-linking";
 
 import type { ResponseTransaction } from "..";

--- a/packages/data-components/src/components/TransactionHistory/TransactionListItem.tsx
+++ b/packages/data-components/src/components/TransactionHistory/TransactionListItem.tsx
@@ -10,10 +10,10 @@ import {
   ListItemCore,
   ListItemIconCore,
   StyledText,
-  TamaguiIcons,
   XStack,
   YStack,
 } from "@coral-xyz/tamagui";
+import * as TamaguiIcons from "@tamagui/lucide-icons";
 
 import type { ProviderId } from "../../apollo/graphql";
 

--- a/packages/data-components/src/components/TransactionHistory/TransactionListItemIcon.tsx
+++ b/packages/data-components/src/components/TransactionHistory/TransactionListItemIcon.tsx
@@ -3,7 +3,8 @@ import { useSuspenseQuery } from "@apollo/client";
 import { UNKNOWN_ICON_SRC, UNKNOWN_NFT_ICON_SRC } from "@coral-xyz/common";
 import { useActiveWallet } from "@coral-xyz/recoil";
 import type { SizeTokens } from "@coral-xyz/tamagui";
-import { ListItemIconCore, TamaguiIcons } from "@coral-xyz/tamagui";
+import { ListItemIconCore } from "@coral-xyz/tamagui";
+import * as TamaguiIcons from "@tamagui/lucide-icons";
 
 import { gql } from "../../apollo";
 import type { ProviderId } from "../../apollo/graphql";

--- a/packages/tamagui-core/src/index.tsx
+++ b/packages/tamagui-core/src/index.tsx
@@ -2,6 +2,5 @@ export * from "./components";
 export * from "./hooks";
 export * from "./tamagui.config";
 export type { ViewStyleWithPseudos } from "@tamagui/core";
-export * as TamaguiIcons from "@tamagui/lucide-icons";
 export * from "tamagui";
 export { Stack as Box } from "tamagui";

--- a/yarn.lock
+++ b/yarn.lock
@@ -4157,6 +4157,7 @@ __metadata:
     "@coral-xyz/themes": "*"
     "@graphql-codegen/cli": ^3.3.1
     "@graphql-codegen/client-preset": ^3.0.1
+    "@tamagui/lucide-icons": ^1.28.1
     "@types/react": ^18.2.6
     eslint-config-custom: "*"
     expo-linking: ^4.0.1

--- a/yarn.lock
+++ b/yarn.lock
@@ -4165,6 +4165,7 @@ __metadata:
     helius-sdk: ^1.0.6
     react: ^18.2.0
     react-error-boundary: ^4.0.4
+    react-native-svg: ^13.9.0
     tsc-alias: ^1.8.6
     typescript: ^5.0.4
   languageName: unknown


### PR DESCRIPTION
`export * as TamaguiIcons from "@tamagui/lucide-icons";` breaks mobile, so imported the icons as TamaguiIcons directly 