### PR TITLE
Partial sign in a batch

### DIFF
--- a/packages/secure-clients/src/SolanaClient/BackpackSolanaWallet.ts
+++ b/packages/secure-clients/src/SolanaClient/BackpackSolanaWallet.ts
@@ -177,9 +177,7 @@ export class BackpackSolanaWallet {
         tx.recentBlockhash = blockhash;
       }
       if (signers) {
-        signers.forEach((s: Signer) => {
-          tx.partialSign(s);
-        });
+        tx.partialSign(...signers);
       }
     } else {
       if (signers) {

--- a/packages/secure-clients/src/SolanaClient/BackpackSolanaWallet.ts
+++ b/packages/secure-clients/src/SolanaClient/BackpackSolanaWallet.ts
@@ -169,17 +169,17 @@ export class BackpackSolanaWallet {
     const commitment = request.commitment;
 
     if (!isVersionedTransaction(tx)) {
-      if (signers) {
-        signers.forEach((s: Signer) => {
-          tx.partialSign(s);
-        });
-      }
       if (!tx.feePayer) {
         tx.feePayer = publicKey;
       }
       if (!tx.recentBlockhash) {
         const { blockhash } = await connection.getLatestBlockhash(commitment);
         tx.recentBlockhash = blockhash;
+      }
+      if (signers) {
+        signers.forEach((s: Signer) => {
+          tx.partialSign(s);
+        });
       }
     } else {
       if (signers) {


### PR DESCRIPTION
Using the API in this way will let you take advantage of signer deduplication.

See the implementation:

https://github.com/solana-labs/solana-web3.js/blob/e1d7df4525b71bc7ef48c6cb0aba2178c88791cb/packages/library-legacy/src/transaction/legacy.ts#L703-L714

> [!NOTE]
> Ignore the first commit in this PR. It belongs to the stacked PR #4312.