### PR TITLE
Partial sign transactions *after* modifying them

### DIFF
--- a/packages/secure-clients/src/SolanaClient/BackpackSolanaWallet.ts
+++ b/packages/secure-clients/src/SolanaClient/BackpackSolanaWallet.ts
@@ -169,17 +169,17 @@ export class BackpackSolanaWallet {
     const commitment = request.commitment;
 
     if (!isVersionedTransaction(tx)) {
-      if (signers) {
-        signers.forEach((s: Signer) => {
-          tx.partialSign(s);
-        });
-      }
       if (!tx.feePayer) {
         tx.feePayer = publicKey;
       }
       if (!tx.recentBlockhash) {
         const { blockhash } = await connection.getLatestBlockhash(commitment);
         tx.recentBlockhash = blockhash;
+      }
+      if (signers) {
+        signers.forEach((s: Signer) => {
+          tx.partialSign(s);
+        });
       }
     } else {
       if (signers) {


### PR DESCRIPTION
In the event that the fee payer or the blockhash gets changed in `prepareTransaction()`, doing so will immediately invalidate the signatures made one block earlier. Sign as late as possible.