### PR TITLE
reduce mobile service worker bundle size

### DIFF
--- a/packages/background/src/backend/core.ts
+++ b/packages/background/src/backend/core.ts
@@ -19,8 +19,6 @@ import {
   DEFAULT_DARK_MODE,
   defaultPreferences,
   deserializeTransaction,
-  EthereumConnectionUrl,
-  EthereumExplorer,
   getAccountRecoveryPaths,
   getAddMessage,
   getRecoveryPaths,
@@ -60,11 +58,17 @@ import {
   NOTIFICATION_USER_ACCOUNT_PUBLIC_KEY_DELETED,
   NOTIFICATION_USER_ACCOUNT_PUBLIC_KEYS_UPDATED,
   NOTIFICATION_XNFT_PREFERENCE_UPDATED,
+  TAB_APPS,
+  TAB_BALANCES,
   TAB_BALANCES_SET,
+  TAB_MESSAGES,
+  TAB_NFTS,
+  TAB_NOTIFICATIONS,
+  TAB_RECENT_ACTIVITY,
+  TAB_SWAP,
   TAB_TOKENS,
   TAB_XNFT,
 } from "@coral-xyz/common";
-import { makeDefaultNav } from "@coral-xyz/recoil";
 import type {
   BlockchainKeyring,
   KeyringStore,
@@ -2067,6 +2071,30 @@ export class Backend {
 
 export const SUCCESS_RESPONSE = "success";
 const defaultNav = makeDefaultNav();
+
+function makeDefaultNav() {
+  const defaultNav: any = {
+    activeTab: TAB_TOKENS,
+    data: {},
+  };
+  [
+    [TAB_BALANCES, "Balances"],
+    [TAB_NFTS, "Nfts"],
+    [TAB_SWAP, "Swap"],
+    [TAB_APPS, "Apps"],
+    [TAB_MESSAGES, "Messages"],
+    [TAB_RECENT_ACTIVITY, "Recent Activity"],
+    [TAB_NOTIFICATIONS, "Notifications"],
+    [TAB_TOKENS, "Tokens"],
+  ].forEach(([tabName, tabTitle]) => {
+    defaultNav.data[tabName] = {
+      id: tabName,
+      urls: [makeUrl(tabName, { title: tabTitle, props: {} })],
+      ref: tabName === "balances" ? "tokens" : undefined,
+    };
+  });
+  return defaultNav;
+}
 
 function setSearchParam(url: string, key: string, value: string): string {
   const [path, search] = url.split("?");

--- a/packages/recoil/src/types.ts
+++ b/packages/recoil/src/types.ts
@@ -1,15 +1,4 @@
-import {
-  type Blockchain,
-  makeUrl,
-  TAB_APPS,
-  TAB_BALANCES,
-  TAB_MESSAGES,
-  TAB_NFTS,
-  TAB_NOTIFICATIONS,
-  TAB_RECENT_ACTIVITY,
-  TAB_SWAP,
-  TAB_TOKENS,
-} from "@coral-xyz/common";
+import { type Blockchain } from "@coral-xyz/common";
 import type { BigNumber } from "ethers";
 import type { RecoilValueReadOnly } from "recoil";
 
@@ -84,32 +73,6 @@ export interface TokenMetadata {
   name: string;
   image: string;
   symbol: string;
-}
-
-export const TABS = [
-  [TAB_BALANCES, "Balances"],
-  [TAB_NFTS, "Nfts"],
-  [TAB_SWAP, "Swap"],
-  [TAB_APPS, "Apps"],
-  [TAB_MESSAGES, "Messages"],
-  [TAB_RECENT_ACTIVITY, "Recent Activity"],
-  [TAB_NOTIFICATIONS, "Notifications"],
-  [TAB_TOKENS, "Tokens"],
-];
-
-export function makeDefaultNav() {
-  const defaultNav: any = {
-    activeTab: TAB_TOKENS,
-    data: {},
-  };
-  TABS.forEach(([tabName, tabTitle]) => {
-    defaultNav.data[tabName] = {
-      id: tabName,
-      urls: [makeUrl(tabName, { title: tabTitle, props: {} })],
-      ref: tabName === "balances" ? "tokens" : undefined,
-    };
-  });
-  return defaultNav;
 }
 
 export type ExtractRecoilType<P> = P extends RecoilValueReadOnly<infer T>


### PR DESCRIPTION
by extracting a function from `@coral-xyz/recoil` and effectively removing it as a dependency (only importing a type now) from `@coral-xyz/background`, the mobile service worker bundle size is reduced from 9.61MB to 3.67MB