### PR TITLE
fix(password): align visibility icon state

### DIFF
--- a/packages/secure-ui/src/RequireUserUnlocked/PasswordInput.tsx
+++ b/packages/secure-ui/src/RequireUserUnlocked/PasswordInput.tsx
@@ -56,9 +56,9 @@ export function PasswordInput(
         }}
       >
         {show ? (
-          <EyeOffIcon {...currentInputProps.passwordIconProps} />
-        ) : (
           <EyeIcon {...currentInputProps.passwordIconProps} />
+        ) : (
+          <EyeOffIcon {...currentInputProps.passwordIconProps} />
         )}
       </Stack>
     </Stack>

--- a/packages/tamagui-core/src/BpComponents/Inputs/BpPasswordInput.tsx
+++ b/packages/tamagui-core/src/BpComponents/Inputs/BpPasswordInput.tsx
@@ -91,9 +91,9 @@ function PasswordInputBase(
         }}
       >
         {show ? (
-          <EyeOffIcon {...currentInputProps.passwordIconProps} />
-        ) : (
           <EyeIcon {...currentInputProps.passwordIconProps} />
+        ) : (
+          <EyeOffIcon {...currentInputProps.passwordIconProps} />
         )}
       </Stack>
     </Stack>


### PR DESCRIPTION
## Summary
- make the signup password field show the open-eye icon only when the password is visible
- keep the hidden state paired with the slashed-eye icon
- apply the same fix to the duplicated secure-ui password input to keep behavior consistent

Fixes #4376