### PR TITLE
typescript error fixed for Image component

### DIFF
--- a/web/components/AppNoLink.tsx
+++ b/web/components/AppNoLink.tsx
@@ -12,8 +12,8 @@ function AppNoLink({ iconUrl, name }: AppNoLinkPros) {
             blurDataURL="/brands/aurory.jpg" //TODO: fix me
             placeholder="blur"
             quality={50}
-            width="100px"
-            height="100px"
+            width="100"
+            height="100"
             style={{ borderRadius: '4px' }}
           />
         </div>


### PR DESCRIPTION
fixed #4342

- Removed "px" from the height and width of the images to prevent typescript error.