### PR TITLE
fix(tx): use northeast glyph in metadata link

### DIFF
--- a/packages/data-components/src/components/TransactionHistory/TransactionDetails/TransactionDetailsTable.tsx
+++ b/packages/data-components/src/components/TransactionHistory/TransactionDetails/TransactionDetailsTable.tsx
@@ -12,7 +12,6 @@ import {
 import { explorerUrl } from "@coral-xyz/secure-background/legacyCommon";
 import type { ViewStyleWithPseudos } from "@coral-xyz/tamagui";
 import {
-  ArrowUpRightIcon,
   openUrl,
   StyledText,
   TableCore,
@@ -109,7 +108,9 @@ function _TransactionSignatureRowValue({ hash }: { hash: string }) {
       <StyledText color="$accentBlue" fontSize="$sm">
         {_truncateSignature(hash)}
       </StyledText>
-      <ArrowUpRightIcon color="$accentBlue" size={14} />
+      <StyledText color="$accentBlue" fontSize="$sm">
+        {"\u2197"}
+      </StyledText>
     </XStack>
   );
 }


### PR DESCRIPTION
## Summary
- replace the tx metadata explorer icon with a smaller northeast-arrow glyph
- keep the tx signature link on the existing theme-aware blue token
- scope the change to the transaction metadata table only

Fixes #3483