### PR TITLE
fix resetting mobile app data from settings

### DIFF
--- a/packages/app-mobile/src/navigation/AccountSettingsNavigator.tsx
+++ b/packages/app-mobile/src/navigation/AccountSettingsNavigator.tsx
@@ -226,7 +226,11 @@ export function AccountSettingsNavigator(): JSX.Element {
           name="import-private-key"
           component={ImportPrivateKeyScreen}
         />
-        <Stack.Screen name="reset-warning" component={ResetWarningScreen} />
+        <Stack.Screen
+          name="reset-warning"
+          component={ResetWarningScreen}
+          options={{ title: "Warning" }}
+        />
         <Stack.Screen
           name="show-secret-phrase-warning"
           component={ShowRecoveryPhraseWarningScreen}

--- a/packages/app-mobile/src/screens/ResetWarningScreen.tsx
+++ b/packages/app-mobile/src/screens/ResetWarningScreen.tsx
@@ -44,7 +44,9 @@ export function ResetWarningScreen({ navigation }): JSX.Element {
       buttonTitle="Reset"
       title="Reset Backpack"
       subtext="This will remove all the user accounts you have created or imported. Make sure you have your existing secret recovery phrase and private keys saved."
-      onNext={reset}
+      onNext={async () => {
+        await reset();
+      }}
     />
   );
 }

--- a/packages/app-mobile/src/screens/ResetWarningScreen.tsx
+++ b/packages/app-mobile/src/screens/ResetWarningScreen.tsx
@@ -1,5 +1,10 @@
 import { View } from "react-native";
 
+import { UI_RPC_METHOD_USER_ACCOUNT_LOGOUT } from "@coral-xyz/common";
+import { useBackgroundClient, useUser } from "@coral-xyz/recoil";
+import { useNavigation } from "@react-navigation/native";
+
+import { WarningIcon } from "~components/Icon";
 import {
   DangerButton,
   Header,
@@ -9,14 +14,8 @@ import {
   SubtextParagraph,
   TwoButtonFooter,
 } from "~components/index";
-import {
-  UI_RPC_METHOD_KEYRING_RESET,
-  UI_RPC_METHOD_USER_ACCOUNT_LOGOUT,
-} from "@coral-xyz/common";
-import { useBackgroundClient, useUser } from "@coral-xyz/recoil";
-import { useNavigation } from "@react-navigation/native";
 
-import { WarningIcon } from "~components/Icon";
+import { useSession } from "~src/lib/SessionProvider";
 
 export function LogoutWarningScreen({ navigation }): JSX.Element {
   const background = useBackgroundClient();
@@ -38,19 +37,14 @@ export function LogoutWarningScreen({ navigation }): JSX.Element {
 }
 
 export function ResetWarningScreen({ navigation }): JSX.Element {
-  const background = useBackgroundClient();
+  const { reset } = useSession();
 
   return (
     <Warning
       buttonTitle="Reset"
       title="Reset Backpack"
       subtext="This will remove all the user accounts you have created or imported. Make sure you have your existing secret recovery phrase and private keys saved."
-      onNext={async () => {
-        await background.request({
-          method: UI_RPC_METHOD_KEYRING_RESET,
-          params: [],
-        });
-      }}
+      onNext={reset}
     />
   );
 }

--- a/packages/app-mobile/src/screens/Unlocked/YourAccountScreen.tsx
+++ b/packages/app-mobile/src/screens/Unlocked/YourAccountScreen.tsx
@@ -1,5 +1,3 @@
-import { Alert } from "react-native";
-
 import { useKeyringHasMnemonic } from "@coral-xyz/recoil";
 
 import { Screen } from "~components/index";
@@ -19,13 +17,6 @@ export function YourAccountScreen({ navigation }): JSX.Element {
           },
         }
       : {}),
-    "Delete account": {
-      onPress: () =>
-        Alert.alert(
-          "Delete Account",
-          "Please email us at support@backpack.app with your username and public keys and we'll delete your account."
-        ),
-    },
     "Log out": {
       onPress: () => navigation.push("reset-warning"),
     },


### PR DESCRIPTION
- tapping the `Settings > Your Account > Log out` button and agreeing to the reset warning will now clear all the data stored on the device
- removes Delete account button for now

> **Note**
> Once we support multiple accounts, the reset button will need to change to a remove account button, which only removes data for a single user