### PR TITLE
setState change to correct manner. update useStep.tsx

### DIFF
--- a/packages/app-extension/src/hooks/useSteps.tsx
+++ b/packages/app-extension/src/hooks/useSteps.tsx
@@ -2,9 +2,9 @@ import { useState } from "react";
 
 export const useSteps = () => {
   const [step, setStep] = useState(0);
-  const nextStep = () => setStep(step + 1);
+  const nextStep = () => setStep((prevStep) => prevStep + 1);
   const prevStep = () => {
-    if (step > 0) setStep(step - 1);
+    if (step > 0) setStep((prevStep) => prevStep - 1);
   };
 
   return {


### PR DESCRIPTION
Changed the way setState is used. When the state is dependent upon on the val, function format must be used. 